### PR TITLE
#14 Add MCP / stdio adapter design note

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ PHOTON Action Memory focuses specifically on action-oriented memory for coding a
 - Add shadow-mode evaluation.
 - Measure reduction in repeated exploration and tool calls.
 - Add repository-local adaptation.
-- Provide an MCP adapter for broader agent compatibility.
+- Provide MCP / stdio adapters for broader agent compatibility.
 
 ## Status
 

--- a/dev-reports/issue-14/design.md
+++ b/dev-reports/issue-14/design.md
@@ -1,0 +1,27 @@
+# Issue #14 Design: MCP / stdio adapter note
+
+## Goal
+
+Add a lightweight design note for non-HTTP integration paths so `photon-action-memory`
+can later support stdio and MCP clients without inventing a second contract beside
+the sidecar API schema.
+
+## Shape
+
+- Create a dedicated workspace note for the adapter policy.
+- Treat `photon_action_memory.api.schema` DTOs as the canonical payload contract
+  for HTTP, stdio, and MCP.
+- Define HTTP as the v0.1.0 runtime surface, stdio as a future local transport
+  wrapper, and MCP as a future tool/resource exposure layer over the same request,
+  response, event, summary, and evaluation schemas.
+- Keep privacy policy transport-neutral: adapters may only pass sanitized,
+  schema-valid DTOs and must not forward raw logs, prompts, tool stdout/stderr, or
+  secrets.
+
+## Scope boundaries
+
+This issue is documentation-only. v0.1.0 should not implement an MCP server,
+stdio protocol loop, transport negotiation, editor plugin, or adapter-specific
+storage. The design note should make those non-goals explicit so implementation
+issues can stay focused on schema, sanitizer, sidecar, fallback ranking, and
+shadow evaluation.

--- a/dev-reports/issue-14/implementation-summary.md
+++ b/dev-reports/issue-14/implementation-summary.md
@@ -1,0 +1,19 @@
+# Issue #14 Implementation Summary
+
+## Changed
+
+- Added `workspace/v0.1.0/mcp_stdio_adapter_design.md`.
+- Documented sidecar schema reuse for HTTP, stdio, and MCP adapters.
+- Defined responsibility boundaries for core service, HTTP localhost sidecar,
+  future stdio adapter, and future MCP adapter.
+- Documented transport-neutral privacy rules: no secret passthrough, no raw logs,
+  no raw prompt/tool stdout/stderr forwarding, and no full payload debug logging.
+- Listed v0.1.0 non-goals for stdio / MCP implementation.
+- Linked the design note from workspace docs and updated the extraction /
+  development preparation plans.
+
+## Not changed
+
+- No runtime adapter implementation was added.
+- No schema changes were made.
+- No tests were added because this issue is documentation-only.

--- a/dev-reports/issue-14/verification.md
+++ b/dev-reports/issue-14/verification.md
@@ -1,0 +1,15 @@
+# Issue #14 Verification
+
+## Checks
+
+- `python -m pytest -q`
+  - Result: passed
+  - Output: `67 passed in 0.85s`
+
+## Acceptance criteria
+
+- sidecar API schema reuse adapter policy: covered in
+  `workspace/v0.1.0/mcp_stdio_adapter_design.md` sections 2, 3, and 6.
+- HTTP / stdio / MCP responsibility boundaries: covered in section 3.
+- secret / raw log policy: covered in section 4.
+- v0.1.0 non-goals: covered in section 5.

--- a/workspace/v0.1.0/01_spec_requirements_architecture.md
+++ b/workspace/v0.1.0/01_spec_requirements_architecture.md
@@ -81,6 +81,8 @@ metrics report に含めない。
 ### 5.1 Sidecar API
 
 v0.1.0 では HTTP localhost を主経路とし、将来 stdio / MCP adapter を追加できる形にする。
+adapter 方針は `workspace/v0.1.0/mcp_stdio_adapter_design.md` に固定し、HTTP /
+stdio / MCP は同じ sidecar API schema を再利用する transport として扱う。
 
 必須 endpoint:
 

--- a/workspace/v0.1.0/03_photon_mlx_extraction_plan.md
+++ b/workspace/v0.1.0/03_photon_mlx_extraction_plan.md
@@ -114,6 +114,7 @@ photon_action_memory/
 
 - Anvil から呼べる API contract を先に固定する
 - PHOTON model なしでも有用な suggestion を返す
+- HTTP / stdio / MCP adapter が同じ sidecar schema を再利用できるようにする
 
 成果物:
 
@@ -122,6 +123,7 @@ photon_action_memory/
 - file / command / query candidate extractor
 - deterministic ranking fallback
 - fail-open behavior
+- MCP / stdio adapter design note
 
 ### Stage 2: Event store and exporter migration
 
@@ -197,6 +199,11 @@ v0.1.x では schema version を必ず含める。
 - enum 値追加は minor version 扱い
 - required field 削除 / rename は破壊的変更
 - 破壊的変更は `v0.2.0` 以降に回す
+
+HTTP / stdio / MCP は transport adapter として扱い、別 schema を作らない。
+adapter 固有の envelope は canonical DTO の外側に置き、payload body は
+`photon_action_memory.api.schema` の request / response / event / evaluation
+contract を再利用する。詳細は `mcp_stdio_adapter_design.md` にまとめる。
 
 ## 6. データ移行ポリシー
 

--- a/workspace/v0.1.0/05_development_preparation_plan.md
+++ b/workspace/v0.1.0/05_development_preparation_plan.md
@@ -480,6 +480,38 @@ shadow-mode log schema:
 - adoption / ignored / outcome を追跡できる。
 - eval runner は raw log を直接吐かない。
 
+## 12.5 MCP / stdio Adapter Design Note
+
+Issue #14 では、HTTP localhost sidecar 以外の統合経路として
+`workspace/v0.1.0/mcp_stdio_adapter_design.md` を追加する。
+
+adapter 方針:
+
+- `photon_action_memory.api.schema` の DTO を HTTP / stdio / MCP 共通の
+  canonical schema として再利用する。
+- HTTP は v0.1.0 の実装対象 transport とし、JSON encoding、status code、
+  timeout、health check を担当する。
+- stdio は将来の local child-process integration 用 transport とし、stdin /
+  stdout の envelope だけを担当する。
+- MCP は将来の tool / resource integration layer とし、tool arguments と
+  canonical DTO の変換、capability discovery、tool result formatting を担当する。
+- sanitizer、event store、ranking、PHOTON scorer、shadow evaluation は core
+  service の責務であり、adapter に重複実装しない。
+- secret、raw conversation log、prompt、tool stdout/stderr、absolute user path
+  を adapter 経由で渡さない。adapter debug log や error にも raw payload を
+  出さない。
+
+v0.1.0 で実装しない範囲:
+
+- stdio adapter process
+- MCP server
+- MCP resource exposure
+- adapter-specific schema / storage
+- remote MCP / remote sidecar deployment
+- raw log streaming
+- secret passthrough mode
+- adapter 経由の online training
+
 ## 13. 実装順チェックリスト
 
 ### Phase 0: Repository bootstrap
@@ -534,6 +566,7 @@ shadow-mode log schema:
 - [ ] [#13](https://github.com/Kewton/photon-action-memory/issues/13) macOS smoke workflow
 - [x] [#9](https://github.com/Kewton/photon-action-memory/issues/9) offline eval runner
 - [ ] [#10](https://github.com/Kewton/photon-action-memory/issues/10) Anvil shadow contract
+- [x] [#14](https://github.com/Kewton/photon-action-memory/issues/14) MCP / stdio adapter design note
 
 ## 14. 初回 PR の推奨スコープ
 

--- a/workspace/v0.1.0/README.md
+++ b/workspace/v0.1.0/README.md
@@ -17,6 +17,7 @@
 | `03_photon_mlx_extraction_plan.md` | `photon-mlx` からの切り出し計画 |
 | `04_work_plan.md` | v0.1.0 作業計画 |
 | `05_development_preparation_plan.md` | `photon-mlx-develop` 実ソース参照後の開発準備作業計画 |
+| `mcp_stdio_adapter_design.md` | MCP / stdio adapter の責務境界と non-goals |
 
 ## v0.1.0 の基本方針
 

--- a/workspace/v0.1.0/mcp_stdio_adapter_design.md
+++ b/workspace/v0.1.0/mcp_stdio_adapter_design.md
@@ -1,0 +1,136 @@
+# MCP / stdio adapter design note
+
+## 1. 目的
+
+v0.1.0 の主経路は HTTP localhost sidecar である。一方で、Codex 系 agent や
+editor / orchestration runtime からの統合では、HTTP を直接呼ぶより stdio や
+MCP tool として公開する方が扱いやすい場合がある。
+
+このメモは、将来の stdio / MCP adapter が既存 sidecar API schema を再利用し、
+transport ごとに別 contract を増やさないための責務境界を固定する。
+
+## 2. 基本方針
+
+- `photon_action_memory.api.schema` の DTO を canonical schema とする。
+- HTTP / stdio / MCP は transport adapter であり、action memory の business
+  logic を持たない。
+- adapter は transport 固有の envelope を canonical DTO に変換し、schema
+  validation 後に core service へ渡す。
+- `schema_version`、`request_id`、`session_id`、`sidecar_status`、warning
+  形式は transport によらず同じ意味で扱う。
+- Anvil や特定 agent の拡張情報は `agent` と `metadata` に閉じ込め、core
+  schema を adapter 固有にしない。
+
+## 3. 責務境界
+
+### Core service
+
+Core service は transport 非依存の処理を担当する。
+
+- schema validation
+- sanitizer
+- event store append / read
+- deterministic fallback ranking
+- optional PHOTON scorer 呼び出し
+- shadow evaluation record handling
+- fail-open response shape の生成
+
+### HTTP localhost sidecar
+
+HTTP は v0.1.0 の唯一の実装対象 transport とする。
+
+- `GET /health`
+- `POST /v1/events`
+- `POST /v1/suggest`
+- `POST /v1/summarize`
+- `POST /v1/evaluate`
+
+HTTP layer は request / response の JSON encoding、status code、timeout、
+local process health check を扱う。ranking、storage、redaction policy は
+core service に委譲する。
+
+### stdio adapter
+
+stdio adapter は将来の local child-process integration 用 transport とする。
+
+- stdin から request envelope を受け取り、stdout に response envelope を返す。
+- payload body は HTTP endpoint と同じ canonical DTO を使う。
+- adapter 固有 field は `method`、`id`、`payload` などの envelope に限定する。
+- long-running session state や event store を adapter 内に持たない。
+- stderr は diagnostics 専用にし、payload、secret、raw log を出さない。
+
+stdio adapter の想定 mapping:
+
+| stdio method | canonical DTO / operation |
+| --- | --- |
+| `health` | health response |
+| `events.append` | `EventRequest` / `/v1/events` 相当 |
+| `suggest` | `SuggestRequest` / `SuggestResponse` |
+| `summarize` | summarize request / response contract |
+| `evaluate` | `EvaluateRequest` / evaluation response contract |
+
+### MCP adapter
+
+MCP adapter は将来の tool / resource integration layer とする。
+
+- MCP tool arguments を canonical DTO に変換する。
+- MCP tool result は canonical response DTO を JSON として返す。
+- MCP の tool description / capability discovery は adapter が担当する。
+- suggestion、event persistence、ranking、sanitizer は core service に委譲する。
+- raw session history や raw tool output を MCP resource として公開しない。
+
+MCP tool の想定 mapping:
+
+| MCP tool | canonical DTO / operation |
+| --- | --- |
+| `photon_health` | health response |
+| `photon_record_event` | `EventRequest` / `/v1/events` 相当 |
+| `photon_suggest` | `SuggestRequest` / `SuggestResponse` |
+| `photon_summarize` | summarize request / response contract |
+| `photon_evaluate` | `EvaluateRequest` / evaluation response contract |
+
+## 4. Privacy / safety policy
+
+adapter は secret や raw log を迂回路として渡してはならない。
+
+- raw conversation log、prompt、tool stdout/stderr、command transcript をそのまま
+  payload に入れない。
+- API key、token、password、credential、署名付き URL、absolute user home path
+  を raw のまま渡さない。
+- adapter debug log に request / response payload 全体を出さない。
+- validation error や transport error は raw payload を echo しない。
+- 永続化前の sanitizer 適用は HTTP / stdio / MCP で同じ rule にする。
+- adapter が受け取る `recent_events` は sanitized summary / artifact reference
+  に限定する。
+
+この方針により、HTTP を使わない統合経路でも event store、dataset exporter、
+eval runner の privacy boundary を弱めない。
+
+## 5. v0.1.0 で実装しない範囲
+
+Issue #14 は design note のみを追加する。v0.1.0 では以下を実装しない。
+
+- stdio adapter process
+- MCP server
+- MCP resource exposure
+- adapter-specific schema
+- adapter-specific event store
+- remote MCP / remote sidecar deployment
+- transport negotiation
+- editor plugin integration
+- raw log streaming
+- secret passthrough mode
+- adapter 経由の online training
+
+v0.1.0 の実装優先度は、canonical schema、sanitizer、local HTTP sidecar、
+deterministic fallback、shadow evaluation の順に維持する。
+
+## 6. 将来の実装チェック
+
+stdio / MCP 実装 issue では、最低限以下を確認する。
+
+- HTTP fixture と同じ `SuggestRequest` / `SuggestResponse` が round-trip する。
+- adapter envelope を外すと canonical DTO として validation できる。
+- secret / absolute path / raw tool output が adapter log に残らない。
+- sidecar unavailable 時も fail-open response shape を返す。
+- adapter 側に ranking / storage logic が重複していない。


### PR DESCRIPTION
Closes #14

## Summary
- Adds the MCP / stdio adapter design note.
- Documents sidecar schema reuse, HTTP/stdio/MCP boundaries, privacy rules, and v0.1.0 non-goals.

## Verification
- See `dev-reports/issue-14/verification.md`.
- Reported check: full pytest.