### PR TITLE
#12 Add checkpoint load interface

### DIFF
--- a/dev-reports/issue-12/design.md
+++ b/dev-reports/issue-12/design.md
@@ -1,0 +1,38 @@
+# Issue #12 Design: Checkpoint load interface
+
+## Goal
+
+Add a runtime-only checkpoint boundary that the optional PHOTON adapter can use
+without importing training modules or requiring MLX on the default import path.
+
+## Shape
+
+- Keep `photon_action_memory.models.checkpoint` pure stdlib.
+- Use `CheckpointState` as the runtime DTO for `state.json`, mirroring the
+  reference training state fields that are safe for runtime consumers.
+- Load only `state.json` and verify `integrity.json` hashes for `state.json`
+  and `weights.npz`; actual MLX weight materialization remains adapter work.
+- Treat missing `integrity.json` as a warning by default and an error in strict
+  mode.
+- Treat hash mismatches, malformed JSON, and non-object state as invalid
+  checkpoints.
+- Drop unknown state keys with a warning so newer checkpoint writers remain
+  forward compatible with older runtimes.
+
+## Adapter Boundary
+
+`photon_adapter` gets a small availability probe that attempts to load a
+configured checkpoint state and returns unavailable on missing or invalid
+checkpoints. The API server already falls back to deterministic ranking when
+`is_model_available()` is false, so this keeps fail-open behavior in one place.
+
+## Tests
+
+Add focused checkpoint tests for:
+
+- import boundary does not import training modules or MLX;
+- valid state load and integrity verification;
+- missing integrity warning vs strict error;
+- hash mismatch rejection;
+- unknown state key warning/drop;
+- adapter fallback when checkpoint is missing or invalid.

--- a/dev-reports/issue-12/implementation-summary.md
+++ b/dev-reports/issue-12/implementation-summary.md
@@ -1,0 +1,25 @@
+# Issue #12 Implementation Summary
+
+## Changed Files
+
+- `photon_action_memory/models/checkpoint.py`
+- `photon_action_memory/models/photon_adapter.py`
+- `tests/test_checkpoint.py`
+- `dev-reports/issue-12/design.md`
+- `dev-reports/issue-12/verification.md`
+
+## Summary
+
+Implemented a stdlib-only runtime checkpoint load boundary with:
+
+- `CheckpointState` DTO for runtime-safe `state.json` data;
+- `load_checkpoint()` / `load_checkpoint_state()` for checkpoint state loading;
+- `verify_checkpoint_integrity()` with optional strict manifest enforcement;
+- `write_integrity_manifest()` for focused tests and future checkpoint writers;
+- warning-and-drop behavior for unknown checkpoint state keys;
+- type checks for known state fields;
+- adapter checkpoint probing via `PHOTON_ACTION_MEMORY_CHECKPOINT`;
+- strict mode configuration via `PHOTON_ACTION_MEMORY_CHECKPOINT_STRICT`;
+- fail-open adapter behavior that returns unavailable on missing or invalid checkpoints.
+
+No training package or MLX import is required by `models.checkpoint`.

--- a/dev-reports/issue-12/verification.md
+++ b/dev-reports/issue-12/verification.md
@@ -1,0 +1,22 @@
+# Issue #12 Verification
+
+## Passed
+
+- `python -m pytest -q tests/test_checkpoint.py tests/test_import.py tests/test_ranking_fallback.py tests/test_sidecar_api.py`
+  - 22 passed
+- `python -m ruff format --check .`
+  - 39 files already formatted
+- `python -m ruff check .`
+  - all checks passed
+- `python -m mypy photon_action_memory tests`
+  - success, no issues in 37 source files
+- `python -m pytest -q`
+  - 74 passed
+- `python -m build`
+  - built sdist and wheel successfully after allowing network access for isolated `hatchling` install
+
+## Notes
+
+An initial sandboxed `python -m build` attempt failed because the isolated build
+environment could not resolve/download `hatchling>=1.25`. The command was
+retried with approved network access and passed.

--- a/photon_action_memory/models/checkpoint.py
+++ b/photon_action_memory/models/checkpoint.py
@@ -1,3 +1,191 @@
-"""Runtime checkpoint I/O placeholder."""
+"""Runtime-only checkpoint I/O boundary for the optional PHOTON adapter.
+
+This module intentionally uses only the Python standard library. Runtime paths
+can import it without importing training modules or optional MLX dependencies.
+"""
 
 from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from dataclasses import dataclass, field, fields
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+_logger = logging.getLogger(__name__)
+
+INTEGRITY_FORMAT_VERSION = "1"
+STATE_FILENAME = "state.json"
+WEIGHTS_FILENAME = "weights.npz"
+INTEGRITY_FILENAME = "integrity.json"
+
+
+@dataclass
+class CheckpointState:
+    """Runtime DTO for checkpoint ``state.json``.
+
+    The fields mirror the training state shape used by the reference PHOTON
+    checkpoint writer, while remaining independent from training-only modules.
+    """
+
+    step: int = 0
+    best_val_loss: float = float("inf")
+    best_step: int = 0
+    patience_counter: int = 0
+    train_losses: list[float] = field(default_factory=list)
+    val_losses: list[float] = field(default_factory=list)
+
+
+def load_checkpoint(path: str | Path, *, verify_integrity: bool = False) -> CheckpointState:
+    """Load checkpoint state from ``path``.
+
+    ``verify_integrity=True`` requires an integrity manifest. When false, a
+    missing manifest only emits a warning so legacy checkpoints can still be
+    probed. Hash mismatches always raise.
+    """
+
+    checkpoint_dir = Path(path)
+    verify_checkpoint_integrity(checkpoint_dir, strict=verify_integrity)
+    return load_checkpoint_state(checkpoint_dir)
+
+
+def load_checkpoint_state(path: str | Path) -> CheckpointState:
+    """Load and validate ``state.json`` without importing model code."""
+
+    state_path = Path(path) / STATE_FILENAME
+    try:
+        raw_state = json.loads(state_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{state_path} is not valid JSON") from exc
+
+    if not isinstance(raw_state, dict):
+        raise ValueError(f"{state_path} must decode to an object, got {type(raw_state).__name__}")
+
+    known_fields = {item.name for item in fields(CheckpointState)}
+    unknown_fields = sorted(set(raw_state) - known_fields)
+    if unknown_fields:
+        _logger.warning("Ignoring unknown checkpoint state keys: %s", unknown_fields)
+
+    filtered = {key: raw_state[key] for key in known_fields if key in raw_state}
+    return _checkpoint_state_from_mapping(filtered, state_path)
+
+
+def verify_checkpoint_integrity(path: str | Path, *, strict: bool = False) -> bool:
+    """Verify ``integrity.json`` hashes for ``state.json`` and ``weights.npz``.
+
+    Returns true when a manifest was present and matched. Returns false when the
+    manifest is absent in non-strict mode. Raises for strict missing manifests,
+    malformed manifests, missing hashed files, or hash mismatches.
+    """
+
+    checkpoint_dir = Path(path)
+    integrity_path = checkpoint_dir / INTEGRITY_FILENAME
+    if not integrity_path.exists():
+        if strict:
+            raise FileNotFoundError(
+                f"{INTEGRITY_FILENAME} missing at {integrity_path} with strict verification"
+            )
+        _logger.warning(
+            "%s missing at %s; checkpoint integrity cannot be verified",
+            INTEGRITY_FILENAME,
+            integrity_path,
+        )
+        return False
+
+    try:
+        manifest = json.loads(integrity_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{integrity_path} is not valid JSON") from exc
+    if not isinstance(manifest, dict):
+        raise ValueError(
+            f"{integrity_path} must decode to an object, got {type(manifest).__name__}"
+        )
+
+    expected_raw = {
+        WEIGHTS_FILENAME: manifest.get("weights_sha256"),
+        STATE_FILENAME: manifest.get("state_sha256"),
+    }
+    missing_hashes = [name for name, digest in expected_raw.items() if not isinstance(digest, str)]
+    if missing_hashes:
+        raise ValueError(
+            f"{integrity_path} missing SHA-256 entries for: {', '.join(missing_hashes)}"
+        )
+    expected = {name: str(digest) for name, digest in expected_raw.items()}
+
+    for filename, expected_digest in expected.items():
+        actual_digest = _sha256_file(checkpoint_dir / filename)
+        if actual_digest != expected_digest:
+            raise ValueError(
+                "checkpoint integrity check failed for "
+                f"{filename}: expected {expected_digest[:12]}, got {actual_digest[:12]}"
+            )
+    return True
+
+
+def write_integrity_manifest(path: str | Path) -> None:
+    """Write an integrity manifest for an existing runtime checkpoint."""
+
+    checkpoint_dir = Path(path)
+    manifest = {
+        "format_version": INTEGRITY_FORMAT_VERSION,
+        "created_at": datetime.now(UTC).isoformat(),
+        "weights_sha256": _sha256_file(checkpoint_dir / WEIGHTS_FILENAME),
+        "state_sha256": _sha256_file(checkpoint_dir / STATE_FILENAME),
+    }
+    integrity_path = checkpoint_dir / INTEGRITY_FILENAME
+    tmp_path = checkpoint_dir / f"{INTEGRITY_FILENAME}.tmp"
+    tmp_path.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+    os.replace(tmp_path, integrity_path)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(64 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _checkpoint_state_from_mapping(values: dict[str, Any], source: Path) -> CheckpointState:
+    coerced = _coerce_state_fields(values, source)
+    return CheckpointState(
+        step=coerced.get("step", 0),
+        best_val_loss=coerced.get("best_val_loss", float("inf")),
+        best_step=coerced.get("best_step", 0),
+        patience_counter=coerced.get("patience_counter", 0),
+        train_losses=coerced.get("train_losses", []),
+        val_losses=coerced.get("val_losses", []),
+    )
+
+
+def _coerce_state_fields(values: dict[str, Any], source: Path) -> dict[str, Any]:
+    coerced: dict[str, object] = {}
+    for key, value in values.items():
+        if key in {"step", "best_step", "patience_counter"}:
+            if not isinstance(value, int):
+                raise ValueError(f"{source} field {key!r} must be an integer")
+            coerced[key] = value
+            continue
+        if key == "best_val_loss":
+            if not isinstance(value, int | float):
+                raise ValueError(f"{source} field {key!r} must be numeric")
+            coerced[key] = float(value)
+            continue
+        if key in {"train_losses", "val_losses"}:
+            coerced[key] = _coerce_loss_list(value, source, key)
+            continue
+    return coerced
+
+
+def _coerce_loss_list(value: object, source: Path, key: str) -> list[float]:
+    if not isinstance(value, list):
+        raise ValueError(f"{source} field {key!r} must be a list")
+    losses: list[float] = []
+    for item in value:
+        if not isinstance(item, int | float):
+            raise ValueError(f"{source} field {key!r} must contain only numbers")
+        losses.append(float(item))
+    return losses

--- a/photon_action_memory/models/photon_adapter.py
+++ b/photon_action_memory/models/photon_adapter.py
@@ -1,8 +1,54 @@
-"""Optional PHOTON/MLX scoring adapter placeholder."""
+"""Optional PHOTON/MLX scoring adapter boundary."""
 
 from __future__ import annotations
 
+import importlib.util
+import logging
+import os
+from pathlib import Path
+
+from photon_action_memory.models.checkpoint import CheckpointState, load_checkpoint
+
+_logger = logging.getLogger(__name__)
+
+CHECKPOINT_ENV = "PHOTON_ACTION_MEMORY_CHECKPOINT"
+CHECKPOINT_STRICT_ENV = "PHOTON_ACTION_MEMORY_CHECKPOINT_STRICT"
+
 
 def is_model_available() -> bool:
-    """Return False until the optional PHOTON adapter is implemented."""
-    return False
+    """Return true only when optional runtime dependencies and checkpoint load."""
+
+    if importlib.util.find_spec("mlx") is None:
+        return False
+    return load_configured_checkpoint_state() is not None
+
+
+def load_configured_checkpoint_state() -> CheckpointState | None:
+    """Load configured checkpoint state, returning unavailable on failure."""
+
+    checkpoint_path = configured_checkpoint_path()
+    if checkpoint_path is None:
+        return None
+    try:
+        return load_checkpoint(checkpoint_path, verify_integrity=_strict_checkpoint_mode())
+    except (OSError, ValueError) as exc:
+        _logger.warning(
+            "PHOTON checkpoint at %s is unavailable; falling back to deterministic ranking: %s",
+            checkpoint_path,
+            exc,
+        )
+        return None
+
+
+def configured_checkpoint_path() -> Path | None:
+    """Return the configured checkpoint directory, if any."""
+
+    raw_path = os.environ.get(CHECKPOINT_ENV, "").strip()
+    if not raw_path:
+        return None
+    return Path(raw_path)
+
+
+def _strict_checkpoint_mode() -> bool:
+    raw_value = os.environ.get(CHECKPOINT_STRICT_ENV, "").strip().lower()
+    return raw_value in {"1", "true", "yes", "on", "strict"}

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+from photon_action_memory.models.checkpoint import (
+    CheckpointState,
+    load_checkpoint,
+    load_checkpoint_state,
+    verify_checkpoint_integrity,
+    write_integrity_manifest,
+)
+from photon_action_memory.models.photon_adapter import (
+    CHECKPOINT_ENV,
+    load_configured_checkpoint_state,
+)
+
+
+def _write_checkpoint(
+    path: Path,
+    *,
+    state: dict[str, object] | None = None,
+    integrity: bool = True,
+) -> None:
+    path.mkdir()
+    (path / "weights.npz").write_bytes(b"runtime checkpoint weights")
+    (path / "state.json").write_text(
+        json.dumps(state if state is not None else {"step": 42, "best_val_loss": 1.25}),
+        encoding="utf-8",
+    )
+    if integrity:
+        write_integrity_manifest(path)
+
+
+def test_checkpoint_module_import_does_not_pull_training_or_mlx_modules() -> None:
+    for module_name in list(sys.modules):
+        if (
+            module_name == "mlx"
+            or module_name.startswith("mlx.")
+            or module_name == "photon_action_memory.training"
+            or module_name.startswith("photon_action_memory.training.")
+        ):
+            sys.modules.pop(module_name, None)
+    sys.modules.pop("photon_action_memory.models.checkpoint", None)
+
+    importlib.import_module("photon_action_memory.models.checkpoint")
+
+    assert "mlx" not in sys.modules
+    assert "photon_action_memory.training" not in sys.modules
+
+
+def test_load_checkpoint_reads_state_and_verifies_integrity(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "ckpt"
+    _write_checkpoint(
+        checkpoint_dir,
+        state={
+            "step": 200,
+            "best_val_loss": 0.75,
+            "best_step": 180,
+            "patience_counter": 2,
+            "train_losses": [1, 0.9],
+            "val_losses": [1.2, 0.8],
+        },
+    )
+
+    assert verify_checkpoint_integrity(checkpoint_dir, strict=True) is True
+    loaded = load_checkpoint(checkpoint_dir, verify_integrity=True)
+
+    assert loaded == CheckpointState(
+        step=200,
+        best_val_loss=0.75,
+        best_step=180,
+        patience_counter=2,
+        train_losses=[1.0, 0.9],
+        val_losses=[1.2, 0.8],
+    )
+
+
+def test_missing_integrity_warns_by_default_but_strict_mode_raises(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    checkpoint_dir = tmp_path / "ckpt"
+    _write_checkpoint(checkpoint_dir, integrity=False)
+
+    with caplog.at_level(logging.WARNING, logger="photon_action_memory.models.checkpoint"):
+        loaded = load_checkpoint(checkpoint_dir)
+
+    assert loaded.step == 42
+    assert any("integrity" in record.message for record in caplog.records)
+
+    with pytest.raises(FileNotFoundError):
+        load_checkpoint(checkpoint_dir, verify_integrity=True)
+
+
+def test_integrity_hash_mismatch_raises(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "ckpt"
+    _write_checkpoint(checkpoint_dir)
+    (checkpoint_dir / "state.json").write_text(json.dumps({"step": 999}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="integrity"):
+        load_checkpoint(checkpoint_dir)
+
+
+def test_unknown_state_keys_warn_and_drop(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    checkpoint_dir = tmp_path / "ckpt"
+    _write_checkpoint(
+        checkpoint_dir,
+        state={"step": 5, "future_state": "ignored"},
+        integrity=False,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="photon_action_memory.models.checkpoint"):
+        loaded = load_checkpoint_state(checkpoint_dir)
+
+    assert loaded == CheckpointState(step=5)
+    assert any("future_state" in record.message for record in caplog.records)
+    assert not hasattr(loaded, "future_state")
+
+
+def test_invalid_state_json_raises(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "ckpt"
+    _write_checkpoint(checkpoint_dir, state=[1, 2, 3], integrity=False)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="must decode to an object"):
+        load_checkpoint_state(checkpoint_dir)
+
+
+def test_adapter_returns_unavailable_for_missing_or_invalid_checkpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(CHECKPOINT_ENV, str(tmp_path / "missing"))
+    assert load_configured_checkpoint_state() is None
+
+    checkpoint_dir = tmp_path / "invalid"
+    _write_checkpoint(checkpoint_dir, integrity=False)
+    (checkpoint_dir / "state.json").write_text("{not json", encoding="utf-8")
+    monkeypatch.setenv(CHECKPOINT_ENV, str(checkpoint_dir))
+
+    assert load_configured_checkpoint_state() is None


### PR DESCRIPTION
Closes #12

## Summary
- Adds runtime-only checkpoint I/O boundaries for the PHOTON adapter.
- Supports optional strict integrity checks and unknown-key warning/drop behavior.
- Keeps training dependencies out of runtime imports.

## Verification
- See `dev-reports/issue-12/verification.md`.
- Reported checks include focused checkpoint/import/ranking/API tests, ruff, mypy, full pytest, and build.