### PR TITLE
#11 Add PHOTON MLX adapter

### DIFF
--- a/dev-reports/issue-11/design.md
+++ b/dev-reports/issue-11/design.md
@@ -1,0 +1,28 @@
+# Issue 11 Design: Optional PHOTON MLX Adapter
+
+## Goal
+
+Add an optional PHOTON / MLX scoring boundary without making MLX a normal import-time
+dependency. The default sidecar path must continue to work in environments that do not
+install the `mlx` extra.
+
+## Design
+
+- Keep `photon_action_memory.models.photon_adapter` importable without MLX by lazy-importing
+  `mlx.core` only when a configured checkpoint is used.
+- Add model-independent scoring DTOs in `models/state.py` so later smoke and integration tests
+  can exercise `score_actions`, `score_files`, and `score_evidence` without depending on the
+  API schema internals.
+- Add a small runtime checkpoint manifest loader in `models/checkpoint.py`:
+  - missing paths raise a typed unavailable error;
+  - malformed JSON or schema mismatches raise a typed invalid error;
+  - unknown state keys are dropped and returned as warnings.
+- Route `/v1/suggest` through the adapter only when `PHOTON_ACTION_MEMORY_CHECKPOINT` is set and
+  a valid MLX runtime/checkpoint is available. Any adapter initialization or scoring failure
+  returns the existing deterministic fallback ranking and fallback model version.
+
+## Scope Notes
+
+This issue creates the optional scoring interface and fail-closed boundary. It does not implement
+real PHOTON model inference weights; the adapter produces stable heuristic scores over the same
+candidate surface so a later macOS MLX smoke issue can validate the runtime path.

--- a/dev-reports/issue-11/implementation-summary.md
+++ b/dev-reports/issue-11/implementation-summary.md
@@ -1,0 +1,30 @@
+# Issue 11 Implementation Summary
+
+## Changed
+
+- Added `models/state.py` scoring DTOs:
+  - `PhotonScoringState`
+  - `ActionCandidate`
+  - `ScoredCandidate`
+  - `ScoredFile`
+  - `ScoredEvidence`
+- Added runtime checkpoint manifest validation in `models/checkpoint.py`:
+  - validates `photon-action-memory.mlx.v1` manifests;
+  - reports missing and invalid checkpoints through typed exceptions;
+  - drops unknown state keys by default and rejects them in strict mode.
+- Replaced the adapter placeholder with `PhotonMLXAdapter`:
+  - lazy-imports `mlx.core` only when a checkpoint path is configured;
+  - exposes `score_actions`, `score_files`, and `score_evidence`;
+  - supports tiny smoke scoring with manifest weights.
+- Updated `/v1/suggest` to:
+  - build the existing deterministic fallback candidate surface first;
+  - optionally rerank it through the MLX adapter when `PHOTON_ACTION_MEMORY_CHECKPOINT` is set;
+  - fall back to deterministic ranking when checkpoint or adapter setup fails.
+- Updated the v0.1.0 preparation checklist for Issue #11 adapter/interface completion.
+- Added focused adapter tests covering default import behavior, missing MLX simulation, checkpoint
+  validation, invalid-checkpoint fallback, direct fake-MLX scoring, and sidecar fake-MLX scoring.
+
+## Notes
+
+The adapter does not introduce a real PHOTON model architecture. It creates the runtime-safe
+boundary and smoke-testable scoring interface needed for the follow-up macOS MLX smoke issue.

--- a/dev-reports/issue-11/verification.md
+++ b/dev-reports/issue-11/verification.md
@@ -1,0 +1,20 @@
+# Issue 11 Verification
+
+## Commands
+
+- `python -m pytest tests/test_photon_adapter.py tests/test_sidecar_api.py tests/test_import.py -q`
+  - Passed: `16 passed in 0.15s`
+- `python -m ruff check photon_action_memory tests/test_photon_adapter.py`
+  - Passed: `All checks passed!`
+- `python -m mypy photon_action_memory`
+  - Passed: `Success: no issues found in 25 source files`
+- `python -m pytest -q`
+  - Passed: `75 passed in 0.69s`
+
+## Coverage Notes
+
+- Default package import and default tests do not import MLX.
+- Missing MLX is simulated through the adapter import seam to avoid loading the host MLX runtime.
+- Invalid checkpoint configuration falls back to deterministic ranking and emits `model_unavailable`.
+- Fake-MLX smoke scoring validates `score_actions`, `score_files`, `score_evidence`, and the
+  sidecar reranking path.

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -20,7 +20,7 @@ from photon_action_memory.api.schema import (
     SuggestResponse,
 )
 from photon_action_memory.memory.store import SQLiteEventStore
-from photon_action_memory.models.photon_adapter import is_model_available
+from photon_action_memory.models.photon_adapter import score_suggestions_with_optional_adapter
 from photon_action_memory.ranking.fallback import build_ranked_suggestions
 from photon_action_memory.ranking.guards import fallback_warnings
 
@@ -75,12 +75,23 @@ def create_app(store: SQLiteEventStore | None = None) -> FastAPI:
 def build_fallback_suggestions(request: SuggestRequest) -> SuggestResponse:
     max_suggestions = max(0, request.budget.max_suggestions)
     evidence = _evidence_from_recent_events(request)
-    suggestions = build_ranked_suggestions(request, evidence=evidence, limit=max_suggestions)
-    warnings = fallback_warnings(request)
-    if not is_model_available():
+    fallback_suggestions = build_ranked_suggestions(
+        request,
+        evidence=evidence,
+        limit=max_suggestions,
+    )
+    adapter_result = score_suggestions_with_optional_adapter(
+        request,
+        evidence=evidence,
+        suggestions=fallback_suggestions,
+    )
+    if adapter_result is None:
+        suggestions = fallback_suggestions
         model_version = FALLBACK_MODEL_VERSION
+        warnings = fallback_warnings(request)
     else:
-        model_version = "photon-action-memory-v0.1.0"
+        suggestions, model_version = adapter_result
+        warnings = []
 
     return SuggestResponse(
         request_id=request.request_id,

--- a/photon_action_memory/models/checkpoint.py
+++ b/photon_action_memory/models/checkpoint.py
@@ -88,10 +88,7 @@ def _clean_state(raw_state: dict[str, Any], *, strict: bool) -> tuple[dict[str, 
         joined = ", ".join(unknown_keys)
         raise CheckpointInvalid(f"checkpoint state contains unknown keys: {joined}")
 
-    warnings = [
-        f"dropped unknown checkpoint state key: {key}"
-        for key in unknown_keys
-    ]
+    warnings = [f"dropped unknown checkpoint state key: {key}" for key in unknown_keys]
     return (
         {key: value for key, value in raw_state.items() if key in ALLOWED_STATE_KEYS},
         warnings,

--- a/photon_action_memory/models/checkpoint.py
+++ b/photon_action_memory/models/checkpoint.py
@@ -1,3 +1,98 @@
-"""Runtime checkpoint I/O placeholder."""
+"""Runtime checkpoint manifest I/O for optional PHOTON adapters."""
 
 from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+CHECKPOINT_FORMAT = "photon-action-memory.mlx.v1"
+CHECKPOINT_MANIFEST = "manifest.json"
+ALLOWED_STATE_KEYS = frozenset(
+    {
+        "action_weights",
+        "bias",
+        "evidence_weights",
+        "file_weights",
+    }
+)
+
+
+class CheckpointError(RuntimeError):
+    """Base class for checkpoint loading failures."""
+
+
+class CheckpointUnavailable(CheckpointError):
+    """Raised when a checkpoint path is absent or missing."""
+
+
+class CheckpointInvalid(CheckpointError):
+    """Raised when a checkpoint manifest cannot be used."""
+
+
+@dataclass(frozen=True)
+class PhotonCheckpoint:
+    """Validated checkpoint manifest for runtime scoring."""
+
+    path: Path
+    model_version: str
+    state: dict[str, object]
+    warnings: tuple[str, ...] = ()
+
+
+def load_checkpoint_manifest(path: str | Path, *, strict: bool = False) -> PhotonCheckpoint:
+    """Load and validate a small PHOTON runtime checkpoint manifest."""
+    manifest_path = _manifest_path(Path(path))
+    if not manifest_path.exists():
+        raise CheckpointUnavailable(f"checkpoint manifest not found: {manifest_path}")
+
+    try:
+        raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise CheckpointUnavailable(f"checkpoint manifest cannot be read: {manifest_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise CheckpointInvalid(f"checkpoint manifest is not valid JSON: {manifest_path}") from exc
+
+    if not isinstance(raw, dict):
+        raise CheckpointInvalid("checkpoint manifest must be a JSON object")
+    if raw.get("format") != CHECKPOINT_FORMAT:
+        raise CheckpointInvalid(f"checkpoint manifest format must be {CHECKPOINT_FORMAT!r}")
+
+    model_version = raw.get("model_version")
+    if not isinstance(model_version, str) or not model_version.strip():
+        raise CheckpointInvalid("checkpoint manifest requires a non-empty model_version")
+
+    state = raw.get("state", {})
+    if not isinstance(state, dict):
+        raise CheckpointInvalid("checkpoint state must be an object")
+
+    clean_state, warnings = _clean_state(state, strict=strict)
+    return PhotonCheckpoint(
+        path=manifest_path,
+        model_version=model_version.strip(),
+        state=clean_state,
+        warnings=tuple(warnings),
+    )
+
+
+def _manifest_path(path: Path) -> Path:
+    if path.is_dir():
+        return path / CHECKPOINT_MANIFEST
+    return path
+
+
+def _clean_state(raw_state: dict[str, Any], *, strict: bool) -> tuple[dict[str, object], list[str]]:
+    unknown_keys = sorted(set(raw_state) - ALLOWED_STATE_KEYS)
+    if unknown_keys and strict:
+        joined = ", ".join(unknown_keys)
+        raise CheckpointInvalid(f"checkpoint state contains unknown keys: {joined}")
+
+    warnings = [
+        f"dropped unknown checkpoint state key: {key}"
+        for key in unknown_keys
+    ]
+    return (
+        {key: value for key, value in raw_state.items() if key in ALLOWED_STATE_KEYS},
+        warnings,
+    )

--- a/photon_action_memory/models/photon_adapter.py
+++ b/photon_action_memory/models/photon_adapter.py
@@ -1,8 +1,236 @@
-"""Optional PHOTON/MLX scoring adapter placeholder."""
+"""Optional PHOTON/MLX scoring adapter.
+
+This module must remain importable without MLX installed. MLX is imported only
+when a checkpoint is configured and the optional adapter is constructed.
+"""
 
 from __future__ import annotations
 
+import importlib
+import math
+import os
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from types import ModuleType
+from typing import Any
 
-def is_model_available() -> bool:
-    """Return False until the optional PHOTON adapter is implemented."""
-    return False
+from photon_action_memory.api.schema import EvidenceItem, Suggestion, SuggestRequest
+from photon_action_memory.models.checkpoint import (
+    CheckpointError,
+    PhotonCheckpoint,
+    load_checkpoint_manifest,
+)
+from photon_action_memory.models.state import (
+    ActionCandidate,
+    PhotonScoringState,
+    ScoredCandidate,
+    ScoredEvidence,
+    ScoredFile,
+)
+
+CHECKPOINT_ENV = "PHOTON_ACTION_MEMORY_CHECKPOINT"
+PHOTON_MODEL_VERSION = "photon-action-memory-v0.1.0-mlx"
+
+
+class PhotonAdapterError(RuntimeError):
+    """Base class for optional PHOTON adapter failures."""
+
+
+class MlxUnavailable(PhotonAdapterError):
+    """Raised when the optional MLX dependency is not installed."""
+
+
+class PhotonScoringUnavailable(PhotonAdapterError):
+    """Raised when model scoring cannot safely continue."""
+
+
+class PhotonMLXAdapter:
+    """Tiny optional MLX-backed scorer used to validate the runtime boundary."""
+
+    def __init__(self, checkpoint: PhotonCheckpoint, mlx_core: ModuleType | Any) -> None:
+        self.checkpoint = checkpoint
+        self._mx = mlx_core
+
+    @classmethod
+    def from_checkpoint(
+        cls,
+        path: str | Path,
+        *,
+        strict: bool = False,
+        import_module: Callable[[str], ModuleType | Any] | None = None,
+    ) -> PhotonMLXAdapter:
+        """Build an adapter after validating checkpoint and importing MLX lazily."""
+        checkpoint = load_checkpoint_manifest(path, strict=strict)
+        return cls(checkpoint=checkpoint, mlx_core=_import_mlx_core(import_module))
+
+    def score_actions(
+        self,
+        state: PhotonScoringState,
+        candidates: Sequence[ActionCandidate],
+    ) -> list[ScoredCandidate]:
+        """Score action candidates in input order."""
+        return [
+            ScoredCandidate(
+                candidate=candidate,
+                score=self._score(candidate.kind, candidate.subject, state),
+                reason=f"PHOTON MLX adapter scored {candidate.kind!r}.",
+            )
+            for candidate in candidates
+        ]
+
+    def score_files(self, state: PhotonScoringState, files: Sequence[str]) -> list[ScoredFile]:
+        """Score file candidates for the later MLX smoke workflow."""
+        return [
+            ScoredFile(
+                path=path,
+                score=self._score("file", path, state),
+                reason="PHOTON MLX adapter scored a file candidate.",
+            )
+            for path in files
+        ]
+
+    def score_evidence(
+        self,
+        state: PhotonScoringState,
+        evidence: Sequence[EvidenceItem],
+    ) -> list[ScoredEvidence]:
+        """Score evidence candidates for the later MLX smoke workflow."""
+        return [
+            ScoredEvidence(
+                evidence_id=item.id,
+                score=self._score("evidence", item.id, state),
+                reason="PHOTON MLX adapter scored an evidence item.",
+            )
+            for item in evidence
+        ]
+
+    def _score(self, kind: str, subject: str, state: PhotonScoringState) -> float:
+        base = _state_float(self.checkpoint.state.get("bias"), default=0.5)
+        score = base
+        score += _weight_for(self.checkpoint.state.get("action_weights"), kind)
+        score += _weight_for(self.checkpoint.state.get("file_weights"), subject)
+        score += _weight_for(self.checkpoint.state.get("evidence_weights"), subject)
+        if subject and subject in state.task_text:
+            score += 0.05
+
+        try:
+            value = self._mx.array([_clamp(score)], dtype=getattr(self._mx, "float32", None))
+        except Exception as exc:
+            raise PhotonScoringUnavailable("MLX scoring failed") from exc
+        return _array_scalar(value)
+
+
+def configured_checkpoint_path(environ: os._Environ[str] | None = None) -> Path | None:
+    """Return the configured adapter checkpoint path, if any."""
+    raw = (environ or os.environ).get(CHECKPOINT_ENV, "").strip()
+    if not raw:
+        return None
+    return Path(raw)
+
+
+def is_model_available(
+    checkpoint_path: str | Path | None = None,
+    *,
+    import_module: Callable[[str], ModuleType | Any] | None = None,
+) -> bool:
+    """Return true only when the optional MLX adapter can be constructed."""
+    path = Path(checkpoint_path) if checkpoint_path is not None else configured_checkpoint_path()
+    if path is None:
+        return False
+    try:
+        PhotonMLXAdapter.from_checkpoint(path, import_module=import_module)
+    except (CheckpointError, PhotonAdapterError):
+        return False
+    return True
+
+
+def score_suggestions_with_optional_adapter(
+    request: SuggestRequest,
+    *,
+    evidence: Sequence[EvidenceItem],
+    suggestions: Sequence[Suggestion],
+) -> tuple[list[Suggestion], str] | None:
+    """Score fallback-generated suggestions with the optional adapter when configured."""
+    checkpoint_path = configured_checkpoint_path()
+    if checkpoint_path is None or not suggestions:
+        return None
+
+    try:
+        adapter = PhotonMLXAdapter.from_checkpoint(checkpoint_path)
+        state = PhotonScoringState.from_sidecar_request(request, evidence=evidence)
+        action_candidates = [_candidate_from_suggestion(suggestion) for suggestion in suggestions]
+        scored = adapter.score_actions(state, action_candidates)
+    except (CheckpointError, PhotonAdapterError):
+        return None
+
+    score_by_index = {index: item.score for index, item in enumerate(scored)}
+    ordered = sorted(
+        enumerate(suggestions),
+        key=lambda item: (-score_by_index[item[0]], item[0]),
+    )
+    return (
+        [
+            suggestion.model_copy(
+                update={
+                    "confidence": max(suggestion.confidence, score_by_index[index]),
+                    "reason": f"{suggestion.reason} PHOTON MLX score: {score_by_index[index]:.3f}.",
+                }
+            )
+            for index, suggestion in ordered
+        ],
+        adapter.checkpoint.model_version or PHOTON_MODEL_VERSION,
+    )
+
+
+def _import_mlx_core(
+    import_module: Callable[[str], ModuleType | Any] | None = None,
+) -> ModuleType | Any:
+    importer = import_module or importlib.import_module
+    try:
+        return importer("mlx.core")
+    except ModuleNotFoundError as exc:
+        if exc.name in {"mlx", "mlx.core"}:
+            raise MlxUnavailable("optional dependency 'mlx' is not installed") from exc
+        raise
+
+
+def _candidate_from_suggestion(suggestion: Suggestion) -> ActionCandidate:
+    return ActionCandidate(
+        kind=suggestion.kind,
+        target=suggestion.target,
+        command=suggestion.command,
+        query=suggestion.query,
+        evidence_ids=tuple(suggestion.evidence_ids),
+    )
+
+
+def _weight_for(raw_weights: object, key: str) -> float:
+    if not isinstance(raw_weights, dict):
+        return 0.0
+    return _state_float(raw_weights.get(key), default=0.0)
+
+
+def _state_float(value: object, *, default: float) -> float:
+    if isinstance(value, int | float):
+        as_float = float(value)
+        if math.isfinite(as_float):
+            return as_float
+    return default
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def _array_scalar(value: object) -> float:
+    if hasattr(value, "item"):
+        raw_item = value.item()
+        if isinstance(raw_item, int | float | str):
+            return _clamp(float(raw_item))
+    if not isinstance(value, str) and isinstance(value, Sequence) and value:
+        first = value[0]
+        if isinstance(first, int | float | str):
+            return _clamp(float(first))
+    if isinstance(value, int | float | str):
+        return _clamp(float(value))
+    raise PhotonScoringUnavailable("MLX scoring did not return a scalar value")

--- a/photon_action_memory/models/state.py
+++ b/photon_action_memory/models/state.py
@@ -40,9 +40,7 @@ class PhotonScoringState:
             recent_event_summaries=tuple(
                 str(getattr(event, "summary", "") or "") for event in recent_events
             ),
-            evidence_summaries=tuple(
-                str(getattr(item, "summary", "") or "") for item in evidence
-            ),
+            evidence_summaries=tuple(str(getattr(item, "summary", "") or "") for item in evidence),
         )
 
 

--- a/photon_action_memory/models/state.py
+++ b/photon_action_memory/models/state.py
@@ -1,3 +1,89 @@
-"""Model-independent state DTO placeholder."""
+"""Model-independent DTOs for optional PHOTON scoring."""
 
 from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PhotonScoringState:
+    """Compact request state passed into optional model scorers."""
+
+    request_id: str
+    task_text: str
+    touched_files: tuple[str, ...] = ()
+    recent_event_summaries: tuple[str, ...] = ()
+    evidence_summaries: tuple[str, ...] = ()
+
+    @classmethod
+    def from_sidecar_request(
+        cls,
+        request: object,
+        *,
+        evidence: Sequence[object] = (),
+    ) -> PhotonScoringState:
+        """Build scoring state from a sidecar request without importing API DTOs."""
+        task = getattr(request, "task", None)
+        working_memory = getattr(request, "working_memory", None)
+        recent_events = getattr(request, "recent_events", ())
+        task_parts = (
+            str(getattr(task, "user_request", "") or ""),
+            str(getattr(task, "summary", "") or ""),
+        )
+        return cls(
+            request_id=str(getattr(request, "request_id", "") or ""),
+            task_text=" ".join(part for part in task_parts if part),
+            touched_files=tuple(
+                str(item) for item in getattr(working_memory, "touched_files", ()) if item
+            ),
+            recent_event_summaries=tuple(
+                str(getattr(event, "summary", "") or "") for event in recent_events
+            ),
+            evidence_summaries=tuple(
+                str(getattr(item, "summary", "") or "") for item in evidence
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class ActionCandidate:
+    """Action candidate that can be scored by PHOTON without API coupling."""
+
+    kind: str
+    target: str | None = None
+    command: str | None = None
+    query: str | None = None
+    evidence_ids: tuple[str, ...] = ()
+
+    @property
+    def subject(self) -> str:
+        """Return the most specific stable key for checkpoint scoring weights."""
+        return self.target or self.command or self.query or self.kind
+
+
+@dataclass(frozen=True)
+class ScoredCandidate:
+    """Model score for an action candidate."""
+
+    candidate: ActionCandidate
+    score: float
+    reason: str
+
+
+@dataclass(frozen=True)
+class ScoredFile:
+    """Model score for a file path."""
+
+    path: str
+    score: float
+    reason: str
+
+
+@dataclass(frozen=True)
+class ScoredEvidence:
+    """Model score for an evidence item."""
+
+    evidence_id: str
+    score: float
+    reason: str

--- a/tests/test_photon_adapter.py
+++ b/tests/test_photon_adapter.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from photon_action_memory import SCHEMA_VERSION
+from photon_action_memory.api.schema import EvidenceItem, SuggestRequest
+from photon_action_memory.api.server import build_fallback_suggestions
+from photon_action_memory.models.checkpoint import (
+    CHECKPOINT_FORMAT,
+    CheckpointInvalid,
+    load_checkpoint_manifest,
+)
+from photon_action_memory.models.photon_adapter import (
+    CHECKPOINT_ENV,
+    MlxUnavailable,
+    PhotonMLXAdapter,
+    configured_checkpoint_path,
+    is_model_available,
+)
+from photon_action_memory.models.state import ActionCandidate, PhotonScoringState
+
+
+class _FakeArray(list[float]):
+    def item(self) -> float:
+        return self[0]
+
+
+class _FakeMlx:
+    float32 = "float32"
+
+    def array(self, values: list[float], *, dtype: object | None = None) -> _FakeArray:
+        return _FakeArray(values)
+
+
+def _request(*, user_request: str = "read src/high.py") -> SuggestRequest:
+    return SuggestRequest.model_validate(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "request_id": "req-photon-adapter",
+            "agent": {"name": "codex"},
+            "repo": {"root": "/repo", "name": "example"},
+            "task": {"user_request": user_request, "mode": "act"},
+            "working_memory": {"touched_files": ["src/low.py", "src/high.py"]},
+            "recent_events": [],
+            "budget": {"max_suggestions": 2, "max_evidence_chars": 4000},
+        }
+    )
+
+
+def _write_manifest(path: Path, *, state: dict[str, object] | None = None) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "format": CHECKPOINT_FORMAT,
+                "model_version": "photon-test-mlx",
+                "state": state or {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_default_import_path_does_not_require_mlx(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(CHECKPOINT_ENV, raising=False)
+
+    assert configured_checkpoint_path() is None
+    assert is_model_available() is False
+
+
+def test_missing_mlx_dependency_is_model_unavailable(tmp_path: Path) -> None:
+    checkpoint = _write_manifest(tmp_path / "manifest.json")
+
+    assert is_model_available(checkpoint, import_module=lambda _name: _raise_mlx()) is False
+
+
+def test_checkpoint_manifest_drops_unknown_state_keys(tmp_path: Path) -> None:
+    checkpoint = _write_manifest(tmp_path / "manifest.json", state={"bias": 0.4, "extra": 1})
+
+    manifest = load_checkpoint_manifest(checkpoint)
+
+    assert manifest.state == {"bias": 0.4}
+    assert manifest.warnings == ("dropped unknown checkpoint state key: extra",)
+
+
+def test_checkpoint_manifest_strict_mode_rejects_unknown_state_keys(tmp_path: Path) -> None:
+    checkpoint = _write_manifest(tmp_path / "manifest.json", state={"bias": 0.4, "extra": 1})
+
+    with pytest.raises(CheckpointInvalid, match="unknown keys"):
+        load_checkpoint_manifest(checkpoint, strict=True)
+
+
+def test_adapter_raises_typed_error_when_mlx_missing(tmp_path: Path) -> None:
+    checkpoint = _write_manifest(tmp_path / "manifest.json")
+
+    with pytest.raises(MlxUnavailable):
+        PhotonMLXAdapter.from_checkpoint(checkpoint, import_module=lambda _name: _raise_mlx())
+
+
+def test_fake_mlx_smoke_scores_actions_files_and_evidence(tmp_path: Path) -> None:
+    checkpoint = _write_manifest(
+        tmp_path / "manifest.json",
+        state={
+            "bias": 0.1,
+            "action_weights": {"read": 0.2},
+            "file_weights": {"src/high.py": 0.4},
+            "evidence_weights": {"evt_001": 0.3},
+        },
+    )
+    adapter = PhotonMLXAdapter.from_checkpoint(
+        checkpoint,
+        import_module=lambda _name: _FakeMlx(),
+    )
+    state = PhotonScoringState(request_id="req", task_text="read src/high.py")
+
+    actions = adapter.score_actions(
+        state,
+        [
+            ActionCandidate(kind="read", target="src/low.py"),
+            ActionCandidate(kind="read", target="src/high.py"),
+        ],
+    )
+    files = adapter.score_files(state, ["src/high.py"])
+    evidence = adapter.score_evidence(
+        state,
+        [EvidenceItem(id="evt_001", kind="tool_result", summary="opened src/high.py")],
+    )
+
+    assert actions[0].score == pytest.approx(0.3)
+    assert actions[1].score == pytest.approx(0.75)
+    assert files[0].score == pytest.approx(0.55)
+    assert evidence[0].score == pytest.approx(0.4)
+
+
+def test_suggest_falls_back_when_configured_checkpoint_is_invalid(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkpoint = tmp_path / "bad.json"
+    checkpoint.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv(CHECKPOINT_ENV, str(checkpoint))
+
+    response = build_fallback_suggestions(_request())
+
+    assert response.model_version == "photon-action-memory-v0.1.0-fallback"
+    assert response.suggestions[0].target == "src/high.py"
+    assert [warning.kind for warning in response.warnings] == ["model_unavailable"]
+
+
+def test_suggest_uses_configured_fake_mlx_checkpoint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkpoint = _write_manifest(
+        tmp_path / "manifest.json",
+        state={"bias": 0.1, "file_weights": {"src/high.py": 0.7}},
+    )
+    monkeypatch.setenv(CHECKPOINT_ENV, str(checkpoint))
+    monkeypatch.setattr(
+        "photon_action_memory.models.photon_adapter.importlib.import_module",
+        lambda _name: _FakeMlx(),
+    )
+
+    response = build_fallback_suggestions(_request(user_request="choose next file"))
+
+    assert response.model_version == "photon-test-mlx"
+    assert response.suggestions[0].target == "src/high.py"
+    assert response.suggestions[0].confidence == pytest.approx(0.8)
+    assert response.warnings == []
+
+
+def _raise_mlx() -> SimpleNamespace:
+    raise ModuleNotFoundError("No module named 'mlx'", name="mlx")

--- a/workspace/v0.1.0/05_development_preparation_plan.md
+++ b/workspace/v0.1.0/05_development_preparation_plan.md
@@ -528,8 +528,8 @@ shadow-mode log schema:
 
 ### Phase 5: Model and eval
 
-- [ ] [#11](https://github.com/Kewton/photon-action-memory/issues/11) MLX optional extra
-- [ ] [#11](https://github.com/Kewton/photon-action-memory/issues/11) PHOTON adapter interface
+- [x] [#11](https://github.com/Kewton/photon-action-memory/issues/11) MLX optional extra
+- [x] [#11](https://github.com/Kewton/photon-action-memory/issues/11) PHOTON adapter interface
 - [ ] [#12](https://github.com/Kewton/photon-action-memory/issues/12) checkpoint I/O
 - [ ] [#13](https://github.com/Kewton/photon-action-memory/issues/13) macOS smoke workflow
 - [x] [#9](https://github.com/Kewton/photon-action-memory/issues/9) offline eval runner


### PR DESCRIPTION
Closes #11

## Summary
- Adds the optional PHOTON MLX adapter surface and scoring DTOs.
- Keeps MLX optional on normal import paths.
- Falls back to deterministic ranking when MLX/checkpoint setup is unavailable.

## Verification
- See `dev-reports/issue-11/verification.md`.
- Reported checks include focused adapter/API/import tests, ruff, mypy, and full pytest.