### PR TITLE
Issue #4: Implement local SQLite event store

### DIFF
--- a/dev-reports/issue-4/design.md
+++ b/dev-reports/issue-4/design.md
@@ -1,0 +1,34 @@
+# Issue 4 Design
+
+## Goal
+
+Implement a local-first SQLite event store for sanitized agent events.
+
+## Approach
+
+- Keep the store stdlib-only with `sqlite3`, `json`, and dataclasses so the M2 sidecar can use it without new dependencies.
+- Expose a small API around an `EventStore` class:
+  - initialize the schema on construction
+  - append one raw event mapping through the sanitizer
+  - read events back in timestamp/id order
+- Store event envelope fields as queryable SQLite columns:
+  - `schema_version`
+  - `event_id`
+  - `session_id`
+  - `turn_id`
+  - `repo_id`
+  - `timestamp`
+  - `event_type`
+- Store the sanitized event as canonical JSON in `payload_json`.
+- Enforce the sanitizer at the public write boundary by having `append_event` call `sanitize_event_payload` internally.
+- Add focused temp-SQLite tests for synthetic event round-trip and fixture privacy checks.
+
+## Sanitizer Scope
+
+Issue 3 owns the full sanitizer. For this issue, the store needs enough sanitizer behavior to guarantee its own acceptance criteria:
+
+- redact secret-like values
+- normalize absolute user/tmp paths
+- preserve structured JSON values
+- mark sanitized payloads with `redaction_status`
+

--- a/dev-reports/issue-4/implementation-summary.md
+++ b/dev-reports/issue-4/implementation-summary.md
@@ -1,0 +1,29 @@
+# Issue 4 Implementation Summary
+
+## Changed Files
+
+- `photon_action_memory/memory/store.py`
+- `photon_action_memory/memory/sanitizer.py`
+- `tests/test_event_store.py`
+- `dev-reports/issue-4/design.md`
+- `dev-reports/issue-4/implementation-summary.md`
+- `dev-reports/issue-4/verification.md`
+
+## Summary
+
+- Added `EventStore`, a local SQLite append/read API for sanitized events.
+- Added `StoredEvent`, a typed dataclass for rows returned from the store.
+- Added SQLite schema initialization for event envelope columns and canonical sanitized JSON payload storage.
+- Enforced sanitizer use inside `EventStore.append_event` before any SQLite write.
+- Added a minimal recursive `sanitize_event_payload` contract alongside `sanitize_text`.
+- Added redaction for common secret, bearer-token, email, control-character, and absolute user/temp path patterns.
+- Added focused temp-SQLite tests for:
+  - synthetic event round-trip
+  - sanitized-only payload persistence
+  - required core event fields
+
+## Notes
+
+- `scripts/commandmate_codex.py` was listed as suspected but does not exist in this worktree.
+- The sanitizer implementation here is intentionally minimal and compatible with the current store needs. Issue #3 remains the fuller sanitizer milestone.
+

--- a/dev-reports/issue-4/verification.md
+++ b/dev-reports/issue-4/verification.md
@@ -1,0 +1,37 @@
+# Issue 4 Verification
+
+## Focused Verification
+
+- Command: `python -m pytest tests/test_event_store.py`
+- Result: passed.
+- Output summary: `3 passed in 0.04s`.
+
+- Command: `python -m ruff check .`
+- Result: passed.
+- Output summary: `All checks passed!`.
+
+- Command: `python -m ruff format --check .`
+- Result: passed.
+- Output summary: `27 files already formatted`.
+
+## Broader Verification
+
+- Command: `python -m pytest`
+- Result: passed.
+- Output summary: `7 passed in 0.05s`.
+
+- Command: `python -m mypy photon_action_memory tests`
+- Result: passed.
+- Output summary: `Success: no issues found in 27 source files`.
+
+## Acceptance Criteria Check
+
+- Event payloads are saved through `sanitize_event_payload` inside `EventStore.append_event`.
+- Synthetic events can be saved to and read from temp SQLite.
+- `schema_version`, `event_id`, `session_id`, `turn_id`, `repo_id`, and `timestamp` are persisted as SQLite columns and included in returned payloads.
+- Store-level tests assert raw secret and absolute user path strings do not remain in SQLite `payload_json`.
+- Unit tests use `tmp_path` SQLite databases.
+
+## Integration Risk
+
+- Issue #3 sanitizer is not yet available. This implementation includes a minimal compatible sanitizer contract for event storage privacy. Future sanitizer work should preserve `sanitize_event_payload(payload: Mapping[str, Any]) -> dict[str, Any]` or update `EventStore.append_event` with an equivalent sanitized-payload boundary.

--- a/photon_action_memory/memory/sanitizer.py
+++ b/photon_action_memory/memory/sanitizer.py
@@ -1,8 +1,88 @@
-"""Sanitizer placeholder for event and dataset text."""
+"""Sanitizers for event and dataset text.
+
+The full sanitizer milestone can add richer reports and domain-specific rules.
+This module keeps the storage boundary private by redacting common secret and
+absolute-path patterns before data is persisted.
+"""
 
 from __future__ import annotations
 
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+_EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
+_BEARER_RE = re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]{8,}\b", re.IGNORECASE)
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"\b(api[_-]?key|token|password|secret)\s*[:=]\s*['\"]?[^'\"\s,;}]+",
+    re.IGNORECASE,
+)
+_OPENAI_KEY_RE = re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b")
+_LONG_TOKEN_RE = re.compile(r"\b[A-Za-z0-9_=-]{32,}\b")
+_USER_PATH_RE = re.compile(r"(?<!\w)/(Users|home)/([^/\s'\",;)]+)((?:/[^/\s'\",;)]+)*)?")
+_TMP_PATH_RE = re.compile(r"(?<!\w)/tmp((?:/[^/\s'\",;)]+)*)?")
+
+SanitizedPayload = dict[str, Any]
+
 
 def sanitize_text(text: str | None) -> str:
-    """Return a safe string placeholder until redaction rules are implemented."""
-    return text or ""
+    """Return text with common secrets and absolute user paths redacted."""
+    if text is None:
+        return ""
+
+    sanitized = _ANSI_ESCAPE_RE.sub("", text)
+    sanitized = _CONTROL_CHAR_RE.sub("", sanitized)
+    sanitized = _EMAIL_RE.sub("[EMAIL]", sanitized)
+    sanitized = _BEARER_RE.sub("Bearer [REDACTED_SECRET]", sanitized)
+    sanitized = _SECRET_ASSIGNMENT_RE.sub(
+        lambda match: f"{match.group(1)}=[REDACTED_SECRET]",
+        sanitized,
+    )
+    sanitized = _OPENAI_KEY_RE.sub("[REDACTED_SECRET]", sanitized)
+    sanitized = _LONG_TOKEN_RE.sub("[REDACTED_SECRET]", sanitized)
+    sanitized = _USER_PATH_RE.sub(lambda match: f"[USER_PATH]{match.group(3) or ''}", sanitized)
+    sanitized = _TMP_PATH_RE.sub(lambda match: f"[TMP_PATH]{match.group(1) or ''}", sanitized)
+    return sanitized
+
+
+def sanitize_event_payload(payload: Mapping[str, Any]) -> SanitizedPayload:
+    """Return a sanitized copy of an event payload safe for local persistence."""
+    sanitized = _sanitize_value(payload)
+    if not isinstance(sanitized, dict):
+        msg = "event payload must sanitize to a JSON object"
+        raise TypeError(msg)
+
+    redaction_status = sanitized.get("redaction_status")
+    if not isinstance(redaction_status, str) or not redaction_status:
+        sanitized["redaction_status"] = (
+            "redacted" if _sanitize_value(payload) != _plain_json_value(payload) else "clean"
+        )
+    return sanitized
+
+
+def _sanitize_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return sanitize_text(value)
+    if isinstance(value, Mapping):
+        return {str(key): _sanitize_value(child) for key, child in value.items()}
+    if _is_sequence(value):
+        return [_sanitize_value(child) for child in value]
+    if value is None or isinstance(value, bool | int | float):
+        return value
+    return sanitize_text(str(value))
+
+
+def _plain_json_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _plain_json_value(child) for key, child in value.items()}
+    if _is_sequence(value):
+        return [_plain_json_value(child) for child in value]
+    if value is None or isinstance(value, str | bool | int | float):
+        return value
+    return str(value)
+
+
+def _is_sequence(value: Any) -> bool:
+    return isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray)

--- a/photon_action_memory/memory/store.py
+++ b/photon_action_memory/memory/store.py
@@ -1,3 +1,216 @@
-"""Local event store placeholder."""
+"""Local SQLite event store for sanitized agent events."""
 
 from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from photon_action_memory import SCHEMA_VERSION
+from photon_action_memory.memory.sanitizer import SanitizedPayload, sanitize_event_payload
+
+
+@dataclass(frozen=True)
+class StoredEvent:
+    """Event row returned by the local event store."""
+
+    schema_version: str
+    event_id: str
+    session_id: str
+    turn_id: str
+    repo_id: str
+    timestamp: str
+    event_type: str
+    payload: SanitizedPayload
+
+
+class EventStore:
+    """Append/read API for sanitized events in a local SQLite database."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self.db_path = Path(db_path)
+        self._connection = sqlite3.connect(self.db_path)
+        self._connection.row_factory = sqlite3.Row
+        self._initialize_schema()
+
+    def close(self) -> None:
+        self._connection.close()
+
+    def __enter__(self) -> EventStore:
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        self.close()
+
+    def append_event(self, event: Mapping[str, Any]) -> StoredEvent:
+        """Sanitize and persist one event, returning the stored representation."""
+        sanitized = sanitize_event_payload(event)
+        schema_version = _string_field(sanitized, "schema_version", default=SCHEMA_VERSION)
+        event_id = _string_field(sanitized, "event_id", default_factory=lambda: str(uuid4()))
+        session_id = _required_string_field(sanitized, "session_id")
+        turn_id = _required_string_field(sanitized, "turn_id")
+        repo_id = _required_string_field(sanitized, "repo_id")
+        timestamp = _string_field(sanitized, "timestamp", default_factory=_utc_timestamp)
+        event_type = _required_string_field(sanitized, "event_type")
+        sanitized = {
+            **sanitized,
+            "schema_version": schema_version,
+            "event_id": event_id,
+            "session_id": session_id,
+            "turn_id": turn_id,
+            "repo_id": repo_id,
+            "timestamp": timestamp,
+            "event_type": event_type,
+        }
+        stored = StoredEvent(
+            schema_version=schema_version,
+            event_id=event_id,
+            session_id=session_id,
+            turn_id=turn_id,
+            repo_id=repo_id,
+            timestamp=timestamp,
+            event_type=event_type,
+            payload=sanitized,
+        )
+
+        payload_json = _to_canonical_json(stored.payload)
+        with self._connection:
+            self._connection.execute(
+                """
+                INSERT INTO events (
+                    schema_version,
+                    event_id,
+                    session_id,
+                    turn_id,
+                    repo_id,
+                    timestamp,
+                    event_type,
+                    payload_json
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    stored.schema_version,
+                    stored.event_id,
+                    stored.session_id,
+                    stored.turn_id,
+                    stored.repo_id,
+                    stored.timestamp,
+                    stored.event_type,
+                    payload_json,
+                ),
+            )
+        return stored
+
+    def list_events(
+        self,
+        *,
+        session_id: str | None = None,
+        repo_id: str | None = None,
+        limit: int | None = None,
+    ) -> list[StoredEvent]:
+        """Read stored events ordered by timestamp and insertion id."""
+        where_clauses: list[str] = []
+        params: list[object] = []
+        if session_id is not None:
+            where_clauses.append("session_id = ?")
+            params.append(session_id)
+        if repo_id is not None:
+            where_clauses.append("repo_id = ?")
+            params.append(repo_id)
+
+        query = "SELECT * FROM events"
+        if where_clauses:
+            query = f"{query} WHERE {' AND '.join(where_clauses)}"
+        query = f"{query} ORDER BY timestamp ASC, id ASC"
+        if limit is not None:
+            if limit < 1:
+                msg = "limit must be greater than zero"
+                raise ValueError(msg)
+            query = f"{query} LIMIT ?"
+            params.append(limit)
+
+        rows = self._connection.execute(query, params).fetchall()
+        return [_stored_event_from_row(row) for row in rows]
+
+    def _initialize_schema(self) -> None:
+        with self._connection:
+            self._connection.executescript(
+                """
+                PRAGMA journal_mode=WAL;
+                CREATE TABLE IF NOT EXISTS events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    schema_version TEXT NOT NULL,
+                    event_id TEXT NOT NULL UNIQUE,
+                    session_id TEXT NOT NULL,
+                    turn_id TEXT NOT NULL,
+                    repo_id TEXT NOT NULL,
+                    timestamp TEXT NOT NULL,
+                    event_type TEXT NOT NULL,
+                    payload_json TEXT NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_events_session_timestamp
+                    ON events (session_id, timestamp);
+                CREATE INDEX IF NOT EXISTS idx_events_repo_timestamp
+                    ON events (repo_id, timestamp);
+                """
+            )
+
+
+def _stored_event_from_row(row: sqlite3.Row) -> StoredEvent:
+    payload = json.loads(row["payload_json"])
+    if not isinstance(payload, dict):
+        msg = "stored event payload must be a JSON object"
+        raise TypeError(msg)
+    return StoredEvent(
+        schema_version=row["schema_version"],
+        event_id=row["event_id"],
+        session_id=row["session_id"],
+        turn_id=row["turn_id"],
+        repo_id=row["repo_id"],
+        timestamp=row["timestamp"],
+        event_type=row["event_type"],
+        payload=payload,
+    )
+
+
+def _required_string_field(payload: Mapping[str, Any], field_name: str) -> str:
+    value = payload.get(field_name)
+    if not isinstance(value, str) or not value:
+        msg = f"event field {field_name!r} is required"
+        raise ValueError(msg)
+    return value
+
+
+def _string_field(
+    payload: Mapping[str, Any],
+    field_name: str,
+    *,
+    default: str | None = None,
+    default_factory: Callable[[], str] | None = None,
+) -> str:
+    value = payload.get(field_name)
+    if isinstance(value, str) and value:
+        return value
+    if default is not None:
+        return default
+    if default_factory is not None:
+        return str(default_factory())
+    msg = f"event field {field_name!r} is required"
+    raise ValueError(msg)
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(UTC).isoformat(timespec="microseconds")
+
+
+def _to_canonical_json(payload: Mapping[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+
+
+__all__ = ["EventStore", "StoredEvent"]

--- a/tests/test_event_store.py
+++ b/tests/test_event_store.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from photon_action_memory import SCHEMA_VERSION
+from photon_action_memory.memory.store import EventStore
+
+
+def test_synthetic_event_round_trips_from_temp_sqlite(tmp_path: Path) -> None:
+    db_path = tmp_path / "events.sqlite"
+    event = {
+        "schema_version": SCHEMA_VERSION,
+        "event_id": "event-1",
+        "session_id": "session-1",
+        "turn_id": "turn-1",
+        "repo_id": "repo-1",
+        "timestamp": "2026-04-30T12:00:00+00:00",
+        "event_type": "synthetic",
+        "tool_name": "pytest",
+        "status": "ok",
+        "summary": "synthetic event",
+        "artifacts": [{"path": "src/session/store.rs"}],
+    }
+
+    with EventStore(db_path) as store:
+        stored = store.append_event(event)
+        loaded = store.list_events(session_id="session-1")
+
+    assert stored.event_id == "event-1"
+    assert loaded == [stored]
+    assert loaded[0].schema_version == SCHEMA_VERSION
+    assert loaded[0].session_id == "session-1"
+    assert loaded[0].turn_id == "turn-1"
+    assert loaded[0].repo_id == "repo-1"
+    assert loaded[0].timestamp == "2026-04-30T12:00:00+00:00"
+    assert loaded[0].payload["redaction_status"] == "clean"
+
+
+def test_event_store_persists_only_sanitized_payload(tmp_path: Path) -> None:
+    db_path = tmp_path / "events.sqlite"
+    raw_secret = "sk-testsecret1234567890"
+    raw_path = "/Users/alice/work/private/repo/main.py"
+    event = {
+        "event_id": "event-privacy",
+        "session_id": "session-privacy",
+        "turn_id": "turn-privacy",
+        "repo_id": "repo-privacy",
+        "timestamp": "2026-04-30T12:01:00+00:00",
+        "event_type": "synthetic",
+        "summary": f"opened {raw_path} with token={raw_secret}",
+        "artifacts": [{"path": raw_path, "metadata": {"authorization": f"Bearer {raw_secret}"}}],
+    }
+
+    with EventStore(db_path) as store:
+        stored = store.append_event(event)
+
+    with sqlite3.connect(db_path) as connection:
+        payload_json = connection.execute("SELECT payload_json FROM events").fetchone()[0]
+
+    payload = json.loads(payload_json)
+    assert payload == stored.payload
+    assert raw_secret not in payload_json
+    assert raw_path not in payload_json
+    assert "[REDACTED_SECRET]" in payload_json
+    assert "[USER_PATH]/work/private/repo/main.py" in payload_json
+    assert payload["redaction_status"] == "redacted"
+
+
+def test_event_store_requires_core_event_fields(tmp_path: Path) -> None:
+    with EventStore(tmp_path / "events.sqlite") as store:
+        with pytest.raises(ValueError, match="session_id"):
+            store.append_event(
+                {
+                    "event_id": "event-missing",
+                    "turn_id": "turn-1",
+                    "repo_id": "repo-1",
+                    "event_type": "synthetic",
+                }
+            )


### PR DESCRIPTION
## Summary
- Implements a local SQLite event store for sanitized PHOTON events.
- Resolves sanitizer integration against Issue #3 by keeping the richer sanitizer API and adding store-compatible payload sanitization.
- Adds focused event store tests and issue development reports.

## Verification
- `python -m pytest -q` -> 44 passed after merging latest develop
- `ruff check .` -> passed
- `ruff format --check .` -> passed

Closes #4