### PR TITLE
#6 [P1][M4] Add deterministic ranking fallback

### DIFF
--- a/dev-reports/issue-6/design.md
+++ b/dev-reports/issue-6/design.md
@@ -1,0 +1,23 @@
+# Issue 6 Design
+
+## Goal
+
+Implement the no-model deterministic ranking path used by `/v1/suggest` so the sidecar can return stable, bounded suggestions when PHOTON scoring is unavailable.
+
+## Approach
+
+- Keep the public schema unchanged.
+- Extract file path candidates from touched files, recent event metadata, and recent event summaries.
+- Score candidates with deterministic integer signals:
+  - recent error file paths first;
+  - touched files and explicit target/path metadata next;
+  - stable first-seen order as the tie breaker.
+- Generate only low-risk `read`, `inspect`, `search`, and optional test/build suggestions; filter destructive shell commands.
+- Keep evidence generation bounded by `budget.max_evidence_chars` and suggestions bounded by `budget.max_suggestions`.
+- Add guard helpers for repeated read/search warnings, missing evidence warnings for edit-like requests, and destructive command filtering.
+
+## Test Plan
+
+- Add focused ranking and guard tests for deterministic ordering, recent error priority, warning triggers, evidence budgeting, and destructive command filtering.
+- Update sidecar API tests to cover the delegated fallback path.
+- Run focused tests first, then the full pytest suite and static checks if practical.

--- a/dev-reports/issue-6/implementation-summary.md
+++ b/dev-reports/issue-6/implementation-summary.md
@@ -1,0 +1,25 @@
+# Issue 6 Implementation Summary
+
+## Changed
+
+- Added deterministic file path extraction in `ranking/candidates.py`.
+- Implemented fallback suggestion ranking in `ranking/fallback.py`:
+  - stable first-seen tie breaking;
+  - recent error file paths ranked above ordinary touched files;
+  - basename matches canonicalized back to touched full paths;
+  - bounded suggestion output;
+  - safe test/build command suggestions and search fallback.
+- Implemented guard helpers in `ranking/guards.py`:
+  - `model_unavailable` fallback warning;
+  - repeated read/search warning detection;
+  - missing evidence warning for edit-like requests;
+  - destructive shell command detection.
+- Updated `/v1/suggest` to delegate fallback suggestion building and warnings to ranking modules.
+- Marked the Issue #6 Phase 4 checklist items complete in the development preparation plan.
+- Added focused tests in `tests/test_ranking_fallback.py`.
+
+## Notes
+
+- The API schema was not changed.
+- The fallback path still returns the existing fallback model version when the PHOTON model is unavailable.
+- Evidence remains sourced from recent events and capped by `budget.max_evidence_chars`.

--- a/dev-reports/issue-6/verification.md
+++ b/dev-reports/issue-6/verification.md
@@ -1,0 +1,26 @@
+# Issue 6 Verification
+
+## Commands
+
+- `python -m pytest tests/test_ranking_fallback.py tests/test_sidecar_api.py -q`
+  - Result: pass, 11 tests.
+- `python -m pytest -q`
+  - Result: pass, 55 tests.
+- `ruff format --check .`
+  - Result: pass, 35 files already formatted.
+- `ruff check .`
+  - Result: pass.
+- `mypy photon_action_memory tests`
+  - Result: pass, no issues.
+- `python -m build`
+  - Result: pass after allowing network access for isolated `hatchling` build dependency installation.
+
+## Coverage
+
+- Same input returns the same ordered response.
+- Recent error file path is ranked first as an `inspect` suggestion.
+- Top-k suggestion limit is enforced.
+- Evidence summaries stay within the evidence character budget.
+- Repeated read/search actions emit `repeat_failure` warnings.
+- Edit-like requests without evidence emit `missing_evidence`.
+- Destructive shell commands are detected and are not emitted as suggestions.

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -16,14 +16,13 @@ from photon_action_memory.api.schema import (
     EventResponse,
     EvidenceItem,
     HealthResponse,
-    Suggestion,
     SuggestRequest,
     SuggestResponse,
-    WarningMessage,
 )
 from photon_action_memory.memory.store import SQLiteEventStore
 from photon_action_memory.models.photon_adapter import is_model_available
-from photon_action_memory.ranking.candidates import extract_candidates
+from photon_action_memory.ranking.fallback import build_ranked_suggestions
+from photon_action_memory.ranking.guards import fallback_warnings
 
 
 def health_payload() -> dict[str, str]:
@@ -76,40 +75,8 @@ def create_app(store: SQLiteEventStore | None = None) -> FastAPI:
 def build_fallback_suggestions(request: SuggestRequest) -> SuggestResponse:
     max_suggestions = max(0, request.budget.max_suggestions)
     evidence = _evidence_from_recent_events(request)
-    candidates = _candidate_targets(request)
-    suggestions: list[Suggestion] = []
-
-    for target in candidates[:max_suggestions]:
-        suggestions.append(
-            Suggestion(
-                kind="read",
-                target=target,
-                confidence=0.35,
-                reason="Deterministic fallback prioritized a touched or recently mentioned file.",
-                evidence_ids=[item.id for item in evidence[:1]],
-            )
-        )
-
-    if len(suggestions) < max_suggestions:
-        query = _fallback_query(request)
-        suggestions.append(
-            Suggestion(
-                kind="search",
-                query=query,
-                confidence=0.2,
-                reason="No model checkpoint is available; search is a low-risk fallback action.",
-                evidence_ids=[item.id for item in evidence[:1]],
-            )
-        )
-
-    warnings = [
-        WarningMessage(
-            kind="model_unavailable",
-            message=(
-                "PHOTON model scoring is unavailable; deterministic fallback suggestions were used."
-            ),
-        )
-    ]
+    suggestions = build_ranked_suggestions(request, evidence=evidence, limit=max_suggestions)
+    warnings = fallback_warnings(request)
     if not is_model_available():
         model_version = FALLBACK_MODEL_VERSION
     else:
@@ -123,20 +90,6 @@ def build_fallback_suggestions(request: SuggestRequest) -> SuggestResponse:
         evidence=evidence,
         warnings=warnings,
     )
-
-
-def _candidate_targets(request: SuggestRequest) -> list[str]:
-    items: list[str] = []
-    items.extend(str(item) for item in request.working_memory.touched_files if item)
-
-    for event in request.recent_events:
-        event_payload = event.model_dump()
-        for key in ("target", "file", "path"):
-            value = event_payload.get(key)
-            if isinstance(value, str) and value:
-                items.append(value)
-
-    return extract_candidates(items)
 
 
 def _evidence_from_recent_events(request: SuggestRequest) -> list[EvidenceItem]:
@@ -167,13 +120,6 @@ def _evidence_from_recent_events(request: SuggestRequest) -> list[EvidenceItem]:
 
 def _event_summary(event: object) -> str:
     return str(getattr(event, "summary", "") or "")
-
-
-def _fallback_query(request: SuggestRequest) -> str:
-    summary = request.task.summary or request.task.user_request
-    if summary:
-        return summary[:120]
-    return request.request_id
 
 
 app = create_app()

--- a/photon_action_memory/ranking/candidates.py
+++ b/photon_action_memory/ranking/candidates.py
@@ -1,6 +1,17 @@
-"""Deterministic candidate extraction placeholder."""
+"""Deterministic candidate extraction helpers."""
 
 from __future__ import annotations
+
+import re
+
+_PATH_RE = re.compile(
+    r"(?<![\w./-])"
+    r"((?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+"
+    r"|[A-Za-z0-9_.-]+\.(?:py|rs|js|ts|tsx|jsx|md|toml|yaml|yml|json|txt|sh|sql))"
+    r"(?::\d+(?::\d+)?)?"
+)
+
+_TRAILING_PUNCTUATION = ".,;:)]}'\"`"
 
 
 def extract_candidates(items: list[str]) -> list[str]:
@@ -12,3 +23,20 @@ def extract_candidates(items: list[str]) -> list[str]:
             seen.add(item)
             out.append(item)
     return out
+
+
+def extract_file_paths(text: str) -> list[str]:
+    """Extract stable file path candidates from free-form event text."""
+    candidates: list[str] = []
+    for match in _PATH_RE.finditer(text):
+        candidate = match.group(1).strip().rstrip(_TRAILING_PUNCTUATION)
+        if _is_safe_path_candidate(candidate):
+            candidates.append(candidate)
+    return extract_candidates(candidates)
+
+
+def _is_safe_path_candidate(candidate: str) -> bool:
+    lowered = candidate.lower()
+    if any(part in lowered for part in ("secret", "token", "password", "credential")):
+        return False
+    return bool(candidate and not candidate.startswith(("-", ".")))

--- a/photon_action_memory/ranking/fallback.py
+++ b/photon_action_memory/ranking/fallback.py
@@ -1,8 +1,236 @@
-"""No-model fallback ranking placeholder."""
+"""No-model deterministic fallback ranking."""
 
 from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from photon_action_memory.api.schema import EvidenceItem, Suggestion, SuggestRequest
+from photon_action_memory.ranking.candidates import extract_candidates, extract_file_paths
+from photon_action_memory.ranking.guards import is_destructive_command
+
+
+@dataclass
+class _FileCandidate:
+    target: str
+    score: int
+    first_seen: int
+    inspect: bool = False
+    evidence_ids: list[str] = field(default_factory=list)
 
 
 def rank_candidates(candidates: list[str], *, limit: int) -> list[str]:
     """Return deterministic top-k candidates."""
-    return candidates[: max(limit, 0)]
+    return extract_candidates(candidates)[: max(limit, 0)]
+
+
+def build_ranked_suggestions(
+    request: SuggestRequest,
+    *,
+    evidence: list[EvidenceItem],
+    limit: int,
+) -> list[Suggestion]:
+    """Build deterministic fallback suggestions for a suggest request."""
+    if limit <= 0:
+        return []
+
+    suggestions: list[Suggestion] = []
+    evidence_ids = {item.id for item in evidence}
+
+    for candidate in _rank_file_candidates(request):
+        suggestions.append(
+            Suggestion(
+                kind="inspect" if candidate.inspect else "read",
+                target=candidate.target,
+                confidence=_confidence(candidate.score),
+                reason=_file_reason(candidate),
+                evidence_ids=[item for item in candidate.evidence_ids if item in evidence_ids],
+            )
+        )
+        if len(suggestions) >= limit:
+            return suggestions
+
+    for suggestion in _command_suggestions(request, evidence):
+        if is_destructive_command(suggestion.command or ""):
+            continue
+        suggestions.append(suggestion)
+        if len(suggestions) >= limit:
+            return suggestions
+
+    suggestions.append(
+        Suggestion(
+            kind="search",
+            query=_fallback_query(request),
+            confidence=0.2,
+            reason="No model checkpoint is available; search is a low-risk fallback action.",
+            evidence_ids=[item.id for item in evidence[:1]],
+        )
+    )
+    return suggestions[:limit]
+
+
+def _rank_file_candidates(request: SuggestRequest) -> list[_FileCandidate]:
+    candidates: dict[str, _FileCandidate] = {}
+    first_seen = 0
+    touched_files = extract_candidates(
+        [item for item in request.working_memory.touched_files if item]
+    )
+    touched_set = set(touched_files)
+
+    for target in touched_files:
+        first_seen = _record_candidate(
+            candidates,
+            target,
+            score=50,
+            first_seen=first_seen,
+            inspect=False,
+            evidence_id=None,
+        )
+
+    task_text = " ".join(
+        part for part in (request.task.user_request, request.task.summary or "") if part
+    )
+    for raw_target in extract_file_paths(task_text):
+        target = _canonical_target(raw_target, touched_files)
+        first_seen = _record_candidate(
+            candidates,
+            target,
+            score=80 if target in touched_set else 55,
+            first_seen=first_seen,
+            inspect=False,
+            evidence_id=None,
+        )
+
+    for index, event in enumerate(request.recent_events, start=1):
+        payload = event.model_dump()
+        error = _is_error_event(payload)
+        evidence_id = f"evt_{index:03d}"
+        metadata_targets = _metadata_targets(payload)
+        summary_targets = extract_file_paths(event.summary)
+        for raw_target in metadata_targets + summary_targets:
+            target = _canonical_target(raw_target, touched_files)
+            score = 70
+            if target in touched_set:
+                score += 30
+            if error:
+                score += 100
+            first_seen = _record_candidate(
+                candidates,
+                target,
+                score=score,
+                first_seen=first_seen,
+                inspect=error,
+                evidence_id=evidence_id,
+            )
+
+    return sorted(
+        candidates.values(),
+        key=lambda item: (-item.score, item.first_seen, item.target),
+    )
+
+
+def _record_candidate(
+    candidates: dict[str, _FileCandidate],
+    target: str,
+    *,
+    score: int,
+    first_seen: int,
+    inspect: bool,
+    evidence_id: str | None,
+) -> int:
+    clean_target = target.strip()
+    if not clean_target:
+        return first_seen
+
+    existing = candidates.get(clean_target)
+    if existing is None:
+        existing = _FileCandidate(
+            target=clean_target,
+            score=score,
+            first_seen=first_seen,
+            inspect=inspect,
+        )
+        candidates[clean_target] = existing
+        first_seen += 1
+    else:
+        existing.score = max(existing.score, score)
+        existing.inspect = existing.inspect or inspect
+
+    if evidence_id and evidence_id not in existing.evidence_ids:
+        existing.evidence_ids.append(evidence_id)
+    return first_seen
+
+
+def _metadata_targets(payload: dict[str, object]) -> list[str]:
+    targets: list[str] = []
+    for key in ("target", "file", "path"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            targets.append(value)
+    return extract_candidates(targets)
+
+
+def _canonical_target(target: str, touched_files: list[str]) -> str:
+    if "/" in target:
+        return target
+    matches = [item for item in touched_files if item.rsplit("/", maxsplit=1)[-1] == target]
+    if len(matches) == 1:
+        return matches[0]
+    return target
+
+
+def _is_error_event(payload: dict[str, object]) -> bool:
+    text = " ".join(
+        str(payload.get(key) or "") for key in ("type", "status", "summary", "kind")
+    ).lower()
+    return any(
+        marker in text
+        for marker in ("error", "failed", "failure", "exception", "traceback", "panic")
+    )
+
+
+def _command_suggestions(request: SuggestRequest, evidence: list[EvidenceItem]) -> list[Suggestion]:
+    suggestions: list[Suggestion] = []
+    text = " ".join(event.summary.lower() for event in request.recent_events)
+    evidence_ids = [item.id for item in evidence[:1]]
+    if "pytest" in text or "test" in text:
+        suggestions.append(
+            Suggestion(
+                kind="test",
+                command="pytest -q",
+                confidence=0.25,
+                reason="Recent test output was present; rerun the focused test suite.",
+                evidence_ids=evidence_ids,
+            )
+        )
+    if "build" in text:
+        suggestions.append(
+            Suggestion(
+                kind="build",
+                command="python -m build",
+                confidence=0.2,
+                reason="Recent build output was present; rerun the package build.",
+                evidence_ids=evidence_ids,
+            )
+        )
+    return suggestions
+
+
+def _confidence(score: int) -> float:
+    if score >= 170:
+        return 0.55
+    if score >= 100:
+        return 0.45
+    return 0.35
+
+
+def _file_reason(candidate: _FileCandidate) -> str:
+    if candidate.inspect:
+        return "Deterministic fallback prioritized a file from a recent error event."
+    return "Deterministic fallback prioritized a touched or recently mentioned file."
+
+
+def _fallback_query(request: SuggestRequest) -> str:
+    summary = request.task.summary or request.task.user_request
+    if summary:
+        return summary[:120]
+    return request.request_id

--- a/photon_action_memory/ranking/guards.py
+++ b/photon_action_memory/ranking/guards.py
@@ -1,3 +1,111 @@
-"""Warning and fallback guard placeholder."""
+"""Warning and fallback guard helpers."""
 
 from __future__ import annotations
+
+import re
+from collections import Counter
+
+from photon_action_memory.api.schema import SuggestRequest, WarningMessage
+
+_DESTRUCTIVE_COMMAND_RE = re.compile(
+    r"(^|\s)(rm\s+-[^\n;]*[rf]|sudo\s+rm|git\s+reset\s+--hard|"
+    r"git\s+clean\s+-[^\n;]*[fd]|mkfs|dd\s+if=|chmod\s+-R\s+777)\b"
+)
+
+_EDIT_TERMS = (
+    "edit",
+    "change",
+    "modify",
+    "implement",
+    "fix",
+    "update",
+    "patch",
+    "write",
+)
+
+
+def is_destructive_command(command: str) -> bool:
+    """Return true when a shell command should never be suggested."""
+    return bool(_DESTRUCTIVE_COMMAND_RE.search(command.strip().lower()))
+
+
+def fallback_warnings(request: SuggestRequest) -> list[WarningMessage]:
+    """Build deterministic non-fatal warnings for fallback suggestions."""
+    warnings: list[WarningMessage] = [
+        WarningMessage(
+            kind="model_unavailable",
+            message=(
+                "PHOTON model scoring is unavailable; deterministic fallback suggestions were used."
+            ),
+        )
+    ]
+    warnings.extend(repeated_action_warnings(request))
+    if needs_missing_evidence_warning(request):
+        warnings.append(
+            WarningMessage(
+                kind="missing_evidence",
+                message="Edit-like request has insufficient supporting evidence.",
+            )
+        )
+    return warnings
+
+
+def repeated_action_warnings(request: SuggestRequest) -> list[WarningMessage]:
+    """Warn when recent read/search actions repeat the same target or query."""
+    keys: list[tuple[str, str]] = []
+    for event in request.recent_events:
+        payload = event.model_dump()
+        action = _action_name(payload)
+        if action not in {"read", "search"}:
+            continue
+        subject = _action_subject(payload)
+        if subject:
+            keys.append((action, subject))
+
+    warnings: list[WarningMessage] = []
+    for (action, subject), count in sorted(Counter(keys).items()):
+        if count > 1:
+            warnings.append(
+                WarningMessage(
+                    kind="repeat_failure",
+                    message=f"Recent {action} action repeated {subject!r} {count} times.",
+                )
+            )
+    return warnings
+
+
+def needs_missing_evidence_warning(request: SuggestRequest) -> bool:
+    """Detect edit-like requests that lack recent or remembered evidence."""
+    text = " ".join(
+        part
+        for part in (
+            request.task.user_request,
+            request.task.summary or "",
+            request.working_memory.active_task or "",
+        )
+        if part
+    ).lower()
+    if not any(term in text for term in _EDIT_TERMS):
+        return False
+    if request.working_memory.evidence_ids:
+        return False
+    return not any((event.evidence_id or event.summary.strip()) for event in request.recent_events)
+
+
+def _action_name(payload: dict[str, object]) -> str:
+    raw = " ".join(
+        str(payload.get(key) or "") for key in ("kind", "action", "tool", "type", "summary")
+    ).lower()
+    if "read" in raw or "open" in raw or "inspect" in raw:
+        return "read"
+    if "search" in raw or "rg" in raw or "grep" in raw:
+        return "search"
+    return ""
+
+
+def _action_subject(payload: dict[str, object]) -> str:
+    for key in ("target", "path", "file", "query", "command"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return str(payload.get("summary") or "").strip()

--- a/tests/test_ranking_fallback.py
+++ b/tests/test_ranking_fallback.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from photon_action_memory import SCHEMA_VERSION
+from photon_action_memory.api.schema import SuggestRequest
+from photon_action_memory.api.server import build_fallback_suggestions
+from photon_action_memory.ranking.guards import is_destructive_command
+
+
+def _request(
+    *,
+    user_request: str = "fix the failing test",
+    touched_files: list[str] | None = None,
+    recent_events: list[dict[str, object]] | None = None,
+    max_suggestions: int = 5,
+    max_evidence_chars: int = 4000,
+) -> SuggestRequest:
+    return SuggestRequest.model_validate(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "request_id": "req-ranking",
+            "agent": {"name": "codex"},
+            "repo": {"root": "/repo", "name": "example"},
+            "task": {"user_request": user_request, "mode": "act"},
+            "working_memory": {"touched_files": touched_files or []},
+            "recent_events": recent_events or [],
+            "budget": {
+                "max_suggestions": max_suggestions,
+                "max_evidence_chars": max_evidence_chars,
+            },
+        }
+    )
+
+
+def test_fallback_ranking_is_deterministic_for_same_input() -> None:
+    request = _request(
+        touched_files=["src/app.py", "tests/test_app.py"],
+        recent_events=[
+            {
+                "type": "tool_result",
+                "status": "error",
+                "summary": "pytest failed in tests/test_app.py:12",
+            },
+            {
+                "type": "tool_result",
+                "tool": "rg",
+                "summary": "searched for app setup",
+                "query": "setup",
+            },
+        ],
+    )
+
+    first = build_fallback_suggestions(request)
+    second = build_fallback_suggestions(request)
+
+    assert first.model_dump() == second.model_dump()
+
+
+def test_recent_error_file_path_is_prioritized_for_inspection() -> None:
+    response = build_fallback_suggestions(
+        _request(
+            touched_files=["src/ordinary.py"],
+            recent_events=[
+                {
+                    "type": "tool_result",
+                    "status": "failed",
+                    "summary": "Traceback in photon_action_memory/ranking/fallback.py:44",
+                }
+            ],
+        )
+    )
+
+    assert response.suggestions[0].kind == "inspect"
+    assert response.suggestions[0].target == "photon_action_memory/ranking/fallback.py"
+
+
+def test_fallback_respects_top_k_and_evidence_char_budget() -> None:
+    response = build_fallback_suggestions(
+        _request(
+            touched_files=["a.py", "b.py", "c.py"],
+            recent_events=[
+                {
+                    "type": "tool_result",
+                    "summary": "a.py " + ("x" * 20),
+                },
+                {
+                    "type": "tool_result",
+                    "summary": "b.py " + ("y" * 20),
+                },
+            ],
+            max_suggestions=1,
+            max_evidence_chars=12,
+        )
+    )
+
+    assert len(response.suggestions) == 1
+    assert sum(len(item.summary) for item in response.evidence) <= 12
+
+
+def test_repeated_read_and_search_actions_emit_warning() -> None:
+    response = build_fallback_suggestions(
+        _request(
+            recent_events=[
+                {
+                    "type": "tool_call",
+                    "tool": "read",
+                    "summary": "read src/app.py",
+                    "target": "src/app.py",
+                },
+                {
+                    "type": "tool_call",
+                    "tool": "read",
+                    "summary": "read src/app.py",
+                    "target": "src/app.py",
+                },
+                {
+                    "type": "tool_call",
+                    "tool": "rg",
+                    "summary": "search setup",
+                    "query": "setup",
+                },
+                {
+                    "type": "tool_call",
+                    "tool": "rg",
+                    "summary": "search setup",
+                    "query": "setup",
+                },
+            ],
+        )
+    )
+
+    warning_kinds = [warning.kind for warning in response.warnings]
+    assert warning_kinds.count("repeat_failure") == 2
+
+
+def test_edit_like_request_without_evidence_emits_missing_evidence_warning() -> None:
+    response = build_fallback_suggestions(
+        _request(user_request="edit src/app.py", recent_events=[])
+    )
+
+    assert "missing_evidence" in [warning.kind for warning in response.warnings]
+
+
+def test_destructive_shell_command_is_not_suggested() -> None:
+    response = build_fallback_suggestions(
+        _request(
+            user_request="fix build",
+            recent_events=[
+                {
+                    "type": "tool_result",
+                    "status": "failed",
+                    "summary": "build failed after a shell command",
+                    "command": "rm -rf /tmp/project",
+                }
+            ],
+        )
+    )
+
+    assert is_destructive_command("rm -rf /tmp/project")
+    assert all(suggestion.command != "rm -rf /tmp/project" for suggestion in response.suggestions)

--- a/workspace/v0.1.0/05_development_preparation_plan.md
+++ b/workspace/v0.1.0/05_development_preparation_plan.md
@@ -506,9 +506,9 @@ shadow-mode log schema:
 - [ ] [#7](https://github.com/Kewton/photon-action-memory/issues/7) MyCodeBranchDesk exporter 移植
 - [ ] [#8](https://github.com/Kewton/photon-action-memory/issues/8) dataset JSONL spec
 - [ ] [#8](https://github.com/Kewton/photon-action-memory/issues/8) deterministic split
-- [ ] [#6](https://github.com/Kewton/photon-action-memory/issues/6) candidate extractor
-- [ ] [#6](https://github.com/Kewton/photon-action-memory/issues/6) fallback ranker
-- [ ] [#6](https://github.com/Kewton/photon-action-memory/issues/6) repeated action / missing evidence warning
+- [x] [#6](https://github.com/Kewton/photon-action-memory/issues/6) candidate extractor
+- [x] [#6](https://github.com/Kewton/photon-action-memory/issues/6) fallback ranker
+- [x] [#6](https://github.com/Kewton/photon-action-memory/issues/6) repeated action / missing evidence warning
 
 ### Phase 5: Model and eval
 


### PR DESCRIPTION
Closes #6

## Summary
- Add deterministic fallback ranking for no-model suggestions.
- Rank recent error file targets first, enforce top-k and evidence budgets, emit repeat/missing-evidence warnings, and filter destructive commands.
- Include focused ranking and sidecar API coverage plus issue dev reports.

## Validation
- `python -m pytest tests/test_ranking_fallback.py tests/test_sidecar_api.py -q`
- `python -m pytest -q`
- `ruff format --check .`
- `ruff check .`
- `mypy photon_action_memory tests`
- `python -m build`
