### PR TITLE
#13 Add macOS MLX smoke workflow

### DIFF
--- a/.github/workflows/mlx-smoke.yml
+++ b/.github/workflows/mlx-smoke.yml
@@ -1,0 +1,33 @@
+name: MLX Smoke
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 18 * * *"
+  push:
+    branches: [develop]
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_VERSION: "3.12"
+  PHOTON_RUN_MLX_SMOKE: "1"
+
+jobs:
+  mlx-smoke:
+    name: macOS MLX smoke
+    runs-on: macos-14
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+      - name: Install
+        run: |
+          python -m pip install -U pip
+          pip install -e ".[dev,mlx]"
+      - name: Smoke
+        run: pytest -q tests/integration/test_mlx_smoke.py

--- a/dev-reports/issue-13/design.md
+++ b/dev-reports/issue-13/design.md
@@ -1,0 +1,18 @@
+# Issue #13 Design
+
+## Goal
+
+Add a separate macOS-only MLX smoke workflow so optional MLX dependency coverage is available without making the standard Ubuntu CI require MLX.
+
+## Scope
+
+- Add `.github/workflows/mlx-smoke.yml` with `workflow_dispatch`, nightly schedule, and `develop` push triggers.
+- Add `tests/integration/test_mlx_smoke.py` as a focused import and tiny scoring smoke.
+- Keep the smoke safe for normal `pytest` runs by requiring explicit workflow opt-in before importing `mlx.core`.
+- Update planning docs only where they should reflect that the workflow now exists.
+
+## Verification Plan
+
+- Run the new smoke test locally and confirm it skips without MLX on non-MLX environments.
+- Run standard test suite to confirm Ubuntu-style dev install still does not require MLX.
+- Run lint/format/type checks because workflow and tests are CI-facing.

--- a/dev-reports/issue-13/implementation-summary.md
+++ b/dev-reports/issue-13/implementation-summary.md
@@ -1,0 +1,13 @@
+# Issue #13 Implementation Summary
+
+## Changes
+
+- Added `.github/workflows/mlx-smoke.yml` for a macOS-only MLX smoke job.
+- Configured the workflow for `workflow_dispatch`, nightly schedule, and `develop` push.
+- Added `tests/integration/test_mlx_smoke.py` with an explicit `PHOTON_RUN_MLX_SMOKE=1` opt-in before importing MLX.
+- Kept the runtime PHOTON adapter fail-closed; MLX importability alone is not treated as an available PHOTON model.
+- Updated v0.1.0 planning docs to describe the separated MLX smoke gate and tiny scoring smoke.
+
+## Notes
+
+The smoke test is collected by normal pytest but skips unless the dedicated workflow opt-in is set. This prevents standard Ubuntu CI and local dev runs from importing or requiring MLX.

--- a/dev-reports/issue-13/verification.md
+++ b/dev-reports/issue-13/verification.md
@@ -1,0 +1,21 @@
+# Issue #13 Verification
+
+## Commands
+
+- `python -m pytest -q tests/integration/test_mlx_smoke.py`
+  - Result: passed with 1 skipped.
+  - Note: skipped locally because `PHOTON_RUN_MLX_SMOKE` is not set outside the dedicated workflow.
+- `ruff format --check .`
+  - Result: passed.
+- `ruff check .`
+  - Result: passed.
+- `mypy photon_action_memory tests`
+  - Result: passed.
+- `python -m pytest -q`
+  - Result: passed with 67 passed, 1 skipped.
+- `python -m build`
+  - Result: passed after rerunning with network access for isolated build dependency installation.
+
+## Local MLX Note
+
+An initial local run that imported `mlx.core` without workflow opt-in aborted the Python process on this machine. The smoke test now requires `PHOTON_RUN_MLX_SMOKE=1` before importing MLX, and the workflow sets that variable explicitly.

--- a/tests/integration/test_mlx_smoke.py
+++ b/tests/integration/test_mlx_smoke.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+
+from photon_action_memory.models.photon_adapter import is_model_available
+
+
+def test_mlx_import_and_tiny_scoring_smoke() -> None:
+    if os.environ.get("PHOTON_RUN_MLX_SMOKE") != "1":
+        pytest.skip("MLX smoke is opt-in outside the dedicated macOS workflow")
+
+    mx: Any = pytest.importorskip("mlx.core")
+
+    assert isinstance(is_model_available(), bool)
+
+    weights = mx.array([0.25, 0.75], dtype=mx.float32)
+    features = mx.array([2.0, 4.0], dtype=mx.float32)
+    score = mx.sum(weights * features)
+    mx.eval(score)
+
+    assert score.item() == pytest.approx(3.5)

--- a/workspace/v0.1.0/02_branch_strategy_ci.md
+++ b/workspace/v0.1.0/02_branch_strategy_ci.md
@@ -68,7 +68,7 @@ Anvil は以下の構成を採用している。
 
 | Job | Trigger | 目的 |
 | --- | --- | --- |
-| `mlx-smoke` | `develop` push / nightly / manual | macOS runner で MLX import + tiny inference smoke |
+| `mlx-smoke` | `develop` push / nightly / manual | macOS runner で MLX import + tiny scoring smoke |
 | `integration-anvil-schema` | PR label / manual | Anvil request fixture との schema compatibility |
 | `eval-shadow` | nightly / manual | fixed fixture に対する suggestion metric |
 | `release` | tag `v*` | wheel / sdist publish artifact 作成 |

--- a/workspace/v0.1.0/05_development_preparation_plan.md
+++ b/workspace/v0.1.0/05_development_preparation_plan.md
@@ -241,12 +241,14 @@ photon_action_memory/
 - `mypy photon_action_memory tests`
 - `pytest -q`
 - `python -m build`
+- macOS MLX smoke は `develop` push / nightly / manual で標準 Ubuntu CI から分離する。
 
 完了条件:
 
 - 空の package を import できる。
 - CI workflow が Ubuntu で通る構成になっている。
 - MLX が未インストールでも import / tests が通る。
+- MLX 導入済み macOS runner で tiny scoring smoke が通る。
 - PR template に schema / sanitizer / fail-open 確認項目がある。
 
 ## 7. M1 Schema First 詳細計画


### PR DESCRIPTION
Closes #13

## Summary
- Adds a macOS-only MLX smoke workflow.
- Keeps standard Ubuntu CI and local default tests from requiring MLX.
- Adds an opt-in integration smoke test.

## Verification
- See `dev-reports/issue-13/verification.md`.
- Reported checks include the MLX smoke test collection, ruff, mypy, full pytest, and build.