### PR TITLE
#10 [P1][M6] Add Anvil shadow-mode contract fixtures

### DIFF
--- a/dev-reports/issue-10/design.md
+++ b/dev-reports/issue-10/design.md
@@ -1,0 +1,34 @@
+# Issue #10 Design: Anvil shadow-mode contract fixtures
+
+## Goal
+
+Fix a minimal, schema-validated integration contract that Anvil can use to call the sidecar in shadow mode and report what happened after the agent chooses its real next action.
+
+## Shape
+
+- Keep `SuggestRequest` / `SuggestResponse` as the request and response contract for `POST /v1/suggest`.
+- Add optional stable `id` fields to `Suggestion` so responses can be joined to later shadow evaluation records without breaking existing callers.
+- Add neutral evaluation DTOs for `POST /v1/evaluate` contract data:
+  - request id
+  - suggestion ids returned by sidecar
+  - actual next action taken by Anvil
+  - matched / ignored reason
+  - outcome
+  - latency in milliseconds
+  - sidecar status
+- Store Anvil-specific details in fixture metadata / extra fields rather than making the core schema Anvil-only.
+
+## Fixtures
+
+Add fixed JSON fixtures under `tests/fixtures/anvil_shadow_mode/`:
+
+- `suggest_request.json`: Anvil shadow-mode input with L2 working memory and recent events.
+- `suggest_response.json`: sidecar guidance with stable suggestion ids and evidence.
+- `event_request.json`: event-store compatible shadow evaluation event.
+- `evaluate_request.json`: adoption/ignored/outcome event tying the request and response to the actual next action.
+
+Tests load those files and validate them through Pydantic models, including round-trip checks and assertions for adoption / ignored / outcome tracking fields.
+
+## Scope boundaries
+
+`/v1/evaluate` remains an M2 stub in the server. This issue fixes the contract and fixtures Anvil can build against; persistence and metric computation stay with later M6 evaluation work.

--- a/dev-reports/issue-10/implementation-summary.md
+++ b/dev-reports/issue-10/implementation-summary.md
@@ -1,0 +1,24 @@
+# Issue #10 Implementation Summary
+
+## Changed
+
+- Added explicit shadow evaluation DTOs in `photon_action_memory/api/schema.py`:
+  - `ActualNextAction`
+  - `EvaluationRecord`
+  - `EvaluationRequest`
+  - `EvaluationResponse`
+  - `SidecarStatus`
+  - `ShadowOutcome`
+- Added optional `Suggestion.id` so sidecar responses can be joined to later shadow evaluation records.
+- Added fixed Anvil shadow-mode fixtures:
+  - `tests/fixtures/anvil_shadow_mode/suggest_request.json`
+  - `tests/fixtures/anvil_shadow_mode/suggest_response.json`
+  - `tests/fixtures/anvil_shadow_mode/event_request.json`
+  - `tests/fixtures/anvil_shadow_mode/evaluate_request.json`
+- Added schema tests that load and validate the fixtures through the Pydantic models.
+- Added `workspace/v0.1.0/anvil_shadow_mode_contract.md` as the handoff integration spec for the Anvil-side issue.
+- Updated v0.1.0 architecture and development-plan docs with the shadow evaluation contract and fixture locations.
+
+## Notes
+
+`/v1/evaluate` remains a stub. This issue fixes the schema and fixture contract that Anvil can implement against; ingestion and metrics computation remain later M6 work.

--- a/dev-reports/issue-10/verification.md
+++ b/dev-reports/issue-10/verification.md
@@ -1,0 +1,27 @@
+# Issue #10 Verification
+
+## Commands
+
+- `python -m pytest tests/test_schema.py -q`
+  - Pass: `10 passed`
+- `python -m ruff format --check .`
+  - Pass: `34 files already formatted`
+- `python -m ruff check .`
+  - Pass: `All checks passed!`
+- `python -m mypy photon_action_memory tests`
+  - Pass: `Success: no issues found in 32 source files`
+- `python -m pytest -q`
+  - Pass: `50 passed`
+- `python -m build`
+  - Pass: built sdist and wheel after allowing network access for isolated build dependency installation.
+
+## Fixture Coverage
+
+- `SuggestRequest` validates the Anvil shadow-mode request fixture.
+- `SuggestResponse` validates stable suggestion ids and response metadata.
+- `EventRequest` validates a `shadow_evaluation` event-store payload.
+- `EvaluationRequest` validates adoption and ignored records with request id, suggestion ids, actual next action, matched, ignored reason, outcome, latency, and sidecar status.
+
+## Notes
+
+An initial sandboxed `python -m build` attempt failed because the isolated build environment could not resolve/download `hatchling>=1.25`. The rerun with network approval passed.

--- a/photon_action_memory/api/schema.py
+++ b/photon_action_memory/api/schema.py
@@ -34,6 +34,8 @@ WarningKind = Literal[
     "sidecar_unavailable",
     "model_unavailable",
 ]
+SidecarStatus = Literal["ok", "timeout", "error", "unavailable", "not_called"]
+ShadowOutcome = Literal["success", "failure", "partial", "unknown"]
 
 
 class SidecarModel(BaseModel):
@@ -115,6 +117,7 @@ class SuggestRequest(SidecarModel):
 class Suggestion(SidecarModel):
     """Action guidance returned by the sidecar."""
 
+    id: str | None = None
     kind: ActionKind
     target: str | None = None
     command: str | None = None
@@ -193,6 +196,45 @@ class EventResponse(SidecarModel):
     stored: bool
 
 
+class ActualNextAction(SidecarModel):
+    """Action Anvil actually took after receiving shadow-mode suggestions."""
+
+    kind: ActionKind | str
+    target: str | None = None
+    command: str | None = None
+    query: str | None = None
+    summary: str
+
+
+class EvaluationRecord(SidecarModel):
+    """One shadow-mode evaluation record for `POST /v1/evaluate`."""
+
+    request_id: str
+    suggestion_ids: list[str] = Field(default_factory=list)
+    actual_next_action: ActualNextAction
+    matched: bool
+    ignored_reason: str | None = None
+    outcome: ShadowOutcome | str = "unknown"
+    latency_ms: float = Field(ge=0)
+    sidecar_status: SidecarStatus | str
+
+
+class EvaluationRequest(SidecarModel):
+    """Request body for recording shadow-mode suggestion outcomes."""
+
+    schema_version: SchemaVersion
+    request_id: str
+    session_id: str | None = None
+    records: list[EvaluationRecord]
+
+
+class EvaluationResponse(SidecarModel):
+    """Response body for accepted shadow-mode evaluation records."""
+
+    status: str
+    accepted: int = Field(ge=0)
+
+
 class HealthResponse(SidecarModel):
     """Response body for health checks."""
 
@@ -208,12 +250,16 @@ WarningMessage = Warning
 __all__ = [
     "SCHEMA_VERSION",
     "ActionKind",
+    "ActualNextAction",
     "AgentInfo",
     "Artifact",
     "Budget",
     "DEFAULT_SCHEMA_VERSION",
     "EventRequest",
     "EventResponse",
+    "EvaluationRecord",
+    "EvaluationRequest",
+    "EvaluationResponse",
     "Evidence",
     "EvidenceItem",
     "FALLBACK_MODEL_VERSION",
@@ -223,6 +269,8 @@ __all__ = [
     "SchemaVersion",
     "SidecarEvent",
     "SidecarModel",
+    "SidecarStatus",
+    "ShadowOutcome",
     "SuggestBudget",
     "SuggestRequest",
     "SuggestResponse",

--- a/tests/fixtures/anvil_shadow_mode/evaluate_request.json
+++ b/tests/fixtures/anvil_shadow_mode/evaluate_request.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "action-memory.v1",
+  "request_id": "anvil-shadow-eval-0001",
+  "session_id": "anvil-session-20260430",
+  "records": [
+    {
+      "request_id": "anvil-shadow-req-0001",
+      "suggestion_ids": [
+        "sug-read-turn-loop",
+        "sug-read-session-store",
+        "sug-search-shadow-eval"
+      ],
+      "actual_next_action": {
+        "kind": "read",
+        "target": "src/agent/loop_run/turn.rs",
+        "summary": "Read the Anvil actor loop before adding the sidecar call."
+      },
+      "matched": true,
+      "ignored_reason": null,
+      "outcome": "success",
+      "latency_ms": 184.2,
+      "sidecar_status": "ok"
+    },
+    {
+      "request_id": "anvil-shadow-req-0002",
+      "suggestion_ids": [
+        "sug-search-shadow-eval"
+      ],
+      "actual_next_action": {
+        "kind": "edit",
+        "target": "src/agent/loop_run/turn.rs",
+        "summary": "Edited the local sidecar boundary after existing plan state already had enough evidence."
+      },
+      "matched": false,
+      "ignored_reason": "existing_plan_had_higher_priority",
+      "outcome": "partial",
+      "latency_ms": 92.7,
+      "sidecar_status": "ok"
+    }
+  ]
+}

--- a/tests/fixtures/anvil_shadow_mode/event_request.json
+++ b/tests/fixtures/anvil_shadow_mode/event_request.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "action-memory.v1",
+  "request_id": "anvil-shadow-events-0001",
+  "events": [
+    {
+      "schema_version": "action-memory.v1",
+      "event_id": "evt-anvil-shadow-0001",
+      "session_id": "anvil-session-20260430",
+      "turn_id": "turn-20260430-001",
+      "repo_id": "anvil",
+      "timestamp": "2026-04-30T12:00:00Z",
+      "event_type": "shadow_evaluation",
+      "status": "success",
+      "summary": "Sidecar suggestion matched the actual next action in shadow mode.",
+      "artifacts": [
+        {
+          "kind": "shadow_evaluation",
+          "value": "anvil-shadow-req-0001",
+          "metadata": {
+            "suggestion_ids": [
+              "sug-read-turn-loop",
+              "sug-read-session-store",
+              "sug-search-shadow-eval"
+            ],
+            "actual_next_action": {
+              "kind": "read",
+              "target": "src/agent/loop_run/turn.rs"
+            },
+            "matched": true,
+            "ignored_reason": null,
+            "outcome": "success",
+            "latency_ms": 184.2,
+            "sidecar_status": "ok"
+          }
+        }
+      ],
+      "redaction_status": "sanitized"
+    }
+  ]
+}

--- a/tests/fixtures/anvil_shadow_mode/suggest_request.json
+++ b/tests/fixtures/anvil_shadow_mode/suggest_request.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "action-memory.v1",
+  "request_id": "anvil-shadow-req-0001",
+  "agent": {
+    "name": "anvil",
+    "version": "0.1.x",
+    "shadow_mode": true
+  },
+  "repo": {
+    "root": "[REPO_ROOT]",
+    "name": "Anvil",
+    "branch": "feature/action-memory-shadow",
+    "commit": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b"
+  },
+  "task": {
+    "user_request": "Wire sidecar suggestions into the actor loop in shadow mode.",
+    "mode": "act",
+    "summary": "Call PHOTON sidecar before choosing the next Anvil action."
+  },
+  "working_memory": {
+    "active_task": "Add shadow-mode sidecar call around the Anvil actor loop",
+    "constraints": [
+      "Do not let sidecar failures block the agent loop",
+      "Log whether the actual next action matched a suggestion"
+    ],
+    "touched_files": [
+      "src/agent/loop_run/turn.rs",
+      "src/session/store.rs"
+    ],
+    "unresolved_errors": [],
+    "active_precautions": [
+      "Keep sidecar calls fail-open",
+      "Do not store raw secrets"
+    ],
+    "plan": [
+      "Read actor loop",
+      "Add sidecar client boundary",
+      "Record shadow evaluation"
+    ],
+    "completed_steps": [
+      "Read actor loop"
+    ],
+    "pending_steps": [
+      "Record shadow evaluation"
+    ],
+    "evidence_ids": [
+      "evt-actor-loop-read"
+    ],
+    "anvil_working_memory": {
+      "turn_id": "turn-20260430-001",
+      "actor_loop_phase": "before_next_action",
+      "active_files": [
+        "src/agent/loop_run/turn.rs"
+      ]
+    }
+  },
+  "recent_events": [
+    {
+      "type": "file_read",
+      "tool": "read",
+      "status": "success",
+      "summary": "Read src/agent/loop_run/turn.rs and found the next-action decision point.",
+      "event_id": "evt-actor-loop-read",
+      "path": "src/agent/loop_run/turn.rs"
+    }
+  ],
+  "budget": {
+    "max_suggestions": 3,
+    "max_evidence_chars": 1200
+  },
+  "shadow_mode": true
+}

--- a/tests/fixtures/anvil_shadow_mode/suggest_response.json
+++ b/tests/fixtures/anvil_shadow_mode/suggest_response.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": "action-memory.v1",
+  "request_id": "anvil-shadow-req-0001",
+  "model_version": "photon-action-memory-v0.1.0-fallback",
+  "suggestions": [
+    {
+      "id": "sug-read-turn-loop",
+      "kind": "read",
+      "target": "src/agent/loop_run/turn.rs",
+      "confidence": 0.72,
+      "reason": "The actor loop contains the next-action decision point for shadow-mode suggestion calls.",
+      "evidence_ids": [
+        "evt_001"
+      ],
+      "risk": "low"
+    },
+    {
+      "id": "sug-read-session-store",
+      "kind": "read",
+      "target": "src/session/store.rs",
+      "confidence": 0.58,
+      "reason": "Working memory serialization is needed to populate the sidecar request.",
+      "evidence_ids": [
+        "evt_001"
+      ],
+      "risk": "low"
+    },
+    {
+      "id": "sug-search-shadow-eval",
+      "kind": "search",
+      "query": "shadow evaluation next action matched ignored reason outcome",
+      "confidence": 0.41,
+      "reason": "Existing evaluation terminology should be reused for adoption and ignored tracking.",
+      "evidence_ids": [],
+      "risk": "low"
+    }
+  ],
+  "evidence": [
+    {
+      "id": "evt_001",
+      "kind": "file_read",
+      "summary": "Read src/agent/loop_run/turn.rs and found the next-action decision point.",
+      "source": "request"
+    }
+  ],
+  "warnings": [
+    {
+      "kind": "model_unavailable",
+      "message": "PHOTON model scoring is unavailable; deterministic fallback suggestions were used."
+    }
+  ],
+  "sidecar_status": "ok",
+  "latency_ms": 184.2
+}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from pydantic import ValidationError
 
 from photon_action_memory import SCHEMA_VERSION
 from photon_action_memory.api.schema import (
+    EvaluationRequest,
+    EventRequest,
     SidecarEvent,
     SuggestRequest,
     SuggestResponse,
 )
+
+FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "anvil_shadow_mode"
 
 
 def test_minimal_suggest_request_round_trip() -> None:
@@ -168,6 +174,48 @@ def test_anvil_working_memory_fixture_round_trip() -> None:
     ]
     assert round_tripped.model_dump()["working_memory"]["anvil_working_memory"]["mode"] == "act"
     assert round_tripped.recent_events[0].type == "tool_result"
+
+
+def test_anvil_shadow_mode_contract_fixtures_validate() -> None:
+    request = SuggestRequest.model_validate_json(
+        (FIXTURE_ROOT / "suggest_request.json").read_text()
+    )
+    response = SuggestResponse.model_validate_json(
+        (FIXTURE_ROOT / "suggest_response.json").read_text()
+    )
+    event = EventRequest.model_validate_json((FIXTURE_ROOT / "event_request.json").read_text())
+    evaluation = EvaluationRequest.model_validate_json(
+        (FIXTURE_ROOT / "evaluate_request.json").read_text()
+    )
+
+    response_suggestion_ids = [item.id for item in response.suggestions if item.id]
+    adopted_record, ignored_record = evaluation.records
+    event_metadata = event.events[0].artifacts[0].metadata
+
+    assert request.request_id == "anvil-shadow-req-0001"
+    assert request.model_dump()["shadow_mode"] is True
+    assert response.request_id == request.request_id
+    assert response_suggestion_ids == [
+        "sug-read-turn-loop",
+        "sug-read-session-store",
+        "sug-search-shadow-eval",
+    ]
+    assert adopted_record.request_id == request.request_id
+    assert adopted_record.suggestion_ids == response_suggestion_ids
+    assert adopted_record.actual_next_action.kind == "read"
+    assert adopted_record.actual_next_action.target == "src/agent/loop_run/turn.rs"
+    assert adopted_record.matched is True
+    assert adopted_record.ignored_reason is None
+    assert adopted_record.outcome == "success"
+    assert adopted_record.latency_ms == 184.2
+    assert adopted_record.sidecar_status == "ok"
+    assert event.events[0].event_type == "shadow_evaluation"
+    assert event_metadata["suggestion_ids"] == response_suggestion_ids
+    assert event_metadata["matched"] is True
+    assert event_metadata["sidecar_status"] == "ok"
+    assert ignored_record.matched is False
+    assert ignored_record.ignored_reason == "existing_plan_had_higher_priority"
+    assert ignored_record.outcome == "partial"
 
 
 def test_event_payload_round_trip_accepts_type_alias() -> None:

--- a/workspace/v0.1.0/01_spec_requirements_architecture.md
+++ b/workspace/v0.1.0/01_spec_requirements_architecture.md
@@ -171,6 +171,52 @@ contract のみ固定する。実体は M6 の shadow eval 実装で追加する
 }
 ```
 
+### 5.4 Shadow Evaluation Contract
+
+Anvil は shadow-mode では suggestion を受け取るが、最終判断は agent loop 側で行う。
+`POST /v1/evaluate` は、その判断結果を後から評価できるように以下を記録する。
+
+```json
+{
+  "schema_version": "action-memory.v1",
+  "request_id": "anvil-shadow-eval-0001",
+  "session_id": "anvil-session-20260430",
+  "records": [
+    {
+      "request_id": "anvil-shadow-req-0001",
+      "suggestion_ids": [
+        "sug-read-turn-loop",
+        "sug-read-session-store"
+      ],
+      "actual_next_action": {
+        "kind": "read",
+        "target": "src/agent/loop_run/turn.rs",
+        "summary": "Read the actor loop before editing"
+      },
+      "matched": true,
+      "ignored_reason": null,
+      "outcome": "success",
+      "latency_ms": 184.2,
+      "sidecar_status": "ok"
+    }
+  ]
+}
+```
+
+contract fixture:
+
+- `tests/fixtures/anvil_shadow_mode/suggest_request.json`
+- `tests/fixtures/anvil_shadow_mode/suggest_response.json`
+- `tests/fixtures/anvil_shadow_mode/event_request.json`
+- `tests/fixtures/anvil_shadow_mode/evaluate_request.json`
+
+integration spec:
+
+- `workspace/v0.1.0/anvil_shadow_mode_contract.md`
+
+これにより request id、suggestion ids、actual next action、matched、
+ignored reason、outcome、latency、sidecar status を固定 schema で追跡する。
+
 ## 6. 非機能要件
 
 | 項目 | 要件 |

--- a/workspace/v0.1.0/05_development_preparation_plan.md
+++ b/workspace/v0.1.0/05_development_preparation_plan.md
@@ -437,6 +437,17 @@ score_evidence(state, evidence) -> list[ScoredEvidence]
 - Anvil shadow-mode request / response fixture
 - shadow evaluation event schema
 
+contract fixtures:
+
+- `tests/fixtures/anvil_shadow_mode/suggest_request.json`
+- `tests/fixtures/anvil_shadow_mode/suggest_response.json`
+- `tests/fixtures/anvil_shadow_mode/event_request.json`
+- `tests/fixtures/anvil_shadow_mode/evaluate_request.json`
+
+integration spec:
+
+- `workspace/v0.1.0/anvil_shadow_mode_contract.md`
+
 metrics:
 
 - next action top-k accuracy

--- a/workspace/v0.1.0/anvil_shadow_mode_contract.md
+++ b/workspace/v0.1.0/anvil_shadow_mode_contract.md
@@ -1,0 +1,41 @@
+# Anvil Shadow-Mode Sidecar Contract
+
+## Purpose
+
+This contract lets Anvil call PHOTON Action Memory in shadow mode without
+delegating final control to the sidecar. The sidecar returns suggestions; Anvil
+records the actual next action and whether that action matched the suggestions.
+
+Canonical fixtures:
+
+- `tests/fixtures/anvil_shadow_mode/suggest_request.json`
+- `tests/fixtures/anvil_shadow_mode/suggest_response.json`
+- `tests/fixtures/anvil_shadow_mode/event_request.json`
+- `tests/fixtures/anvil_shadow_mode/evaluate_request.json`
+
+## Flow
+
+1. Before choosing the next actor-loop action, Anvil sends `POST /v1/suggest`.
+2. Anvil executes its normal next action regardless of the sidecar result.
+3. Anvil records a `shadow_evaluation` event through `POST /v1/events`.
+4. Anvil batches shadow outcome records through `POST /v1/evaluate`.
+
+`/v1/evaluate` can remain a stub while Anvil integration is developed. The
+fixture fixes the schema Anvil should produce once evaluation ingestion is
+enabled.
+
+## Required Fields
+
+Each shadow evaluation record must include:
+
+- `request_id`: the original suggest request id.
+- `suggestion_ids`: stable ids from the sidecar response.
+- `actual_next_action`: the action Anvil actually took.
+- `matched`: whether the actual action adopted or matched a suggestion.
+- `ignored_reason`: nullable reason when suggestions were ignored.
+- `outcome`: `success`, `failure`, `partial`, or `unknown`.
+- `latency_ms`: sidecar call latency measured by the caller.
+- `sidecar_status`: `ok`, `timeout`, `error`, `unavailable`, or `not_called`.
+
+Anvil-specific working-memory details should stay in metadata / extra fields so
+the core schema remains usable by other agents.


### PR DESCRIPTION
Closes #10

## Summary
- Add Anvil shadow-mode request/response/event/evaluation contract fixtures.
- Validate adoption and ignored evaluation payloads with request ids, suggestion ids, actual action, outcome, latency, and sidecar status.
- Include integration documentation and issue dev reports.

## Validation
- `python -m pytest tests/test_schema.py -q`
- `python -m pytest -q`
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m mypy photon_action_memory tests`
- `python -m build`
