### PR TITLE
Issue #2: Define v1 sidecar schema

### DIFF
--- a/dev-reports/issue-2/design.md
+++ b/dev-reports/issue-2/design.md
@@ -1,0 +1,20 @@
+# Issue #2 Design Note
+
+## Goal
+
+Define the first versioned sidecar schema for request, response, and event payloads. The schema must be strict about required contract fields while remaining forward-compatible with optional fields that future Anvil or sidecar versions may add.
+
+## Approach
+
+- Implement Pydantic v2 models in `photon_action_memory/api/schema.py`.
+- Require `schema_version` on `SuggestRequest`, `SuggestResponse`, and `SidecarEvent`, and validate it as `action-memory.v1`.
+- Model the documented v0.1.0 suggest request/response shapes from `workspace/v0.1.0/01_spec_requirements_architecture.md`.
+- Represent Anvil WorkingMemory-like state with a neutral `WorkingMemory` DTO containing active task, constraints, touched files, unresolved errors, precautions, and plan/evidence-oriented optional lists.
+- Use `extra="allow"` on schema models so unknown optional fields survive validation and serialization instead of breaking older consumers.
+- Add tests for minimal payloads, malformed/missing required fields, unknown optional fields, and an Anvil-style round trip.
+
+## Non-goals
+
+- No FastAPI endpoint implementation in this issue.
+- No event persistence, sanitizer, ranking, or MLX adapter behavior.
+- No JSON Schema file generation unless a later integration requires it.

--- a/dev-reports/issue-2/implementation-summary.md
+++ b/dev-reports/issue-2/implementation-summary.md
@@ -1,0 +1,22 @@
+# Issue #2 Implementation Summary
+
+## Files Changed
+
+- `photon_action_memory/api/schema.py`
+  - Replaced the placeholder with Pydantic v2 schema models for v1 sidecar payloads.
+  - Added required `schema_version` validation for `SuggestRequest`, `SuggestResponse`, `SidecarEvent`, and `EventRequest`.
+  - Added request DTOs for agent, repo, task, working memory, recent events, and budget.
+  - Added response DTOs for suggestions, evidence, and warnings.
+  - Added event DTOs for sidecar event ingestion and artifacts.
+  - Set the shared schema model config to `extra="allow"` so unknown optional fields are accepted and preserved.
+- `tests/test_schema.py`
+  - Added focused schema tests for minimal payloads, malformed payloads, missing required fields, unknown optional fields, Anvil-style working memory round trip, and event alias round trip.
+- `dev-reports/issue-2/design.md`
+  - Recorded the schema-first design before editing.
+
+## Contract Notes
+
+- `schema_version` currently accepts only `action-memory.v1`, matching `photon_action_memory.SCHEMA_VERSION`.
+- `WorkingMemory` models the documented neutral fields and allows extra Anvil-specific slots, such as a nested `anvil_working_memory` object.
+- `SidecarEvent` accepts either `event_type` or `type` on input for compatibility with the documented compact event shape.
+- The implementation is schema-only. API routing, persistence, sanitization, and ranking behavior remain owned by later issues.

--- a/dev-reports/issue-2/verification.md
+++ b/dev-reports/issue-2/verification.md
@@ -1,0 +1,36 @@
+# Issue #2 Verification
+
+## Focused Verification
+
+- `python -m pytest -q tests/test_schema.py`
+  - Result: passed.
+  - Output: `9 passed in 0.02s`.
+
+## Broader Verification
+
+- `ruff check .`
+  - Result: passed.
+  - Output: `All checks passed!`.
+- `ruff format --check .`
+  - Result: passed.
+  - Output: `27 files already formatted`.
+- `python -m pytest -q`
+  - Result: passed.
+  - Output: `13 passed in 0.02s`.
+- `mypy photon_action_memory tests`
+  - Result: passed.
+  - Output: `Success: no issues found in 27 source files`.
+- `python -m build`
+  - Result: passed after rerunning with network access for isolated build dependency installation.
+  - Output: `Successfully built photon_action_memory-0.1.0.tar.gz and photon_action_memory-0.1.0-py3-none-any.whl`.
+
+## Local Environment Notes
+
+- Running bare `pytest -q` before editable installation failed with `ModuleNotFoundError: No module named 'photon_action_memory'`.
+- `python -m pytest -q` passed from the worktree because it includes the repository root on `sys.path`.
+- The GitHub CI workflow installs the package with `pip install -e ".[dev]"` before running `pytest -q`, so this local bare-command import issue is not expected to affect CI.
+
+## Integration Risks
+
+- No canonical live Anvil `WorkingMemory` fixture was present in this worktree or issue references. The test fixture uses the documented Anvil integration points and preserves an `anvil_working_memory` extension object through round trip.
+- If Anvil's concrete field names differ from this representative fixture, the adapter should map them into the neutral `WorkingMemory` fields while keeping the original payload in an extra extension field.

--- a/photon_action_memory/api/schema.py
+++ b/photon_action_memory/api/schema.py
@@ -1,10 +1,200 @@
-"""Versioned sidecar API schema placeholders.
+"""Versioned sidecar API schema.
 
-Concrete Pydantic models are introduced in the schema-first milestone.
+The v1 schema intentionally accepts unknown optional fields so agents can add
+shadow-mode metadata without breaking older sidecar builds.
 """
 
 from __future__ import annotations
 
+from typing import Literal
+
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+
 from photon_action_memory import SCHEMA_VERSION
 
-__all__ = ["SCHEMA_VERSION"]
+SchemaVersion = Literal["action-memory.v1"]
+
+ActionKind = Literal[
+    "read",
+    "search",
+    "edit",
+    "test",
+    "build",
+    "inspect",
+    "ask_user",
+    "answer",
+    "replan",
+]
+WarningKind = Literal["drift", "repeat_failure", "missing_evidence", "sidecar_unavailable"]
+
+
+class SidecarModel(BaseModel):
+    """Base model for forward-compatible sidecar DTOs."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+class AgentInfo(SidecarModel):
+    """Agent identity included in sidecar requests."""
+
+    name: str
+    version: str | None = None
+
+
+class RepoInfo(SidecarModel):
+    """Repository state visible to the coding agent."""
+
+    root: str
+    name: str | None = None
+    branch: str | None = None
+    commit: str | None = None
+
+
+class TaskState(SidecarModel):
+    """Current user task and agent mode."""
+
+    user_request: str
+    mode: Literal["plan", "act", "answer"] | str
+    summary: str | None = None
+
+
+class WorkingMemory(SidecarModel):
+    """Neutral representation of agent working memory, including Anvil-like L2 state."""
+
+    active_task: str | None = None
+    constraints: list[str] = Field(default_factory=list)
+    touched_files: list[str] = Field(default_factory=list)
+    unresolved_errors: list[str] = Field(default_factory=list)
+    active_precautions: list[str] = Field(default_factory=list)
+    plan: list[str] = Field(default_factory=list)
+    completed_steps: list[str] = Field(default_factory=list)
+    pending_steps: list[str] = Field(default_factory=list)
+    evidence_ids: list[str] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
+
+
+class RecentEvent(SidecarModel):
+    """Compact event embedded in a suggest request."""
+
+    type: str
+    tool: str | None = None
+    status: str | None = None
+    summary: str
+    event_id: str | None = None
+    evidence_id: str | None = None
+
+
+class Budget(SidecarModel):
+    """Suggestion budget hints for the sidecar."""
+
+    max_suggestions: int = Field(default=8, ge=0)
+    max_evidence_chars: int = Field(default=4000, ge=0)
+
+
+class SuggestRequest(SidecarModel):
+    """Request body for `POST /v1/suggest`."""
+
+    schema_version: SchemaVersion
+    request_id: str
+    agent: AgentInfo
+    repo: RepoInfo
+    task: TaskState
+    working_memory: WorkingMemory
+    recent_events: list[RecentEvent] = Field(default_factory=list)
+    budget: Budget = Field(default_factory=Budget)
+
+
+class Suggestion(SidecarModel):
+    """Action guidance returned by the sidecar."""
+
+    kind: ActionKind
+    target: str | None = None
+    command: str | None = None
+    query: str | None = None
+    confidence: float = Field(ge=0.0, le=1.0)
+    reason: str
+    evidence_ids: list[str] = Field(default_factory=list)
+    risk: str | None = None
+
+
+class Evidence(SidecarModel):
+    """Evidence item supporting one or more suggestions."""
+
+    id: str
+    kind: str
+    summary: str
+    source: str | None = None
+
+
+class Warning(SidecarModel):
+    """Non-fatal sidecar warning."""
+
+    kind: WarningKind | str
+    message: str
+
+
+class SuggestResponse(SidecarModel):
+    """Response body for `POST /v1/suggest`."""
+
+    schema_version: SchemaVersion
+    request_id: str
+    model_version: str
+    suggestions: list[Suggestion] = Field(default_factory=list)
+    evidence: list[Evidence] = Field(default_factory=list)
+    warnings: list[Warning] = Field(default_factory=list)
+
+
+class Artifact(SidecarModel):
+    """File, command, or tool artifact attached to an event."""
+
+    kind: str
+    value: str
+    metadata: dict[str, object] = Field(default_factory=dict)
+
+
+class SidecarEvent(SidecarModel):
+    """Event payload accepted by `POST /v1/events`."""
+
+    schema_version: SchemaVersion
+    event_id: str
+    session_id: str
+    turn_id: str | None = None
+    repo_id: str | None = None
+    timestamp: str
+    event_type: str = Field(validation_alias=AliasChoices("event_type", "type"))
+    tool_name: str | None = None
+    status: str | None = None
+    summary: str
+    artifacts: list[Artifact] = Field(default_factory=list)
+    redaction_status: Literal["raw", "sanitized", "redacted", "unknown"] | str = "unknown"
+
+
+class EventRequest(SidecarModel):
+    """Request body for ingesting one or more events."""
+
+    schema_version: SchemaVersion
+    request_id: str
+    events: list[SidecarEvent]
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "ActionKind",
+    "AgentInfo",
+    "Artifact",
+    "Budget",
+    "EventRequest",
+    "Evidence",
+    "RecentEvent",
+    "RepoInfo",
+    "SchemaVersion",
+    "SidecarEvent",
+    "SidecarModel",
+    "SuggestRequest",
+    "SuggestResponse",
+    "Suggestion",
+    "TaskState",
+    "Warning",
+    "WarningKind",
+    "WorkingMemory",
+]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from photon_action_memory import SCHEMA_VERSION
+from photon_action_memory.api.schema import (
+    SidecarEvent,
+    SuggestRequest,
+    SuggestResponse,
+)
+
+
+def test_minimal_suggest_request_round_trip() -> None:
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "request_id": "turn-001",
+        "agent": {"name": "anvil"},
+        "repo": {"root": "/repo"},
+        "task": {"user_request": "Fix the failing test", "mode": "act"},
+        "working_memory": {},
+    }
+
+    request = SuggestRequest.model_validate(payload)
+    round_tripped = SuggestRequest.model_validate_json(request.model_dump_json())
+
+    assert round_tripped.schema_version == SCHEMA_VERSION
+    assert round_tripped.request_id == "turn-001"
+    assert round_tripped.agent.name == "anvil"
+    assert round_tripped.budget.max_suggestions == 8
+    assert round_tripped.recent_events == []
+
+
+def test_unknown_optional_fields_are_preserved() -> None:
+    request = SuggestRequest.model_validate(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "request_id": "turn-unknown-extra",
+            "agent": {"name": "anvil", "build_channel": "nightly"},
+            "repo": {"root": "/repo"},
+            "task": {"user_request": "Inspect state", "mode": "plan"},
+            "working_memory": {"active_task": "inspect state", "custom_slot": {"value": 1}},
+            "shadow_mode": True,
+        }
+    )
+
+    dumped = request.model_dump()
+
+    assert dumped["shadow_mode"] is True
+    assert dumped["agent"]["build_channel"] == "nightly"
+    assert dumped["working_memory"]["custom_slot"] == {"value": 1}
+
+
+@pytest.mark.parametrize(
+    ("model", "payload"),
+    [
+        (
+            SuggestRequest,
+            {
+                "request_id": "missing-version",
+                "agent": {"name": "anvil"},
+                "repo": {"root": "/repo"},
+                "task": {"user_request": "Fix", "mode": "act"},
+                "working_memory": {},
+            },
+        ),
+        (
+            SuggestResponse,
+            {
+                "request_id": "missing-version",
+                "model_version": "photon-action-memory-v0.1.0",
+            },
+        ),
+        (
+            SidecarEvent,
+            {
+                "event_id": "evt-001",
+                "session_id": "sess-001",
+                "timestamp": "2026-04-30T12:00:00Z",
+                "event_type": "tool_result",
+                "summary": "grep succeeded",
+            },
+        ),
+    ],
+)
+def test_schema_version_is_required(model: type[object], payload: dict[str, object]) -> None:
+    with pytest.raises(ValidationError):
+        model.model_validate(payload)  # type: ignore[attr-defined]
+
+
+def test_required_field_missing_is_validation_error() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        SuggestRequest.model_validate(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "request_id": "turn-002",
+                "agent": {"name": "anvil"},
+                "repo": {"root": "/repo"},
+                "working_memory": {},
+            }
+        )
+
+    assert "task" in str(exc_info.value)
+
+
+def test_malformed_schema_version_is_validation_error() -> None:
+    with pytest.raises(ValidationError):
+        SuggestResponse.model_validate(
+            {
+                "schema_version": "action-memory.v2",
+                "request_id": "turn-003",
+                "model_version": "photon-action-memory-v0.1.0",
+            }
+        )
+
+
+def test_anvil_working_memory_fixture_round_trip() -> None:
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "request_id": "anvil-turn-42",
+        "agent": {"name": "anvil", "version": "0.1.x"},
+        "repo": {
+            "root": "/Users/example/work/Anvil",
+            "name": "Anvil",
+            "branch": "feature/example",
+            "commit": "HEAD",
+        },
+        "task": {
+            "user_request": "Define a schema for sidecar messages",
+            "mode": "act",
+            "summary": "Implement v1 schema models",
+        },
+        "working_memory": {
+            "active_task": "Implement schema-first DTOs",
+            "constraints": ["Do not store raw secrets", "Keep sidecar fail-open"],
+            "touched_files": ["photon_action_memory/api/schema.py", "tests/test_schema.py"],
+            "unresolved_errors": ["mypy has not run yet"],
+            "active_precautions": ["Preserve unknown optional fields"],
+            "plan": ["Read docs", "Implement models", "Add tests"],
+            "completed_steps": ["Read docs"],
+            "pending_steps": ["Run focused verification"],
+            "evidence_ids": ["evt-001"],
+            "anvil_working_memory": {
+                "mode": "act",
+                "active_files": ["src/session/store.rs"],
+                "tool_loop": {"last_tool": "rg", "last_status": "success"},
+            },
+        },
+        "recent_events": [
+            {
+                "type": "tool_result",
+                "tool": "rg",
+                "status": "success",
+                "summary": "found WorkingMemory integration points",
+                "event_id": "evt-001",
+            }
+        ],
+        "budget": {"max_suggestions": 3, "max_evidence_chars": 1200},
+    }
+
+    request = SuggestRequest.model_validate(payload)
+    round_tripped = SuggestRequest.model_validate_json(request.model_dump_json())
+
+    assert round_tripped.working_memory.active_task == "Implement schema-first DTOs"
+    assert round_tripped.working_memory.touched_files == [
+        "photon_action_memory/api/schema.py",
+        "tests/test_schema.py",
+    ]
+    assert round_tripped.model_dump()["working_memory"]["anvil_working_memory"]["mode"] == "act"
+    assert round_tripped.recent_events[0].type == "tool_result"
+
+
+def test_event_payload_round_trip_accepts_type_alias() -> None:
+    event = SidecarEvent.model_validate(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "event_id": "evt-001",
+            "session_id": "sess-001",
+            "turn_id": "turn-001",
+            "repo_id": "repo-anvil",
+            "timestamp": "2026-04-30T12:00:00Z",
+            "type": "tool_result",
+            "tool_name": "pytest",
+            "status": "success",
+            "summary": "schema tests passed",
+            "artifacts": [{"kind": "command", "value": "pytest tests/test_schema.py"}],
+            "redaction_status": "sanitized",
+        }
+    )
+
+    round_tripped = SidecarEvent.model_validate_json(event.model_dump_json())
+
+    assert round_tripped.schema_version == SCHEMA_VERSION
+    assert round_tripped.event_type == "tool_result"
+    assert round_tripped.artifacts[0].value == "pytest tests/test_schema.py"


### PR DESCRIPTION
## Summary
- Defines the v1 sidecar API schema contract.
- Adds focused schema tests and issue development reports.

## Verification
- `python -m pytest -q` -> 13 passed
- `ruff check .` -> passed
- `ruff format --check .` -> passed

Closes #2