### PR TITLE
Issue #5: Implement sidecar health, events, and suggest MVP

### DIFF
--- a/dev-reports/issue-5/design.md
+++ b/dev-reports/issue-5/design.md
@@ -1,0 +1,34 @@
+# Issue #5 Design Note
+
+## Scope
+
+Implement the smallest M2 sidecar MVP that can run without a PHOTON model,
+checkpoint, or the later full schema/store milestones:
+
+- FastAPI `GET /health`
+- `POST /v1/events` backed by a local SQLite append-only event store
+- `POST /v1/suggest` with deterministic no-model suggestions
+- `POST /v1/summarize` and `POST /v1/evaluate` fixed as `501` stubs
+- Python client methods that fail open on sidecar errors or timeouts
+
+## Approach
+
+The API schema is intentionally permissive: required top-level fields are
+validated where M2 needs a stable contract, while nested agent/repo/task/event
+payloads remain dictionaries so M1 can still harden them later without this PR
+overfitting early. Unknown optional fields are accepted by Pydantic models.
+
+The event store uses Python's standard `sqlite3` module and stores one JSON
+payload per event. The default database path is under the system temp directory
+so the sidecar works out of the box during local smoke tests. Tests can inject a
+temporary store through `create_app`.
+
+Suggestion generation is a deterministic fallback. It extracts touched files and
+recent event summaries from the request, returns read/search suggestions up to
+the requested budget, and emits a warning that model scoring is unavailable.
+This satisfies fail-open behavior while leaving a narrow seam for future ranking
+and model-backed scoring.
+
+The client uses `httpx.Client` with a timeout and catches `httpx.HTTPError`.
+For suggest failures it returns the same response shape as the server, with an
+empty suggestions list and a `sidecar_unavailable` warning.

--- a/dev-reports/issue-5/implementation-summary.md
+++ b/dev-reports/issue-5/implementation-summary.md
@@ -1,0 +1,25 @@
+# Issue #5 Implementation Summary
+
+## Implemented
+
+- Added permissive M2 Pydantic API contracts in `photon_action_memory/api/schema.py`.
+- Implemented a local SQLite append-only event store in `photon_action_memory/memory/store.py`.
+- Implemented FastAPI sidecar routes in `photon_action_memory/api/server.py`:
+  - `GET /health`
+  - `POST /v1/events`
+  - `POST /v1/suggest`
+  - `POST /v1/summarize` as `501`
+  - `POST /v1/evaluate` as `501`
+- Implemented a synchronous fail-open `SidecarClient` in `photon_action_memory/api/client.py`.
+- Added focused API/client tests in `tests/test_sidecar_api.py`.
+- Updated existing import smoke tests for the expanded health/fallback response contract.
+- Updated v0.1.0 workspace docs to record the M2 stub contract and Issue #5 checklist progress.
+
+## Contract Notes
+
+- `POST /v1/suggest` works without a model or checkpoint by returning deterministic fallback
+  suggestions and a `model_unavailable` warning.
+- `SidecarClient.suggest()` catches `httpx.HTTPError` and JSON shape errors, then returns
+  an empty fail-open suggestion response with a `sidecar_unavailable` warning.
+- The SQLite store is intentionally minimal and stores sanitized JSON payloads. It is compatible
+  with the Issue #5 MVP but does not replace the future full Issue #4 store hardening.

--- a/dev-reports/issue-5/verification.md
+++ b/dev-reports/issue-5/verification.md
@@ -1,0 +1,56 @@
+# Issue #5 Verification
+
+Date: 2026-04-30
+
+## Commands
+
+```text
+python -m ruff check .
+```
+
+Result:
+
+```text
+All checks passed!
+```
+
+```text
+python -m ruff format --check .
+```
+
+Result:
+
+```text
+27 files already formatted
+```
+
+```text
+python -m pytest -q tests/test_sidecar_api.py tests/test_import.py
+```
+
+Result:
+
+```text
+.........                                                                [100%]
+9 passed in 0.12s
+```
+
+Additional shared-contract check:
+
+```text
+python -m mypy photon_action_memory tests
+```
+
+Result:
+
+```text
+Success: no issues found in 27 source files
+```
+
+## Integration Risk
+
+- No external PHOTON model, MLX runtime, or checkpoint is required for this issue. The suggest
+  path deliberately uses the local deterministic fallback and records that in the response.
+- The event store is a minimal local SQLite contract for M2. Future Issue #4 work may replace or
+  extend the schema, but this implementation verifies synthetic event persistence through the
+  public sidecar endpoint.

--- a/photon_action_memory/api/client.py
+++ b/photon_action_memory/api/client.py
@@ -1,8 +1,75 @@
-"""Fail-open sidecar client placeholder."""
+"""Fail-open sidecar client."""
 
 from __future__ import annotations
 
+from typing import Any
 
-def fallback_response(reason: str) -> dict[str, object]:
+import httpx
+
+from photon_action_memory import SCHEMA_VERSION
+from photon_action_memory.api.schema import FALLBACK_MODEL_VERSION
+
+
+def fallback_response(reason: str, *, request_id: str = "") -> dict[str, object]:
     """Return the minimal shape a client can use when the sidecar is unavailable."""
-    return {"suggestions": [], "warnings": [{"kind": "sidecar_unavailable", "message": reason}]}
+    return {
+        "request_id": request_id,
+        "schema_version": SCHEMA_VERSION,
+        "model_version": FALLBACK_MODEL_VERSION,
+        "suggestions": [],
+        "evidence": [],
+        "warnings": [{"kind": "sidecar_unavailable", "message": reason}],
+    }
+
+
+class SidecarClient:
+    """Small synchronous client that never blocks agent progress on suggest."""
+
+    def __init__(
+        self,
+        base_url: str = "http://127.0.0.1:8765",
+        *,
+        timeout: float = 0.5,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self._client = httpx.Client(base_url=base_url, timeout=timeout, transport=transport)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def health(self) -> dict[str, Any]:
+        response = self._client.get("/health")
+        response.raise_for_status()
+        payload = response.json()
+        if isinstance(payload, dict):
+            return payload
+        raise ValueError("sidecar health response was not an object")
+
+    def record_event(self, event: dict[str, Any]) -> dict[str, Any]:
+        response = self._client.post("/v1/events", json=event)
+        response.raise_for_status()
+        payload = response.json()
+        if isinstance(payload, dict):
+            return payload
+        raise ValueError("sidecar event response was not an object")
+
+    def suggest(self, request: dict[str, Any]) -> dict[str, Any]:
+        request_id = request.get("request_id")
+        try:
+            response = self._client.post("/v1/suggest", json=request)
+            response.raise_for_status()
+            payload = response.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            return fallback_response(str(exc), request_id=str(request_id or ""))
+
+        if isinstance(payload, dict):
+            return payload
+        return fallback_response(
+            "sidecar suggest response was not an object", request_id=str(request_id or "")
+        )
+
+    def __enter__(self) -> SidecarClient:
+        return self
+
+    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
+        self.close()

--- a/photon_action_memory/api/schema.py
+++ b/photon_action_memory/api/schema.py
@@ -13,6 +13,7 @@ from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 from photon_action_memory import SCHEMA_VERSION
 
 SchemaVersion = Literal["action-memory.v1"]
+DEFAULT_SCHEMA_VERSION: SchemaVersion = "action-memory.v1"
 FALLBACK_MODEL_VERSION = "photon-action-memory-v0.1.0-fallback"
 
 ActionKind = Literal[
@@ -196,7 +197,7 @@ class HealthResponse(SidecarModel):
     """Response body for health checks."""
 
     status: str
-    schema_version: SchemaVersion = SCHEMA_VERSION
+    schema_version: SchemaVersion = DEFAULT_SCHEMA_VERSION
 
 
 EvidenceItem = Evidence
@@ -210,6 +211,7 @@ __all__ = [
     "AgentInfo",
     "Artifact",
     "Budget",
+    "DEFAULT_SCHEMA_VERSION",
     "EventRequest",
     "EventResponse",
     "Evidence",

--- a/photon_action_memory/api/schema.py
+++ b/photon_action_memory/api/schema.py
@@ -1,10 +1,110 @@
-"""Versioned sidecar API schema placeholders.
+"""Versioned sidecar API schema.
 
-Concrete Pydantic models are introduced in the schema-first milestone.
+These models intentionally keep nested payloads permissive for the M2 sidecar
+MVP. Later schema-first work can tighten individual nested objects while
+preserving the top-level request/response contract introduced here.
 """
 
 from __future__ import annotations
 
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
 from photon_action_memory import SCHEMA_VERSION
 
-__all__ = ["SCHEMA_VERSION"]
+FALLBACK_MODEL_VERSION = "photon-action-memory-v0.1.0-fallback"
+
+
+class ExtraBaseModel(BaseModel):
+    """Base model that accepts forward-compatible optional fields."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+class WarningMessage(ExtraBaseModel):
+    kind: str
+    message: str
+
+
+class EvidenceItem(ExtraBaseModel):
+    id: str
+    kind: str
+    summary: str
+    source: str = "request"
+
+
+class Suggestion(ExtraBaseModel):
+    kind: str
+    target: str | None = None
+    command: str | None = None
+    query: str | None = None
+    confidence: float
+    reason: str
+    evidence_ids: list[str] = Field(default_factory=list)
+
+
+class SuggestBudget(ExtraBaseModel):
+    max_suggestions: int = 8
+    max_evidence_chars: int = 4000
+
+
+class SuggestRequest(ExtraBaseModel):
+    request_id: str
+    schema_version: str = SCHEMA_VERSION
+    agent: dict[str, Any] = Field(default_factory=dict)
+    repo: dict[str, Any] = Field(default_factory=dict)
+    task: dict[str, Any] = Field(default_factory=dict)
+    working_memory: dict[str, Any] = Field(default_factory=dict)
+    recent_events: list[dict[str, Any]] = Field(default_factory=list)
+    budget: SuggestBudget = Field(default_factory=SuggestBudget)
+
+
+class SuggestResponse(ExtraBaseModel):
+    request_id: str
+    schema_version: str = SCHEMA_VERSION
+    model_version: str
+    suggestions: list[Suggestion] = Field(default_factory=list)
+    evidence: list[EvidenceItem] = Field(default_factory=list)
+    warnings: list[WarningMessage] = Field(default_factory=list)
+
+
+class EventRequest(ExtraBaseModel):
+    schema_version: str = SCHEMA_VERSION
+    event_id: str | None = None
+    session_id: str | None = None
+    turn_id: str | None = None
+    repo_id: str | None = None
+    timestamp: str | None = None
+    event_type: str = "synthetic"
+    tool_name: str | None = None
+    status: str | None = None
+    summary: str = ""
+    artifacts: dict[str, Any] = Field(default_factory=dict)
+    redaction_status: str = "unspecified"
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class EventResponse(ExtraBaseModel):
+    status: str
+    event_id: str
+    stored: bool
+
+
+class HealthResponse(ExtraBaseModel):
+    status: str
+    schema_version: str = SCHEMA_VERSION
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "EventRequest",
+    "EventResponse",
+    "EvidenceItem",
+    "FALLBACK_MODEL_VERSION",
+    "HealthResponse",
+    "SuggestRequest",
+    "SuggestResponse",
+    "Suggestion",
+    "WarningMessage",
+]

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI, HTTPException
 
 from photon_action_memory import SCHEMA_VERSION, __version__
 from photon_action_memory.api.schema import (
+    DEFAULT_SCHEMA_VERSION,
     FALLBACK_MODEL_VERSION,
     EventRequest,
     EventResponse,
@@ -44,7 +45,7 @@ def create_app(store: SQLiteEventStore | None = None) -> FastAPI:
 
     @app.get("/health", response_model=HealthResponse)
     def health() -> HealthResponse:
-        return HealthResponse(**health_payload())
+        return HealthResponse(status="ok", schema_version=DEFAULT_SCHEMA_VERSION)
 
     @app.post("/v1/events", response_model=EventResponse)
     def append_event(event: EventRequest) -> EventResponse:

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -1,8 +1,177 @@
-"""FastAPI sidecar entrypoint placeholder."""
+"""FastAPI sidecar entrypoint."""
 
 from __future__ import annotations
 
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+
+from photon_action_memory import SCHEMA_VERSION, __version__
+from photon_action_memory.api.schema import (
+    FALLBACK_MODEL_VERSION,
+    EventRequest,
+    EventResponse,
+    EvidenceItem,
+    HealthResponse,
+    Suggestion,
+    SuggestRequest,
+    SuggestResponse,
+    WarningMessage,
+)
+from photon_action_memory.memory.store import SQLiteEventStore
+from photon_action_memory.models.photon_adapter import is_model_available
+from photon_action_memory.ranking.candidates import extract_candidates
+
 
 def health_payload() -> dict[str, str]:
-    """Return a minimal health payload without importing FastAPI yet."""
-    return {"status": "ok"}
+    """Return a minimal health payload for direct client smoke checks."""
+    return {"status": "ok", "schema_version": SCHEMA_VERSION}
+
+
+def default_store_path() -> Path:
+    configured = os.environ.get("PHOTON_ACTION_MEMORY_DB")
+    if configured:
+        return Path(configured)
+    return Path(tempfile.gettempdir()) / "photon-action-memory" / "events.sqlite"
+
+
+def create_app(store: SQLiteEventStore | None = None) -> FastAPI:
+    event_store = store or SQLiteEventStore(default_store_path())
+    app = FastAPI(title="PHOTON Action Memory", version=__version__)
+    app.state.event_store = event_store
+
+    @app.get("/health", response_model=HealthResponse)
+    def health() -> HealthResponse:
+        return HealthResponse(**health_payload())
+
+    @app.post("/v1/events", response_model=EventResponse)
+    def append_event(event: EventRequest) -> EventResponse:
+        stored = event_store.append(event.model_dump(mode="json"))
+        return EventResponse(status="stored", event_id=stored.event_id, stored=True)
+
+    @app.post("/v1/suggest", response_model=SuggestResponse)
+    def suggest(request: SuggestRequest) -> SuggestResponse:
+        return build_fallback_suggestions(request)
+
+    @app.post("/v1/summarize")
+    def summarize_stub() -> None:
+        raise HTTPException(status_code=501, detail="summarize is not implemented in M2")
+
+    @app.post("/v1/evaluate")
+    def evaluate_stub() -> None:
+        raise HTTPException(status_code=501, detail="evaluate is not implemented in M2")
+
+    return app
+
+
+def build_fallback_suggestions(request: SuggestRequest) -> SuggestResponse:
+    max_suggestions = max(0, request.budget.max_suggestions)
+    evidence = _evidence_from_recent_events(request)
+    candidates = _candidate_targets(request)
+    suggestions: list[Suggestion] = []
+
+    for target in candidates[:max_suggestions]:
+        suggestions.append(
+            Suggestion(
+                kind="read",
+                target=target,
+                confidence=0.35,
+                reason="Deterministic fallback prioritized a touched or recently mentioned file.",
+                evidence_ids=[item.id for item in evidence[:1]],
+            )
+        )
+
+    if len(suggestions) < max_suggestions:
+        query = _fallback_query(request)
+        suggestions.append(
+            Suggestion(
+                kind="search",
+                query=query,
+                confidence=0.2,
+                reason="No model checkpoint is available; search is a low-risk fallback action.",
+                evidence_ids=[item.id for item in evidence[:1]],
+            )
+        )
+
+    warnings = [
+        WarningMessage(
+            kind="model_unavailable",
+            message=(
+                "PHOTON model scoring is unavailable; deterministic fallback suggestions were used."
+            ),
+        )
+    ]
+    if not is_model_available():
+        model_version = FALLBACK_MODEL_VERSION
+    else:
+        model_version = "photon-action-memory-v0.1.0"
+
+    return SuggestResponse(
+        request_id=request.request_id,
+        schema_version=request.schema_version,
+        model_version=model_version,
+        suggestions=suggestions[:max_suggestions],
+        evidence=evidence,
+        warnings=warnings,
+    )
+
+
+def _candidate_targets(request: SuggestRequest) -> list[str]:
+    items: list[str] = []
+    touched_files = request.working_memory.get("touched_files")
+    if isinstance(touched_files, list):
+        items.extend(str(item) for item in touched_files if item)
+
+    for event in request.recent_events:
+        for key in ("target", "file", "path"):
+            value = event.get(key)
+            if isinstance(value, str) and value:
+                items.append(value)
+
+    return extract_candidates(items)
+
+
+def _evidence_from_recent_events(request: SuggestRequest) -> list[EvidenceItem]:
+    evidence: list[EvidenceItem] = []
+    remaining_chars = max(0, request.budget.max_evidence_chars)
+
+    for index, event in enumerate(request.recent_events, start=1):
+        summary = _event_summary(event)
+        if not summary:
+            continue
+        clipped = summary[:remaining_chars]
+        if not clipped:
+            break
+        evidence.append(
+            EvidenceItem(
+                id=f"evt_{index:03d}",
+                kind=str(event.get("type") or event.get("event_type") or "event"),
+                summary=clipped,
+                source="request",
+            )
+        )
+        remaining_chars -= len(clipped)
+        if remaining_chars <= 0:
+            break
+
+    return evidence
+
+
+def _event_summary(event: dict[str, Any]) -> str:
+    value = event.get("summary") or event.get("message")
+    if isinstance(value, str):
+        return value
+    return ""
+
+
+def _fallback_query(request: SuggestRequest) -> str:
+    summary = request.task.get("summary") or request.task.get("user_request")
+    if isinstance(summary, str) and summary:
+        return summary[:120]
+    return request.request_id
+
+
+app = create_app()

--- a/photon_action_memory/memory/store.py
+++ b/photon_action_memory/memory/store.py
@@ -1,3 +1,110 @@
-"""Local event store placeholder."""
+"""Local SQLite event store for sidecar events."""
 
 from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from photon_action_memory.memory.sanitizer import sanitize_text
+
+
+@dataclass(frozen=True)
+class StoredEvent:
+    event_id: str
+    received_at: str
+    payload: dict[str, Any]
+
+
+class SQLiteEventStore:
+    """Append-only SQLite store for JSON event payloads."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._initialize()
+
+    def append(self, payload: dict[str, Any]) -> StoredEvent:
+        sanitized_payload = _sanitize_payload(payload)
+        event_id = _coerce_event_id(sanitized_payload.get("event_id"))
+        sanitized_payload["event_id"] = event_id
+        received_at = datetime.now(UTC).isoformat()
+
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO events (event_id, received_at, payload_json)
+                VALUES (?, ?, ?)
+                """,
+                (
+                    event_id,
+                    received_at,
+                    json.dumps(sanitized_payload, sort_keys=True, separators=(",", ":")),
+                ),
+            )
+
+        return StoredEvent(event_id=event_id, received_at=received_at, payload=sanitized_payload)
+
+    def list_events(self, *, limit: int = 100) -> list[StoredEvent]:
+        safe_limit = max(0, limit)
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT event_id, received_at, payload_json
+                FROM events
+                ORDER BY received_at ASC
+                LIMIT ?
+                """,
+                (safe_limit,),
+            ).fetchall()
+
+        return [
+            StoredEvent(
+                event_id=str(row["event_id"]),
+                received_at=str(row["received_at"]),
+                payload=dict(json.loads(str(row["payload_json"]))),
+            )
+            for row in rows
+        ]
+
+    def count(self) -> int:
+        with self._connect() as connection:
+            row = connection.execute("SELECT COUNT(*) AS count FROM events").fetchone()
+        return int(row["count"])
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.path)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    def _initialize(self) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS events (
+                    event_id TEXT PRIMARY KEY,
+                    received_at TEXT NOT NULL,
+                    payload_json TEXT NOT NULL
+                )
+                """
+            )
+
+
+def _coerce_event_id(value: object) -> str:
+    if isinstance(value, str) and value:
+        return value
+    return f"evt_{uuid4().hex}"
+
+
+def _sanitize_payload(value: Any) -> Any:
+    if isinstance(value, str):
+        return sanitize_text(value)
+    if isinstance(value, list):
+        return [_sanitize_payload(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _sanitize_payload(item) for key, item in value.items()}
+    return value

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -13,12 +13,13 @@ def test_package_metadata() -> None:
 
 
 def test_placeholder_health_payload() -> None:
-    assert health_payload() == {"status": "ok"}
+    assert health_payload() == {"status": "ok", "schema_version": "action-memory.v1"}
 
 
 def test_placeholder_fail_open_response() -> None:
     payload = fallback_response("timeout")
     assert payload["suggestions"] == []
+    assert payload["evidence"] == []
     assert payload["warnings"] == [{"kind": "sidecar_unavailable", "message": "timeout"}]
 
 

--- a/tests/test_sidecar_api.py
+++ b/tests/test_sidecar_api.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+from fastapi.testclient import TestClient
+
+from photon_action_memory.api.client import SidecarClient
+from photon_action_memory.api.server import create_app
+from photon_action_memory.memory.store import SQLiteEventStore
+
+
+def test_health_check_succeeds(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+
+    with TestClient(app) as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "schema_version": "action-memory.v1"}
+
+
+def test_events_endpoint_stores_synthetic_event(tmp_path: Path) -> None:
+    store = SQLiteEventStore(tmp_path / "events.sqlite")
+    app = create_app(store)
+    event = {
+        "event_id": "evt_synthetic_001",
+        "event_type": "synthetic",
+        "session_id": "session-1",
+        "summary": "opened photon_action_memory/api/server.py",
+    }
+
+    with TestClient(app) as client:
+        response = client.post("/v1/events", json=event)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "stored",
+        "event_id": "evt_synthetic_001",
+        "stored": True,
+    }
+    assert store.count() == 1
+    stored_event = store.list_events()[0]
+    assert stored_event.payload["summary"] == "opened photon_action_memory/api/server.py"
+
+
+def test_suggest_returns_no_model_fallback(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    request = {
+        "request_id": "req-1",
+        "task": {"summary": "implement sidecar"},
+        "working_memory": {"touched_files": ["photon_action_memory/api/server.py"]},
+        "recent_events": [
+            {
+                "type": "tool_result",
+                "summary": "server.py contains the FastAPI entrypoint",
+            }
+        ],
+        "budget": {"max_suggestions": 2, "max_evidence_chars": 80},
+    }
+
+    with TestClient(app) as client:
+        response = client.post("/v1/suggest", json=request)
+
+    payload = response.json()
+    assert response.status_code == 200
+    assert payload["request_id"] == "req-1"
+    assert payload["model_version"] == "photon-action-memory-v0.1.0-fallback"
+    assert payload["suggestions"][0]["kind"] == "read"
+    assert payload["suggestions"][0]["target"] == "photon_action_memory/api/server.py"
+    assert payload["warnings"] == [
+        {
+            "kind": "model_unavailable",
+            "message": (
+                "PHOTON model scoring is unavailable; deterministic fallback suggestions were used."
+            ),
+        }
+    ]
+
+
+def test_summarize_and_evaluate_are_m2_stubs(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+
+    with TestClient(app) as client:
+        summarize_response = client.post("/v1/summarize", json={})
+        evaluate_response = client.post("/v1/evaluate", json={})
+
+    assert summarize_response.status_code == 501
+    assert evaluate_response.status_code == 501
+
+
+def test_client_suggest_fails_open_on_sidecar_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"detail": "boom"})
+
+    transport = httpx.MockTransport(handler)
+    with SidecarClient(transport=transport) as client:
+        payload = client.suggest({"request_id": "req-timeout"})
+
+    assert payload["request_id"] == "req-timeout"
+    assert payload["suggestions"] == []
+    assert payload["warnings"][0]["kind"] == "sidecar_unavailable"

--- a/workspace/v0.1.0/01_spec_requirements_architecture.md
+++ b/workspace/v0.1.0/01_spec_requirements_architecture.md
@@ -88,6 +88,9 @@ v0.1.0 では HTTP localhost を主経路とし、将来 stdio / MCP adapter を
 | `POST /v1/summarize` | session / tool loop を compact memory に変換 |
 | `POST /v1/evaluate` | shadow-mode の suggestion と実行結果を記録 |
 
+M2 MVP では `summarize` / `evaluate` は `501 Not Implemented` を返し、
+contract のみ固定する。実体は M6 の shadow eval 実装で追加する。
+
 ### 5.2 Suggest Request
 
 最小 schema:

--- a/workspace/v0.1.0/05_development_preparation_plan.md
+++ b/workspace/v0.1.0/05_development_preparation_plan.md
@@ -496,10 +496,10 @@ shadow-mode log schema:
 ### Phase 3: Sidecar first run
 
 - [ ] [#4](https://github.com/Kewton/photon-action-memory/issues/4) SQLite event store
-- [ ] [#5](https://github.com/Kewton/photon-action-memory/issues/5) FastAPI server
-- [ ] [#5](https://github.com/Kewton/photon-action-memory/issues/5) fail-open client
-- [ ] [#5](https://github.com/Kewton/photon-action-memory/issues/5) synthetic event smoke
-- [ ] [#5](https://github.com/Kewton/photon-action-memory/issues/5) no-model suggest smoke
+- [x] [#5](https://github.com/Kewton/photon-action-memory/issues/5) FastAPI server
+- [x] [#5](https://github.com/Kewton/photon-action-memory/issues/5) fail-open client
+- [x] [#5](https://github.com/Kewton/photon-action-memory/issues/5) synthetic event smoke
+- [x] [#5](https://github.com/Kewton/photon-action-memory/issues/5) no-model suggest smoke
 
 ### Phase 4: Dataset and ranking
 


### PR DESCRIPTION
## Summary
- Implements FastAPI sidecar health, event ingestion, summarize/evaluate stubs, and deterministic suggest fallback.
- Adds fail-open sidecar client behavior.
- Integrates with the v1 schema and SQLite event store from Issues #2 and #4.

## Verification
- `python -m pytest -q` -> 49 passed after merging latest develop and resolving schema/store conflicts
- `ruff check .` -> passed
- `ruff format --check .` -> passed

Closes #5