### PR TITLE
[codex] Improve CommandMate orchestration publishing

### DIFF
--- a/.codex/skills/orchestrate/SKILL.md
+++ b/.codex/skills/orchestrate/SKILL.md
@@ -15,6 +15,10 @@ Use this skill when the user asks to run `/orchestrate <issue...>` for this repo
 - Prefer repository-local artifacts under `workspace/management/runs/`.
 - Do not delete, reset, or overwrite existing worktrees without explicit user approval.
 - Do not merge PRs with failing CI unless the user explicitly approves.
+- Do not start/stop CommandMate or kill port processes unless the user explicitly asks.
+- Treat `commandmatedev` read failures such as `Server is not running` as "unreachable"
+  until verified outside the sandbox; Codex sandboxed localhost access can fail even when
+  the user's terminal and CommandMate server are healthy.
 - Include manual UAT steps when GUI or real-device confirmation is needed.
 
 ## First Action
@@ -32,4 +36,3 @@ Review the generated:
 - `workspace/management/runs/<run_id>/dependency-plan.md`
 
 Proceed to worktree creation and CommandMate dispatch only after the plan is coherent and any blocking questions have been answered.
-

--- a/.github/workflows/mlx-smoke.yml
+++ b/.github/workflows/mlx-smoke.yml
@@ -1,0 +1,33 @@
+name: MLX Smoke
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 18 * * *"
+  push:
+    branches: [develop]
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_VERSION: "3.12"
+  PHOTON_RUN_MLX_SMOKE: "1"
+
+jobs:
+  mlx-smoke:
+    name: macOS MLX smoke
+    runs-on: macos-14
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+      - name: Install
+        run: |
+          python -m pip install -U pip
+          pip install -e ".[dev,mlx]"
+      - name: Smoke
+        run: pytest -q tests/integration/test_mlx_smoke.py

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ PHOTON Action Memory focuses specifically on action-oriented memory for coding a
 - Add shadow-mode evaluation.
 - Measure reduction in repeated exploration and tool calls.
 - Add repository-local adaptation.
-- Provide an MCP adapter for broader agent compatibility.
+- Provide MCP / stdio adapters for broader agent compatibility.
 
 ## Status
 

--- a/dev-reports/issue-11/design.md
+++ b/dev-reports/issue-11/design.md
@@ -1,0 +1,28 @@
+# Issue 11 Design: Optional PHOTON MLX Adapter
+
+## Goal
+
+Add an optional PHOTON / MLX scoring boundary without making MLX a normal import-time
+dependency. The default sidecar path must continue to work in environments that do not
+install the `mlx` extra.
+
+## Design
+
+- Keep `photon_action_memory.models.photon_adapter` importable without MLX by lazy-importing
+  `mlx.core` only when a configured checkpoint is used.
+- Add model-independent scoring DTOs in `models/state.py` so later smoke and integration tests
+  can exercise `score_actions`, `score_files`, and `score_evidence` without depending on the
+  API schema internals.
+- Add a small runtime checkpoint manifest loader in `models/checkpoint.py`:
+  - missing paths raise a typed unavailable error;
+  - malformed JSON or schema mismatches raise a typed invalid error;
+  - unknown state keys are dropped and returned as warnings.
+- Route `/v1/suggest` through the adapter only when `PHOTON_ACTION_MEMORY_CHECKPOINT` is set and
+  a valid MLX runtime/checkpoint is available. Any adapter initialization or scoring failure
+  returns the existing deterministic fallback ranking and fallback model version.
+
+## Scope Notes
+
+This issue creates the optional scoring interface and fail-closed boundary. It does not implement
+real PHOTON model inference weights; the adapter produces stable heuristic scores over the same
+candidate surface so a later macOS MLX smoke issue can validate the runtime path.

--- a/dev-reports/issue-11/implementation-summary.md
+++ b/dev-reports/issue-11/implementation-summary.md
@@ -1,0 +1,30 @@
+# Issue 11 Implementation Summary
+
+## Changed
+
+- Added `models/state.py` scoring DTOs:
+  - `PhotonScoringState`
+  - `ActionCandidate`
+  - `ScoredCandidate`
+  - `ScoredFile`
+  - `ScoredEvidence`
+- Added runtime checkpoint manifest validation in `models/checkpoint.py`:
+  - validates `photon-action-memory.mlx.v1` manifests;
+  - reports missing and invalid checkpoints through typed exceptions;
+  - drops unknown state keys by default and rejects them in strict mode.
+- Replaced the adapter placeholder with `PhotonMLXAdapter`:
+  - lazy-imports `mlx.core` only when a checkpoint path is configured;
+  - exposes `score_actions`, `score_files`, and `score_evidence`;
+  - supports tiny smoke scoring with manifest weights.
+- Updated `/v1/suggest` to:
+  - build the existing deterministic fallback candidate surface first;
+  - optionally rerank it through the MLX adapter when `PHOTON_ACTION_MEMORY_CHECKPOINT` is set;
+  - fall back to deterministic ranking when checkpoint or adapter setup fails.
+- Updated the v0.1.0 preparation checklist for Issue #11 adapter/interface completion.
+- Added focused adapter tests covering default import behavior, missing MLX simulation, checkpoint
+  validation, invalid-checkpoint fallback, direct fake-MLX scoring, and sidecar fake-MLX scoring.
+
+## Notes
+
+The adapter does not introduce a real PHOTON model architecture. It creates the runtime-safe
+boundary and smoke-testable scoring interface needed for the follow-up macOS MLX smoke issue.

--- a/dev-reports/issue-11/verification.md
+++ b/dev-reports/issue-11/verification.md
@@ -1,0 +1,20 @@
+# Issue 11 Verification
+
+## Commands
+
+- `python -m pytest tests/test_photon_adapter.py tests/test_sidecar_api.py tests/test_import.py -q`
+  - Passed: `16 passed in 0.15s`
+- `python -m ruff check photon_action_memory tests/test_photon_adapter.py`
+  - Passed: `All checks passed!`
+- `python -m mypy photon_action_memory`
+  - Passed: `Success: no issues found in 25 source files`
+- `python -m pytest -q`
+  - Passed: `75 passed in 0.69s`
+
+## Coverage Notes
+
+- Default package import and default tests do not import MLX.
+- Missing MLX is simulated through the adapter import seam to avoid loading the host MLX runtime.
+- Invalid checkpoint configuration falls back to deterministic ranking and emits `model_unavailable`.
+- Fake-MLX smoke scoring validates `score_actions`, `score_files`, `score_evidence`, and the
+  sidecar reranking path.

--- a/dev-reports/issue-12/design.md
+++ b/dev-reports/issue-12/design.md
@@ -1,0 +1,38 @@
+# Issue #12 Design: Checkpoint load interface
+
+## Goal
+
+Add a runtime-only checkpoint boundary that the optional PHOTON adapter can use
+without importing training modules or requiring MLX on the default import path.
+
+## Shape
+
+- Keep `photon_action_memory.models.checkpoint` pure stdlib.
+- Use `CheckpointState` as the runtime DTO for `state.json`, mirroring the
+  reference training state fields that are safe for runtime consumers.
+- Load only `state.json` and verify `integrity.json` hashes for `state.json`
+  and `weights.npz`; actual MLX weight materialization remains adapter work.
+- Treat missing `integrity.json` as a warning by default and an error in strict
+  mode.
+- Treat hash mismatches, malformed JSON, and non-object state as invalid
+  checkpoints.
+- Drop unknown state keys with a warning so newer checkpoint writers remain
+  forward compatible with older runtimes.
+
+## Adapter Boundary
+
+`photon_adapter` gets a small availability probe that attempts to load a
+configured checkpoint state and returns unavailable on missing or invalid
+checkpoints. The API server already falls back to deterministic ranking when
+`is_model_available()` is false, so this keeps fail-open behavior in one place.
+
+## Tests
+
+Add focused checkpoint tests for:
+
+- import boundary does not import training modules or MLX;
+- valid state load and integrity verification;
+- missing integrity warning vs strict error;
+- hash mismatch rejection;
+- unknown state key warning/drop;
+- adapter fallback when checkpoint is missing or invalid.

--- a/dev-reports/issue-12/implementation-summary.md
+++ b/dev-reports/issue-12/implementation-summary.md
@@ -1,0 +1,25 @@
+# Issue #12 Implementation Summary
+
+## Changed Files
+
+- `photon_action_memory/models/checkpoint.py`
+- `photon_action_memory/models/photon_adapter.py`
+- `tests/test_checkpoint.py`
+- `dev-reports/issue-12/design.md`
+- `dev-reports/issue-12/verification.md`
+
+## Summary
+
+Implemented a stdlib-only runtime checkpoint load boundary with:
+
+- `CheckpointState` DTO for runtime-safe `state.json` data;
+- `load_checkpoint()` / `load_checkpoint_state()` for checkpoint state loading;
+- `verify_checkpoint_integrity()` with optional strict manifest enforcement;
+- `write_integrity_manifest()` for focused tests and future checkpoint writers;
+- warning-and-drop behavior for unknown checkpoint state keys;
+- type checks for known state fields;
+- adapter checkpoint probing via `PHOTON_ACTION_MEMORY_CHECKPOINT`;
+- strict mode configuration via `PHOTON_ACTION_MEMORY_CHECKPOINT_STRICT`;
+- fail-open adapter behavior that returns unavailable on missing or invalid checkpoints.
+
+No training package or MLX import is required by `models.checkpoint`.

--- a/dev-reports/issue-12/verification.md
+++ b/dev-reports/issue-12/verification.md
@@ -1,0 +1,22 @@
+# Issue #12 Verification
+
+## Passed
+
+- `python -m pytest -q tests/test_checkpoint.py tests/test_import.py tests/test_ranking_fallback.py tests/test_sidecar_api.py`
+  - 22 passed
+- `python -m ruff format --check .`
+  - 39 files already formatted
+- `python -m ruff check .`
+  - all checks passed
+- `python -m mypy photon_action_memory tests`
+  - success, no issues in 37 source files
+- `python -m pytest -q`
+  - 74 passed
+- `python -m build`
+  - built sdist and wheel successfully after allowing network access for isolated `hatchling` install
+
+## Notes
+
+An initial sandboxed `python -m build` attempt failed because the isolated build
+environment could not resolve/download `hatchling>=1.25`. The command was
+retried with approved network access and passed.

--- a/dev-reports/issue-13/design.md
+++ b/dev-reports/issue-13/design.md
@@ -1,0 +1,18 @@
+# Issue #13 Design
+
+## Goal
+
+Add a separate macOS-only MLX smoke workflow so optional MLX dependency coverage is available without making the standard Ubuntu CI require MLX.
+
+## Scope
+
+- Add `.github/workflows/mlx-smoke.yml` with `workflow_dispatch`, nightly schedule, and `develop` push triggers.
+- Add `tests/integration/test_mlx_smoke.py` as a focused import and tiny scoring smoke.
+- Keep the smoke safe for normal `pytest` runs by requiring explicit workflow opt-in before importing `mlx.core`.
+- Update planning docs only where they should reflect that the workflow now exists.
+
+## Verification Plan
+
+- Run the new smoke test locally and confirm it skips without MLX on non-MLX environments.
+- Run standard test suite to confirm Ubuntu-style dev install still does not require MLX.
+- Run lint/format/type checks because workflow and tests are CI-facing.

--- a/dev-reports/issue-13/implementation-summary.md
+++ b/dev-reports/issue-13/implementation-summary.md
@@ -1,0 +1,13 @@
+# Issue #13 Implementation Summary
+
+## Changes
+
+- Added `.github/workflows/mlx-smoke.yml` for a macOS-only MLX smoke job.
+- Configured the workflow for `workflow_dispatch`, nightly schedule, and `develop` push.
+- Added `tests/integration/test_mlx_smoke.py` with an explicit `PHOTON_RUN_MLX_SMOKE=1` opt-in before importing MLX.
+- Kept the runtime PHOTON adapter fail-closed; MLX importability alone is not treated as an available PHOTON model.
+- Updated v0.1.0 planning docs to describe the separated MLX smoke gate and tiny scoring smoke.
+
+## Notes
+
+The smoke test is collected by normal pytest but skips unless the dedicated workflow opt-in is set. This prevents standard Ubuntu CI and local dev runs from importing or requiring MLX.

--- a/dev-reports/issue-13/verification.md
+++ b/dev-reports/issue-13/verification.md
@@ -1,0 +1,21 @@
+# Issue #13 Verification
+
+## Commands
+
+- `python -m pytest -q tests/integration/test_mlx_smoke.py`
+  - Result: passed with 1 skipped.
+  - Note: skipped locally because `PHOTON_RUN_MLX_SMOKE` is not set outside the dedicated workflow.
+- `ruff format --check .`
+  - Result: passed.
+- `ruff check .`
+  - Result: passed.
+- `mypy photon_action_memory tests`
+  - Result: passed.
+- `python -m pytest -q`
+  - Result: passed with 67 passed, 1 skipped.
+- `python -m build`
+  - Result: passed after rerunning with network access for isolated build dependency installation.
+
+## Local MLX Note
+
+An initial local run that imported `mlx.core` without workflow opt-in aborted the Python process on this machine. The smoke test now requires `PHOTON_RUN_MLX_SMOKE=1` before importing MLX, and the workflow sets that variable explicitly.

--- a/dev-reports/issue-14/design.md
+++ b/dev-reports/issue-14/design.md
@@ -1,0 +1,27 @@
+# Issue #14 Design: MCP / stdio adapter note
+
+## Goal
+
+Add a lightweight design note for non-HTTP integration paths so `photon-action-memory`
+can later support stdio and MCP clients without inventing a second contract beside
+the sidecar API schema.
+
+## Shape
+
+- Create a dedicated workspace note for the adapter policy.
+- Treat `photon_action_memory.api.schema` DTOs as the canonical payload contract
+  for HTTP, stdio, and MCP.
+- Define HTTP as the v0.1.0 runtime surface, stdio as a future local transport
+  wrapper, and MCP as a future tool/resource exposure layer over the same request,
+  response, event, summary, and evaluation schemas.
+- Keep privacy policy transport-neutral: adapters may only pass sanitized,
+  schema-valid DTOs and must not forward raw logs, prompts, tool stdout/stderr, or
+  secrets.
+
+## Scope boundaries
+
+This issue is documentation-only. v0.1.0 should not implement an MCP server,
+stdio protocol loop, transport negotiation, editor plugin, or adapter-specific
+storage. The design note should make those non-goals explicit so implementation
+issues can stay focused on schema, sanitizer, sidecar, fallback ranking, and
+shadow evaluation.

--- a/dev-reports/issue-14/implementation-summary.md
+++ b/dev-reports/issue-14/implementation-summary.md
@@ -1,0 +1,19 @@
+# Issue #14 Implementation Summary
+
+## Changed
+
+- Added `workspace/v0.1.0/mcp_stdio_adapter_design.md`.
+- Documented sidecar schema reuse for HTTP, stdio, and MCP adapters.
+- Defined responsibility boundaries for core service, HTTP localhost sidecar,
+  future stdio adapter, and future MCP adapter.
+- Documented transport-neutral privacy rules: no secret passthrough, no raw logs,
+  no raw prompt/tool stdout/stderr forwarding, and no full payload debug logging.
+- Listed v0.1.0 non-goals for stdio / MCP implementation.
+- Linked the design note from workspace docs and updated the extraction /
+  development preparation plans.
+
+## Not changed
+
+- No runtime adapter implementation was added.
+- No schema changes were made.
+- No tests were added because this issue is documentation-only.

--- a/dev-reports/issue-14/verification.md
+++ b/dev-reports/issue-14/verification.md
@@ -1,0 +1,15 @@
+# Issue #14 Verification
+
+## Checks
+
+- `python -m pytest -q`
+  - Result: passed
+  - Output: `67 passed in 0.85s`
+
+## Acceptance criteria
+
+- sidecar API schema reuse adapter policy: covered in
+  `workspace/v0.1.0/mcp_stdio_adapter_design.md` sections 2, 3, and 6.
+- HTTP / stdio / MCP responsibility boundaries: covered in section 3.
+- secret / raw log policy: covered in section 4.
+- v0.1.0 non-goals: covered in section 5.

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -20,7 +20,7 @@ from photon_action_memory.api.schema import (
     SuggestResponse,
 )
 from photon_action_memory.memory.store import SQLiteEventStore
-from photon_action_memory.models.photon_adapter import is_model_available
+from photon_action_memory.models.photon_adapter import score_suggestions_with_optional_adapter
 from photon_action_memory.ranking.fallback import build_ranked_suggestions
 from photon_action_memory.ranking.guards import fallback_warnings
 
@@ -75,12 +75,23 @@ def create_app(store: SQLiteEventStore | None = None) -> FastAPI:
 def build_fallback_suggestions(request: SuggestRequest) -> SuggestResponse:
     max_suggestions = max(0, request.budget.max_suggestions)
     evidence = _evidence_from_recent_events(request)
-    suggestions = build_ranked_suggestions(request, evidence=evidence, limit=max_suggestions)
-    warnings = fallback_warnings(request)
-    if not is_model_available():
+    fallback_suggestions = build_ranked_suggestions(
+        request,
+        evidence=evidence,
+        limit=max_suggestions,
+    )
+    adapter_result = score_suggestions_with_optional_adapter(
+        request,
+        evidence=evidence,
+        suggestions=fallback_suggestions,
+    )
+    if adapter_result is None:
+        suggestions = fallback_suggestions
         model_version = FALLBACK_MODEL_VERSION
+        warnings = fallback_warnings(request)
     else:
-        model_version = "photon-action-memory-v0.1.0"
+        suggestions, model_version = adapter_result
+        warnings = []
 
     return SuggestResponse(
         request_id=request.request_id,

--- a/photon_action_memory/models/checkpoint.py
+++ b/photon_action_memory/models/checkpoint.py
@@ -88,10 +88,7 @@ def _clean_state(raw_state: dict[str, Any], *, strict: bool) -> tuple[dict[str, 
         joined = ", ".join(unknown_keys)
         raise CheckpointInvalid(f"checkpoint state contains unknown keys: {joined}")
 
-    warnings = [
-        f"dropped unknown checkpoint state key: {key}"
-        for key in unknown_keys
-    ]
+    warnings = [f"dropped unknown checkpoint state key: {key}" for key in unknown_keys]
     return (
         {key: value for key, value in raw_state.items() if key in ALLOWED_STATE_KEYS},
         warnings,

--- a/photon_action_memory/models/checkpoint.py
+++ b/photon_action_memory/models/checkpoint.py
@@ -1,3 +1,98 @@
-"""Runtime checkpoint I/O placeholder."""
+"""Runtime checkpoint manifest I/O for optional PHOTON adapters."""
 
 from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+CHECKPOINT_FORMAT = "photon-action-memory.mlx.v1"
+CHECKPOINT_MANIFEST = "manifest.json"
+ALLOWED_STATE_KEYS = frozenset(
+    {
+        "action_weights",
+        "bias",
+        "evidence_weights",
+        "file_weights",
+    }
+)
+
+
+class CheckpointError(RuntimeError):
+    """Base class for checkpoint loading failures."""
+
+
+class CheckpointUnavailable(CheckpointError):
+    """Raised when a checkpoint path is absent or missing."""
+
+
+class CheckpointInvalid(CheckpointError):
+    """Raised when a checkpoint manifest cannot be used."""
+
+
+@dataclass(frozen=True)
+class PhotonCheckpoint:
+    """Validated checkpoint manifest for runtime scoring."""
+
+    path: Path
+    model_version: str
+    state: dict[str, object]
+    warnings: tuple[str, ...] = ()
+
+
+def load_checkpoint_manifest(path: str | Path, *, strict: bool = False) -> PhotonCheckpoint:
+    """Load and validate a small PHOTON runtime checkpoint manifest."""
+    manifest_path = _manifest_path(Path(path))
+    if not manifest_path.exists():
+        raise CheckpointUnavailable(f"checkpoint manifest not found: {manifest_path}")
+
+    try:
+        raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise CheckpointUnavailable(f"checkpoint manifest cannot be read: {manifest_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise CheckpointInvalid(f"checkpoint manifest is not valid JSON: {manifest_path}") from exc
+
+    if not isinstance(raw, dict):
+        raise CheckpointInvalid("checkpoint manifest must be a JSON object")
+    if raw.get("format") != CHECKPOINT_FORMAT:
+        raise CheckpointInvalid(f"checkpoint manifest format must be {CHECKPOINT_FORMAT!r}")
+
+    model_version = raw.get("model_version")
+    if not isinstance(model_version, str) or not model_version.strip():
+        raise CheckpointInvalid("checkpoint manifest requires a non-empty model_version")
+
+    state = raw.get("state", {})
+    if not isinstance(state, dict):
+        raise CheckpointInvalid("checkpoint state must be an object")
+
+    clean_state, warnings = _clean_state(state, strict=strict)
+    return PhotonCheckpoint(
+        path=manifest_path,
+        model_version=model_version.strip(),
+        state=clean_state,
+        warnings=tuple(warnings),
+    )
+
+
+def _manifest_path(path: Path) -> Path:
+    if path.is_dir():
+        return path / CHECKPOINT_MANIFEST
+    return path
+
+
+def _clean_state(raw_state: dict[str, Any], *, strict: bool) -> tuple[dict[str, object], list[str]]:
+    unknown_keys = sorted(set(raw_state) - ALLOWED_STATE_KEYS)
+    if unknown_keys and strict:
+        joined = ", ".join(unknown_keys)
+        raise CheckpointInvalid(f"checkpoint state contains unknown keys: {joined}")
+
+    warnings = [
+        f"dropped unknown checkpoint state key: {key}"
+        for key in unknown_keys
+    ]
+    return (
+        {key: value for key, value in raw_state.items() if key in ALLOWED_STATE_KEYS},
+        warnings,
+    )

--- a/photon_action_memory/models/checkpoint.py
+++ b/photon_action_memory/models/checkpoint.py
@@ -1,3 +1,191 @@
-"""Runtime checkpoint I/O placeholder."""
+"""Runtime-only checkpoint I/O boundary for the optional PHOTON adapter.
+
+This module intentionally uses only the Python standard library. Runtime paths
+can import it without importing training modules or optional MLX dependencies.
+"""
 
 from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from dataclasses import dataclass, field, fields
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+_logger = logging.getLogger(__name__)
+
+INTEGRITY_FORMAT_VERSION = "1"
+STATE_FILENAME = "state.json"
+WEIGHTS_FILENAME = "weights.npz"
+INTEGRITY_FILENAME = "integrity.json"
+
+
+@dataclass
+class CheckpointState:
+    """Runtime DTO for checkpoint ``state.json``.
+
+    The fields mirror the training state shape used by the reference PHOTON
+    checkpoint writer, while remaining independent from training-only modules.
+    """
+
+    step: int = 0
+    best_val_loss: float = float("inf")
+    best_step: int = 0
+    patience_counter: int = 0
+    train_losses: list[float] = field(default_factory=list)
+    val_losses: list[float] = field(default_factory=list)
+
+
+def load_checkpoint(path: str | Path, *, verify_integrity: bool = False) -> CheckpointState:
+    """Load checkpoint state from ``path``.
+
+    ``verify_integrity=True`` requires an integrity manifest. When false, a
+    missing manifest only emits a warning so legacy checkpoints can still be
+    probed. Hash mismatches always raise.
+    """
+
+    checkpoint_dir = Path(path)
+    verify_checkpoint_integrity(checkpoint_dir, strict=verify_integrity)
+    return load_checkpoint_state(checkpoint_dir)
+
+
+def load_checkpoint_state(path: str | Path) -> CheckpointState:
+    """Load and validate ``state.json`` without importing model code."""
+
+    state_path = Path(path) / STATE_FILENAME
+    try:
+        raw_state = json.loads(state_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{state_path} is not valid JSON") from exc
+
+    if not isinstance(raw_state, dict):
+        raise ValueError(f"{state_path} must decode to an object, got {type(raw_state).__name__}")
+
+    known_fields = {item.name for item in fields(CheckpointState)}
+    unknown_fields = sorted(set(raw_state) - known_fields)
+    if unknown_fields:
+        _logger.warning("Ignoring unknown checkpoint state keys: %s", unknown_fields)
+
+    filtered = {key: raw_state[key] for key in known_fields if key in raw_state}
+    return _checkpoint_state_from_mapping(filtered, state_path)
+
+
+def verify_checkpoint_integrity(path: str | Path, *, strict: bool = False) -> bool:
+    """Verify ``integrity.json`` hashes for ``state.json`` and ``weights.npz``.
+
+    Returns true when a manifest was present and matched. Returns false when the
+    manifest is absent in non-strict mode. Raises for strict missing manifests,
+    malformed manifests, missing hashed files, or hash mismatches.
+    """
+
+    checkpoint_dir = Path(path)
+    integrity_path = checkpoint_dir / INTEGRITY_FILENAME
+    if not integrity_path.exists():
+        if strict:
+            raise FileNotFoundError(
+                f"{INTEGRITY_FILENAME} missing at {integrity_path} with strict verification"
+            )
+        _logger.warning(
+            "%s missing at %s; checkpoint integrity cannot be verified",
+            INTEGRITY_FILENAME,
+            integrity_path,
+        )
+        return False
+
+    try:
+        manifest = json.loads(integrity_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{integrity_path} is not valid JSON") from exc
+    if not isinstance(manifest, dict):
+        raise ValueError(
+            f"{integrity_path} must decode to an object, got {type(manifest).__name__}"
+        )
+
+    expected_raw = {
+        WEIGHTS_FILENAME: manifest.get("weights_sha256"),
+        STATE_FILENAME: manifest.get("state_sha256"),
+    }
+    missing_hashes = [name for name, digest in expected_raw.items() if not isinstance(digest, str)]
+    if missing_hashes:
+        raise ValueError(
+            f"{integrity_path} missing SHA-256 entries for: {', '.join(missing_hashes)}"
+        )
+    expected = {name: str(digest) for name, digest in expected_raw.items()}
+
+    for filename, expected_digest in expected.items():
+        actual_digest = _sha256_file(checkpoint_dir / filename)
+        if actual_digest != expected_digest:
+            raise ValueError(
+                "checkpoint integrity check failed for "
+                f"{filename}: expected {expected_digest[:12]}, got {actual_digest[:12]}"
+            )
+    return True
+
+
+def write_integrity_manifest(path: str | Path) -> None:
+    """Write an integrity manifest for an existing runtime checkpoint."""
+
+    checkpoint_dir = Path(path)
+    manifest = {
+        "format_version": INTEGRITY_FORMAT_VERSION,
+        "created_at": datetime.now(UTC).isoformat(),
+        "weights_sha256": _sha256_file(checkpoint_dir / WEIGHTS_FILENAME),
+        "state_sha256": _sha256_file(checkpoint_dir / STATE_FILENAME),
+    }
+    integrity_path = checkpoint_dir / INTEGRITY_FILENAME
+    tmp_path = checkpoint_dir / f"{INTEGRITY_FILENAME}.tmp"
+    tmp_path.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+    os.replace(tmp_path, integrity_path)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(64 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _checkpoint_state_from_mapping(values: dict[str, Any], source: Path) -> CheckpointState:
+    coerced = _coerce_state_fields(values, source)
+    return CheckpointState(
+        step=coerced.get("step", 0),
+        best_val_loss=coerced.get("best_val_loss", float("inf")),
+        best_step=coerced.get("best_step", 0),
+        patience_counter=coerced.get("patience_counter", 0),
+        train_losses=coerced.get("train_losses", []),
+        val_losses=coerced.get("val_losses", []),
+    )
+
+
+def _coerce_state_fields(values: dict[str, Any], source: Path) -> dict[str, Any]:
+    coerced: dict[str, object] = {}
+    for key, value in values.items():
+        if key in {"step", "best_step", "patience_counter"}:
+            if not isinstance(value, int):
+                raise ValueError(f"{source} field {key!r} must be an integer")
+            coerced[key] = value
+            continue
+        if key == "best_val_loss":
+            if not isinstance(value, int | float):
+                raise ValueError(f"{source} field {key!r} must be numeric")
+            coerced[key] = float(value)
+            continue
+        if key in {"train_losses", "val_losses"}:
+            coerced[key] = _coerce_loss_list(value, source, key)
+            continue
+    return coerced
+
+
+def _coerce_loss_list(value: object, source: Path, key: str) -> list[float]:
+    if not isinstance(value, list):
+        raise ValueError(f"{source} field {key!r} must be a list")
+    losses: list[float] = []
+    for item in value:
+        if not isinstance(item, int | float):
+            raise ValueError(f"{source} field {key!r} must contain only numbers")
+        losses.append(float(item))
+    return losses

--- a/photon_action_memory/models/photon_adapter.py
+++ b/photon_action_memory/models/photon_adapter.py
@@ -1,8 +1,54 @@
-"""Optional PHOTON/MLX scoring adapter placeholder."""
+"""Optional PHOTON/MLX scoring adapter boundary."""
 
 from __future__ import annotations
 
+import importlib.util
+import logging
+import os
+from pathlib import Path
+
+from photon_action_memory.models.checkpoint import CheckpointState, load_checkpoint
+
+_logger = logging.getLogger(__name__)
+
+CHECKPOINT_ENV = "PHOTON_ACTION_MEMORY_CHECKPOINT"
+CHECKPOINT_STRICT_ENV = "PHOTON_ACTION_MEMORY_CHECKPOINT_STRICT"
+
 
 def is_model_available() -> bool:
-    """Return False until the optional PHOTON adapter is implemented."""
-    return False
+    """Return true only when optional runtime dependencies and checkpoint load."""
+
+    if importlib.util.find_spec("mlx") is None:
+        return False
+    return load_configured_checkpoint_state() is not None
+
+
+def load_configured_checkpoint_state() -> CheckpointState | None:
+    """Load configured checkpoint state, returning unavailable on failure."""
+
+    checkpoint_path = configured_checkpoint_path()
+    if checkpoint_path is None:
+        return None
+    try:
+        return load_checkpoint(checkpoint_path, verify_integrity=_strict_checkpoint_mode())
+    except (OSError, ValueError) as exc:
+        _logger.warning(
+            "PHOTON checkpoint at %s is unavailable; falling back to deterministic ranking: %s",
+            checkpoint_path,
+            exc,
+        )
+        return None
+
+
+def configured_checkpoint_path() -> Path | None:
+    """Return the configured checkpoint directory, if any."""
+
+    raw_path = os.environ.get(CHECKPOINT_ENV, "").strip()
+    if not raw_path:
+        return None
+    return Path(raw_path)
+
+
+def _strict_checkpoint_mode() -> bool:
+    raw_value = os.environ.get(CHECKPOINT_STRICT_ENV, "").strip().lower()
+    return raw_value in {"1", "true", "yes", "on", "strict"}

--- a/photon_action_memory/models/photon_adapter.py
+++ b/photon_action_memory/models/photon_adapter.py
@@ -1,8 +1,236 @@
-"""Optional PHOTON/MLX scoring adapter placeholder."""
+"""Optional PHOTON/MLX scoring adapter.
+
+This module must remain importable without MLX installed. MLX is imported only
+when a checkpoint is configured and the optional adapter is constructed.
+"""
 
 from __future__ import annotations
 
+import importlib
+import math
+import os
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from types import ModuleType
+from typing import Any
 
-def is_model_available() -> bool:
-    """Return False until the optional PHOTON adapter is implemented."""
-    return False
+from photon_action_memory.api.schema import EvidenceItem, Suggestion, SuggestRequest
+from photon_action_memory.models.checkpoint import (
+    CheckpointError,
+    PhotonCheckpoint,
+    load_checkpoint_manifest,
+)
+from photon_action_memory.models.state import (
+    ActionCandidate,
+    PhotonScoringState,
+    ScoredCandidate,
+    ScoredEvidence,
+    ScoredFile,
+)
+
+CHECKPOINT_ENV = "PHOTON_ACTION_MEMORY_CHECKPOINT"
+PHOTON_MODEL_VERSION = "photon-action-memory-v0.1.0-mlx"
+
+
+class PhotonAdapterError(RuntimeError):
+    """Base class for optional PHOTON adapter failures."""
+
+
+class MlxUnavailable(PhotonAdapterError):
+    """Raised when the optional MLX dependency is not installed."""
+
+
+class PhotonScoringUnavailable(PhotonAdapterError):
+    """Raised when model scoring cannot safely continue."""
+
+
+class PhotonMLXAdapter:
+    """Tiny optional MLX-backed scorer used to validate the runtime boundary."""
+
+    def __init__(self, checkpoint: PhotonCheckpoint, mlx_core: ModuleType | Any) -> None:
+        self.checkpoint = checkpoint
+        self._mx = mlx_core
+
+    @classmethod
+    def from_checkpoint(
+        cls,
+        path: str | Path,
+        *,
+        strict: bool = False,
+        import_module: Callable[[str], ModuleType | Any] | None = None,
+    ) -> PhotonMLXAdapter:
+        """Build an adapter after validating checkpoint and importing MLX lazily."""
+        checkpoint = load_checkpoint_manifest(path, strict=strict)
+        return cls(checkpoint=checkpoint, mlx_core=_import_mlx_core(import_module))
+
+    def score_actions(
+        self,
+        state: PhotonScoringState,
+        candidates: Sequence[ActionCandidate],
+    ) -> list[ScoredCandidate]:
+        """Score action candidates in input order."""
+        return [
+            ScoredCandidate(
+                candidate=candidate,
+                score=self._score(candidate.kind, candidate.subject, state),
+                reason=f"PHOTON MLX adapter scored {candidate.kind!r}.",
+            )
+            for candidate in candidates
+        ]
+
+    def score_files(self, state: PhotonScoringState, files: Sequence[str]) -> list[ScoredFile]:
+        """Score file candidates for the later MLX smoke workflow."""
+        return [
+            ScoredFile(
+                path=path,
+                score=self._score("file", path, state),
+                reason="PHOTON MLX adapter scored a file candidate.",
+            )
+            for path in files
+        ]
+
+    def score_evidence(
+        self,
+        state: PhotonScoringState,
+        evidence: Sequence[EvidenceItem],
+    ) -> list[ScoredEvidence]:
+        """Score evidence candidates for the later MLX smoke workflow."""
+        return [
+            ScoredEvidence(
+                evidence_id=item.id,
+                score=self._score("evidence", item.id, state),
+                reason="PHOTON MLX adapter scored an evidence item.",
+            )
+            for item in evidence
+        ]
+
+    def _score(self, kind: str, subject: str, state: PhotonScoringState) -> float:
+        base = _state_float(self.checkpoint.state.get("bias"), default=0.5)
+        score = base
+        score += _weight_for(self.checkpoint.state.get("action_weights"), kind)
+        score += _weight_for(self.checkpoint.state.get("file_weights"), subject)
+        score += _weight_for(self.checkpoint.state.get("evidence_weights"), subject)
+        if subject and subject in state.task_text:
+            score += 0.05
+
+        try:
+            value = self._mx.array([_clamp(score)], dtype=getattr(self._mx, "float32", None))
+        except Exception as exc:
+            raise PhotonScoringUnavailable("MLX scoring failed") from exc
+        return _array_scalar(value)
+
+
+def configured_checkpoint_path(environ: os._Environ[str] | None = None) -> Path | None:
+    """Return the configured adapter checkpoint path, if any."""
+    raw = (environ or os.environ).get(CHECKPOINT_ENV, "").strip()
+    if not raw:
+        return None
+    return Path(raw)
+
+
+def is_model_available(
+    checkpoint_path: str | Path | None = None,
+    *,
+    import_module: Callable[[str], ModuleType | Any] | None = None,
+) -> bool:
+    """Return true only when the optional MLX adapter can be constructed."""
+    path = Path(checkpoint_path) if checkpoint_path is not None else configured_checkpoint_path()
+    if path is None:
+        return False
+    try:
+        PhotonMLXAdapter.from_checkpoint(path, import_module=import_module)
+    except (CheckpointError, PhotonAdapterError):
+        return False
+    return True
+
+
+def score_suggestions_with_optional_adapter(
+    request: SuggestRequest,
+    *,
+    evidence: Sequence[EvidenceItem],
+    suggestions: Sequence[Suggestion],
+) -> tuple[list[Suggestion], str] | None:
+    """Score fallback-generated suggestions with the optional adapter when configured."""
+    checkpoint_path = configured_checkpoint_path()
+    if checkpoint_path is None or not suggestions:
+        return None
+
+    try:
+        adapter = PhotonMLXAdapter.from_checkpoint(checkpoint_path)
+        state = PhotonScoringState.from_sidecar_request(request, evidence=evidence)
+        action_candidates = [_candidate_from_suggestion(suggestion) for suggestion in suggestions]
+        scored = adapter.score_actions(state, action_candidates)
+    except (CheckpointError, PhotonAdapterError):
+        return None
+
+    score_by_index = {index: item.score for index, item in enumerate(scored)}
+    ordered = sorted(
+        enumerate(suggestions),
+        key=lambda item: (-score_by_index[item[0]], item[0]),
+    )
+    return (
+        [
+            suggestion.model_copy(
+                update={
+                    "confidence": max(suggestion.confidence, score_by_index[index]),
+                    "reason": f"{suggestion.reason} PHOTON MLX score: {score_by_index[index]:.3f}.",
+                }
+            )
+            for index, suggestion in ordered
+        ],
+        adapter.checkpoint.model_version or PHOTON_MODEL_VERSION,
+    )
+
+
+def _import_mlx_core(
+    import_module: Callable[[str], ModuleType | Any] | None = None,
+) -> ModuleType | Any:
+    importer = import_module or importlib.import_module
+    try:
+        return importer("mlx.core")
+    except ModuleNotFoundError as exc:
+        if exc.name in {"mlx", "mlx.core"}:
+            raise MlxUnavailable("optional dependency 'mlx' is not installed") from exc
+        raise
+
+
+def _candidate_from_suggestion(suggestion: Suggestion) -> ActionCandidate:
+    return ActionCandidate(
+        kind=suggestion.kind,
+        target=suggestion.target,
+        command=suggestion.command,
+        query=suggestion.query,
+        evidence_ids=tuple(suggestion.evidence_ids),
+    )
+
+
+def _weight_for(raw_weights: object, key: str) -> float:
+    if not isinstance(raw_weights, dict):
+        return 0.0
+    return _state_float(raw_weights.get(key), default=0.0)
+
+
+def _state_float(value: object, *, default: float) -> float:
+    if isinstance(value, int | float):
+        as_float = float(value)
+        if math.isfinite(as_float):
+            return as_float
+    return default
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def _array_scalar(value: object) -> float:
+    if hasattr(value, "item"):
+        raw_item = value.item()
+        if isinstance(raw_item, int | float | str):
+            return _clamp(float(raw_item))
+    if not isinstance(value, str) and isinstance(value, Sequence) and value:
+        first = value[0]
+        if isinstance(first, int | float | str):
+            return _clamp(float(first))
+    if isinstance(value, int | float | str):
+        return _clamp(float(value))
+    raise PhotonScoringUnavailable("MLX scoring did not return a scalar value")

--- a/photon_action_memory/models/state.py
+++ b/photon_action_memory/models/state.py
@@ -40,9 +40,7 @@ class PhotonScoringState:
             recent_event_summaries=tuple(
                 str(getattr(event, "summary", "") or "") for event in recent_events
             ),
-            evidence_summaries=tuple(
-                str(getattr(item, "summary", "") or "") for item in evidence
-            ),
+            evidence_summaries=tuple(str(getattr(item, "summary", "") or "") for item in evidence),
         )
 
 

--- a/photon_action_memory/models/state.py
+++ b/photon_action_memory/models/state.py
@@ -1,3 +1,89 @@
-"""Model-independent state DTO placeholder."""
+"""Model-independent DTOs for optional PHOTON scoring."""
 
 from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PhotonScoringState:
+    """Compact request state passed into optional model scorers."""
+
+    request_id: str
+    task_text: str
+    touched_files: tuple[str, ...] = ()
+    recent_event_summaries: tuple[str, ...] = ()
+    evidence_summaries: tuple[str, ...] = ()
+
+    @classmethod
+    def from_sidecar_request(
+        cls,
+        request: object,
+        *,
+        evidence: Sequence[object] = (),
+    ) -> PhotonScoringState:
+        """Build scoring state from a sidecar request without importing API DTOs."""
+        task = getattr(request, "task", None)
+        working_memory = getattr(request, "working_memory", None)
+        recent_events = getattr(request, "recent_events", ())
+        task_parts = (
+            str(getattr(task, "user_request", "") or ""),
+            str(getattr(task, "summary", "") or ""),
+        )
+        return cls(
+            request_id=str(getattr(request, "request_id", "") or ""),
+            task_text=" ".join(part for part in task_parts if part),
+            touched_files=tuple(
+                str(item) for item in getattr(working_memory, "touched_files", ()) if item
+            ),
+            recent_event_summaries=tuple(
+                str(getattr(event, "summary", "") or "") for event in recent_events
+            ),
+            evidence_summaries=tuple(
+                str(getattr(item, "summary", "") or "") for item in evidence
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class ActionCandidate:
+    """Action candidate that can be scored by PHOTON without API coupling."""
+
+    kind: str
+    target: str | None = None
+    command: str | None = None
+    query: str | None = None
+    evidence_ids: tuple[str, ...] = ()
+
+    @property
+    def subject(self) -> str:
+        """Return the most specific stable key for checkpoint scoring weights."""
+        return self.target or self.command or self.query or self.kind
+
+
+@dataclass(frozen=True)
+class ScoredCandidate:
+    """Model score for an action candidate."""
+
+    candidate: ActionCandidate
+    score: float
+    reason: str
+
+
+@dataclass(frozen=True)
+class ScoredFile:
+    """Model score for a file path."""
+
+    path: str
+    score: float
+    reason: str
+
+
+@dataclass(frozen=True)
+class ScoredEvidence:
+    """Model score for an evidence item."""
+
+    evidence_id: str
+    score: float
+    reason: str

--- a/scripts/codex_orchestrate.py
+++ b/scripts/codex_orchestrate.py
@@ -89,6 +89,14 @@ class WorkerSessionResult:
 
 
 @dataclass(frozen=True)
+class WorkerWaitResult:
+    issue_number: int
+    worktree_id: str
+    status: str
+    message: str
+
+
+@dataclass(frozen=True)
 class PullRequestResult:
     issue_number: int
     branch_name: str
@@ -175,6 +183,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--poll-commandmate", action="store_true")
     parser.add_argument("--codex-agent-name", default="")
     parser.add_argument("--commandmate-duration", default="3h")
+    parser.add_argument("--wait-commandmate-timeout", type=int, default=10800)
+    parser.add_argument("--wait-commandmate-stall-timeout", type=int, default=0)
     parser.add_argument("--repo", default="")
     parser.add_argument(
         "--integration-check",
@@ -1054,6 +1064,17 @@ def build_commandmate_send_command(
     return cmd
 
 
+def build_commandmate_ls_command(
+    *, branch_prefix: str | None = None, json_output: bool = True
+) -> list[str]:
+    cmd = ["commandmatedev", "ls"]
+    if branch_prefix:
+        cmd.extend(["--branch", branch_prefix])
+    if json_output:
+        cmd.append("--json")
+    return cmd
+
+
 def commandmate_worktree_id(branch_name: str) -> str:
     return f"{commandmate_repository_name()}-{branch_name.replace('/', '-')}"
 
@@ -1137,22 +1158,17 @@ def poll_worker_startup(
             commands,
         )
     if state["running"] is True and state["processing"] is False:
-        resume = ["commandmatedev", "send", worktree_id, "a"]
-        runner(resume, cwd=REPO_ROOT)
-        state = get_commandmate_state(worktree_id, codex_agent_name=codex_agent_name, runner=runner)
-        commands = (*commands, " ".join(resume))
-        if state["processing"] is True:
-            return WorkerSessionResult(
-                issue_number,
-                worktree_id,
-                "processing",
-                True,
-                state["running"],
-                "worker resumed after short prompt",
-                commands,
-            )
+        return WorkerSessionResult(
+            issue_number,
+            worktree_id,
+            "started-but-idle",
+            False,
+            True,
+            "worker session is running but not processing",
+            commands,
+        )
     if state["found"] is False:
-        message = "worktree session not found in CommandMate"
+        message = str(state.get("message") or "worktree session not found in CommandMate")
     else:
         message = "worker did not enter processing state"
     return WorkerSessionResult(
@@ -1168,14 +1184,34 @@ def poll_worker_startup(
 
 def get_commandmate_state(
     worktree_id: str, *, codex_agent_name: str, runner: Runner = run_command
-) -> dict[str, bool | None]:
-    completed = runner(["commandmatedev", "ls", "--json"], cwd=REPO_ROOT)
-    if completed.returncode != 0 or not completed.stdout.strip():
-        return {"found": False, "running": None, "processing": None}
+) -> dict[str, object]:
+    completed = runner(build_commandmate_ls_command(), cwd=REPO_ROOT)
+    if completed.returncode != 0:
+        return {
+            "found": False,
+            "running": None,
+            "processing": None,
+            "status": "unreachable",
+            "message": classify_commandmate_failure(completed),
+        }
+    if not completed.stdout.strip():
+        return {
+            "found": False,
+            "running": None,
+            "processing": None,
+            "status": "empty-response",
+            "message": "commandmatedev ls returned no output",
+        }
     try:
         raw = json.loads(completed.stdout)
     except json.JSONDecodeError:
-        return {"found": False, "running": None, "processing": None}
+        return {
+            "found": False,
+            "running": None,
+            "processing": None,
+            "status": "invalid-json",
+            "message": "commandmatedev ls returned invalid JSON",
+        }
     items = raw if isinstance(raw, list) else raw.get("worktrees", [])
     for item in items:
         if not isinstance(item, dict):
@@ -1207,8 +1243,87 @@ def get_commandmate_state(
             "found": True,
             "running": running,
             "processing": bool(processing) if processing is not None else None,
+            "status": "found",
+            "message": "worktree session found",
         }
-    return {"found": False, "running": None, "processing": None}
+    return {
+        "found": False,
+        "running": None,
+        "processing": None,
+        "status": "not-found",
+        "message": "worktree session not found in CommandMate",
+    }
+
+
+def classify_commandmate_failure(completed: subprocess.CompletedProcess[str]) -> str:
+    output = "\n".join(part for part in (completed.stderr, completed.stdout) if part).strip()
+    lowered = output.lower()
+    if (
+        "server is not running" in lowered
+        or "fetch failed" in lowered
+        or "econnrefused" in lowered
+        or "couldn't connect to server" in lowered
+    ):
+        return (
+            "commandmate-unreachable: local CommandMate HTTP endpoint could not be reached. "
+            "This can be a sandbox localhost access issue; do not infer server shutdown or start "
+            "CommandMate automatically."
+        )
+    return output or "commandmate command failed"
+
+
+def wait_for_commandmate_workers(
+    results: list[WorkerSessionResult],
+    *,
+    timeout_seconds: int,
+    stall_timeout_seconds: int,
+    runner: Runner = run_command,
+) -> list[WorkerWaitResult]:
+    wait_results: list[WorkerWaitResult] = []
+    for result in results:
+        if result.status not in {"sent", "processing", "started-but-idle"}:
+            continue
+        cmd = ["commandmatedev", "wait", result.worktree_id, "--timeout", str(timeout_seconds)]
+        if stall_timeout_seconds > 0:
+            cmd.extend(["--stall-timeout", str(stall_timeout_seconds)])
+        completed = runner(cmd, cwd=REPO_ROOT)
+        if completed.returncode == 0:
+            wait_results.append(
+                WorkerWaitResult(
+                    result.issue_number,
+                    result.worktree_id,
+                    "completed",
+                    completed.stdout.strip() or "worker completed",
+                )
+            )
+        else:
+            wait_results.append(
+                WorkerWaitResult(
+                    result.issue_number,
+                    result.worktree_id,
+                    "blocked",
+                    classify_commandmate_failure(completed),
+                )
+            )
+    return wait_results
+
+
+def render_worker_wait_report(results: list[WorkerWaitResult]) -> str:
+    lines = ["# CommandMate Wait Report", ""]
+    if not results:
+        return "# CommandMate Wait Report\n\nNo worker wait requested.\n"
+    for result in results:
+        lines.extend(
+            [
+                f"## Issue #{result.issue_number}",
+                "",
+                f"- Worktree ID: `{result.worktree_id}`",
+                f"- Status: `{result.status}`",
+                f"- Message: {result.message}",
+                "",
+            ]
+        )
+    return "\n".join(lines)
 
 
 def render_pr_body(analysis: IssueAnalysis, run_id: str) -> str:
@@ -1294,6 +1409,20 @@ def create_pull_requests(
                 )
             )
             continue
+        if not dry_run:
+            push = push_branch_to_origin(analysis.branch_name, runner=runner)
+            if push.returncode != 0:
+                results.append(
+                    PullRequestResult(
+                        issue_number=analysis.issue.number,
+                        branch_name=analysis.branch_name,
+                        status="blocked",
+                        pr_number=None,
+                        url=None,
+                        message=push.stderr.strip() or "branch push failed",
+                    )
+                )
+                continue
         existing = None if dry_run else find_existing_pr(analysis.branch_name, runner=runner)
         if existing is not None:
             results.append(
@@ -1335,17 +1464,45 @@ def create_pull_requests(
             )
             continue
         completed = runner(cmd, cwd=REPO_ROOT, check=True)
+        url = completed.stdout.strip() or None
         results.append(
             PullRequestResult(
                 issue_number=analysis.issue.number,
                 branch_name=analysis.branch_name,
                 status="created",
-                pr_number=None,
-                url=completed.stdout.strip() or None,
-                message="PR created",
+                pr_number=parse_pr_number(url or ""),
+                url=url,
+                message="branch pushed and PR created",
             )
         )
     return results
+
+
+def push_branch_to_origin(
+    branch_name: str, *, runner: Runner = run_command
+) -> subprocess.CompletedProcess[str]:
+    return runner(["git", "push", "-u", "origin", branch_name], cwd=REPO_ROOT)
+
+
+def parse_pr_number(value: str) -> int | None:
+    match = re.search(r"/pull/(\d+)(?:\D*$|$)", value)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def pr_numbers_for_merge(results: list[PullRequestResult]) -> list[int]:
+    numbers: list[int] = []
+    for result in results:
+        if result.status not in {"created", "existing"}:
+            continue
+        if result.pr_number is not None:
+            numbers.append(result.pr_number)
+            continue
+        parsed = parse_pr_number(result.url or "")
+        if parsed is not None:
+            numbers.append(parsed)
+    return numbers
 
 
 def branch_has_commits(branch_name: str, *, runner: Runner = run_command) -> bool:
@@ -1395,9 +1552,9 @@ def merge_pull_requests(
         if mergeable.status != "mergeable":
             results.append(mergeable)
             break
-        checks = runner(["gh", "pr", "checks", str(pr_number)], cwd=REPO_ROOT)
-        if checks.returncode != 0:
-            results.append(MergeResult(pr_number, "blocked", "CI checks failed or unavailable"))
+        checks = wait_for_pr_checks(pr_number, runner=runner)
+        if checks.status != "passed":
+            results.append(MergeResult(pr_number, "blocked", checks.message))
             break
         cmd = ["gh", "pr", "merge", str(pr_number)]
         if merge_method is not None:
@@ -1410,7 +1567,7 @@ def merge_pull_requests(
             break
         runner(["git", "pull", "--ff-only", "origin", "develop"], cwd=REPO_ROOT, check=True)
         verification = run_integration_checks(integration_checks, runner=runner)
-        if verification != "passed":
+        if verification.startswith("failed:"):
             results.append(
                 MergeResult(
                     pr_number,
@@ -1422,6 +1579,20 @@ def merge_pull_requests(
             break
         results.append(MergeResult(pr_number, "merged", "merged and develop updated", verification))
     return results
+
+
+def wait_for_pr_checks(pr_number: int, *, runner: Runner = run_command) -> MergeResult:
+    checks = runner(
+        ["gh", "pr", "checks", str(pr_number), "--watch", "--interval", "10"],
+        cwd=REPO_ROOT,
+    )
+    if checks.returncode != 0:
+        return MergeResult(
+            pr_number,
+            "blocked",
+            checks.stderr.strip() or "CI checks failed or unavailable",
+        )
+    return MergeResult(pr_number, "passed", "CI checks passed")
 
 
 def check_pr_mergeability(pr_number: int, *, runner: Runner = run_command) -> MergeResult:
@@ -1778,6 +1949,10 @@ def main() -> int:
 
     worktree_results: list[WorktreeResult] = []
     dispatch_results: list[WorkerSessionResult] = []
+    wait_results: list[WorkerWaitResult] = []
+    publish_requested = (
+        args.create_prs or args.merge_prs or (not dry_run and phase_at_least(args.phase, "pr"))
+    )
     if args.create_worktrees or (not dry_run and phase_at_least(args.phase, "dev")):
         worktree_results = create_or_reuse_worktrees(analyses, dry_run=dry_run)
         dispatch_results = dispatch_commandmate(
@@ -1806,7 +1981,7 @@ def main() -> int:
                         },
                     )
                 )
-            elif result.status in {"sent", "processing", "planned"}:
+            elif result.status in {"sent", "processing", "planned", "started-but-idle"}:
                 photon_results.append(
                     emit_photon_event(
                         args.photon_url,
@@ -1820,16 +1995,40 @@ def main() -> int:
                     )
                 )
 
-    if args.create_prs:
+    can_publish = True
+    if publish_requested and not dry_run and args.dispatch_commandmate and dispatch_results:
+        wait_results = wait_for_commandmate_workers(
+            dispatch_results,
+            timeout_seconds=args.wait_commandmate_timeout,
+            stall_timeout_seconds=args.wait_commandmate_stall_timeout,
+        )
+        (run_dir / "commandmate-wait-report.md").write_text(
+            render_worker_wait_report(wait_results),
+            encoding="utf-8",
+        )
+        can_publish = all(result.status == "completed" for result in wait_results)
+
+    pr_results: list[PullRequestResult] = []
+    if publish_requested and can_publish:
         pr_results = create_pull_requests(analyses, run_id=run_dir.name, dry_run=dry_run)
         (run_dir / "pr-report.md").write_text(render_pr_report(pr_results), encoding="utf-8")
+    elif publish_requested:
+        (run_dir / "pr-report.md").write_text(
+            "# PR Report\n\nSkipped because one or more CommandMate workers did not complete.\n",
+            encoding="utf-8",
+        )
 
-    if args.merge_prs:
+    merge_requested = args.merge_prs or (not dry_run and phase_at_least(args.phase, "merge"))
+    if merge_requested and can_publish:
         pr_numbers = [int(part.strip()) for part in args.pr_numbers.split(",") if part.strip()]
         if not pr_numbers:
-            pr_numbers = [analysis.issue.number for analysis in analyses] if dry_run else []
+            pr_numbers = (
+                [analysis.issue.number for analysis in analyses]
+                if dry_run
+                else pr_numbers_for_merge(pr_results)
+            )
         if not pr_numbers:
-            raise ValueError("--merge-prs requires --pr-numbers outside dry-run mode")
+            raise ValueError("merge phase requires created/existing PR numbers")
         merge_results = merge_pull_requests(
             pr_numbers,
             dry_run=dry_run,
@@ -1854,6 +2053,11 @@ def main() -> int:
                     },
                 )
             )
+    elif merge_requested:
+        (run_dir / "merge-report.md").write_text(
+            "# Merge Report\n\nSkipped because one or more CommandMate workers did not complete.\n",
+            encoding="utf-8",
+        )
 
     if args.write_uat or phase_at_least(args.phase, "uat"):
         (run_dir / "uat-report.md").write_text(render_uat_report(analyses), encoding="utf-8")

--- a/scripts/commandmate_codex.py
+++ b/scripts/commandmate_codex.py
@@ -72,13 +72,22 @@ def build_send_command(
     return cmd
 
 
+def build_ls_command(*, branch_prefix: str | None = None, json_output: bool = True) -> list[str]:
+    cmd = ["commandmatedev", "ls"]
+    if branch_prefix:
+        cmd.extend(["--branch", branch_prefix])
+    if json_output:
+        cmd.append("--json")
+    return cmd
+
+
 def command_to_display(cmd: list[str]) -> str:
     return " ".join(cmd)
 
 
 def list_sessions() -> list[WorktreeSession]:
     completed = subprocess.run(
-        ["commandmatedev", "ls", "--json"],
+        build_ls_command(),
         check=True,
         capture_output=True,
         text=True,

--- a/tests/integration/test_mlx_smoke.py
+++ b/tests/integration/test_mlx_smoke.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+
+from photon_action_memory.models.photon_adapter import is_model_available
+
+
+def test_mlx_import_and_tiny_scoring_smoke() -> None:
+    if os.environ.get("PHOTON_RUN_MLX_SMOKE") != "1":
+        pytest.skip("MLX smoke is opt-in outside the dedicated macOS workflow")
+
+    mx: Any = pytest.importorskip("mlx.core")
+
+    assert isinstance(is_model_available(), bool)
+
+    weights = mx.array([0.25, 0.75], dtype=mx.float32)
+    features = mx.array([2.0, 4.0], dtype=mx.float32)
+    score = mx.sum(weights * features)
+    mx.eval(score)
+
+    assert score.item() == pytest.approx(3.5)

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+from photon_action_memory.models.checkpoint import (
+    CheckpointState,
+    load_checkpoint,
+    load_checkpoint_state,
+    verify_checkpoint_integrity,
+    write_integrity_manifest,
+)
+from photon_action_memory.models.photon_adapter import (
+    CHECKPOINT_ENV,
+    load_configured_checkpoint_state,
+)
+
+
+def _write_checkpoint(
+    path: Path,
+    *,
+    state: dict[str, object] | None = None,
+    integrity: bool = True,
+) -> None:
+    path.mkdir()
+    (path / "weights.npz").write_bytes(b"runtime checkpoint weights")
+    (path / "state.json").write_text(
+        json.dumps(state if state is not None else {"step": 42, "best_val_loss": 1.25}),
+        encoding="utf-8",
+    )
+    if integrity:
+        write_integrity_manifest(path)
+
+
+def test_checkpoint_module_import_does_not_pull_training_or_mlx_modules() -> None:
+    for module_name in list(sys.modules):
+        if (
+            module_name == "mlx"
+            or module_name.startswith("mlx.")
+            or module_name == "photon_action_memory.training"
+            or module_name.startswith("photon_action_memory.training.")
+        ):
+            sys.modules.pop(module_name, None)
+    sys.modules.pop("photon_action_memory.models.checkpoint", None)
+
+    importlib.import_module("photon_action_memory.models.checkpoint")
+
+    assert "mlx" not in sys.modules
+    assert "photon_action_memory.training" not in sys.modules
+
+
+def test_load_checkpoint_reads_state_and_verifies_integrity(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "ckpt"
+    _write_checkpoint(
+        checkpoint_dir,
+        state={
+            "step": 200,
+            "best_val_loss": 0.75,
+            "best_step": 180,
+            "patience_counter": 2,
+            "train_losses": [1, 0.9],
+            "val_losses": [1.2, 0.8],
+        },
+    )
+
+    assert verify_checkpoint_integrity(checkpoint_dir, strict=True) is True
+    loaded = load_checkpoint(checkpoint_dir, verify_integrity=True)
+
+    assert loaded == CheckpointState(
+        step=200,
+        best_val_loss=0.75,
+        best_step=180,
+        patience_counter=2,
+        train_losses=[1.0, 0.9],
+        val_losses=[1.2, 0.8],
+    )
+
+
+def test_missing_integrity_warns_by_default_but_strict_mode_raises(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    checkpoint_dir = tmp_path / "ckpt"
+    _write_checkpoint(checkpoint_dir, integrity=False)
+
+    with caplog.at_level(logging.WARNING, logger="photon_action_memory.models.checkpoint"):
+        loaded = load_checkpoint(checkpoint_dir)
+
+    assert loaded.step == 42
+    assert any("integrity" in record.message for record in caplog.records)
+
+    with pytest.raises(FileNotFoundError):
+        load_checkpoint(checkpoint_dir, verify_integrity=True)
+
+
+def test_integrity_hash_mismatch_raises(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "ckpt"
+    _write_checkpoint(checkpoint_dir)
+    (checkpoint_dir / "state.json").write_text(json.dumps({"step": 999}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="integrity"):
+        load_checkpoint(checkpoint_dir)
+
+
+def test_unknown_state_keys_warn_and_drop(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    checkpoint_dir = tmp_path / "ckpt"
+    _write_checkpoint(
+        checkpoint_dir,
+        state={"step": 5, "future_state": "ignored"},
+        integrity=False,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="photon_action_memory.models.checkpoint"):
+        loaded = load_checkpoint_state(checkpoint_dir)
+
+    assert loaded == CheckpointState(step=5)
+    assert any("future_state" in record.message for record in caplog.records)
+    assert not hasattr(loaded, "future_state")
+
+
+def test_invalid_state_json_raises(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "ckpt"
+    _write_checkpoint(checkpoint_dir, state=[1, 2, 3], integrity=False)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="must decode to an object"):
+        load_checkpoint_state(checkpoint_dir)
+
+
+def test_adapter_returns_unavailable_for_missing_or_invalid_checkpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(CHECKPOINT_ENV, str(tmp_path / "missing"))
+    assert load_configured_checkpoint_state() is None
+
+    checkpoint_dir = tmp_path / "invalid"
+    _write_checkpoint(checkpoint_dir, integrity=False)
+    (checkpoint_dir / "state.json").write_text("{not json", encoding="utf-8")
+    monkeypatch.setenv(CHECKPOINT_ENV, str(checkpoint_dir))
+
+    assert load_configured_checkpoint_state() is None

--- a/tests/test_codex_orchestrate.py
+++ b/tests/test_codex_orchestrate.py
@@ -240,6 +240,28 @@ def test_commandmate_send_command_omits_agent_by_default() -> None:
     ]
 
 
+def test_commandmate_ls_command_omits_empty_branch_prefix() -> None:
+    module = load_script()
+
+    assert module.build_commandmate_ls_command(branch_prefix="feature/issue-") == [
+        "commandmatedev",
+        "ls",
+        "--branch",
+        "feature/issue-",
+        "--json",
+    ]
+    assert module.build_commandmate_ls_command(branch_prefix=None) == [
+        "commandmatedev",
+        "ls",
+        "--json",
+    ]
+    assert module.build_commandmate_ls_command(branch_prefix="") == [
+        "commandmatedev",
+        "ls",
+        "--json",
+    ]
+
+
 def test_commandmate_worktree_id_uses_commandmate_branch_format() -> None:
     module = load_script()
 
@@ -262,13 +284,13 @@ def test_commandmate_repository_name_strips_issue_worktree_suffix(
     assert module.commandmate_repository_name() == "photon-action-memory"
 
 
-def test_poll_worker_startup_resumes_stuck_worker() -> None:
+def test_poll_worker_startup_reports_started_idle_without_prompting() -> None:
     module = load_script()
     calls: list[list[str]] = []
 
     def fake_runner(args, **kwargs):  # type: ignore[no-untyped-def]
         calls.append(args)
-        if args == ["commandmatedev", "ls", "--json"] and len(calls) < 3:
+        if args == ["commandmatedev", "ls", "--json"]:
             return module.subprocess.CompletedProcess(
                 args,
                 0,
@@ -285,23 +307,6 @@ def test_poll_worker_startup_resumes_stuck_worker() -> None:
                 ),
                 "",
             )
-        if args == ["commandmatedev", "ls", "--json"]:
-            return module.subprocess.CompletedProcess(
-                args,
-                0,
-                json.dumps(
-                    {
-                        "worktrees": [
-                            {
-                                "id": "repo-issue-1",
-                                "status": "running",
-                                "isProcessing": True,
-                            }
-                        ]
-                    }
-                ),
-                "",
-            )
         return module.subprocess.CompletedProcess(args, 0, "", "")
 
     result = module.poll_worker_startup(
@@ -312,8 +317,112 @@ def test_poll_worker_startup_resumes_stuck_worker() -> None:
         runner=fake_runner,
     )
 
-    assert result.status == "processing"
-    assert ["commandmatedev", "send", "repo-issue-1", "a"] in calls
+    assert result.status == "started-but-idle"
+    assert result.message == "worker session is running but not processing"
+    assert result.running is True
+    assert result.processing is False
+    assert calls == [["commandmatedev", "ls", "--json"]]
+
+
+def test_poll_worker_startup_reports_commandmate_unreachable() -> None:
+    module = load_script()
+    calls: list[list[str]] = []
+
+    def fake_runner(args, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(args)
+        return module.subprocess.CompletedProcess(
+            args,
+            1,
+            "",
+            "Error: Server is not running. Start it with: commandmate start",
+        )
+
+    result = module.poll_worker_startup(
+        1,
+        "repo-issue-1",
+        codex_agent_name="",
+        commands=("hello", "task"),
+        runner=fake_runner,
+    )
+
+    assert result.status == "blocked"
+    assert result.message.startswith("commandmate-unreachable:")
+    assert result.running is None
+    assert result.processing is None
+    assert calls == [["commandmatedev", "ls", "--json"]]
+
+
+def test_wait_for_commandmate_workers_uses_wait_without_starting_server() -> None:
+    module = load_script()
+    calls: list[list[str]] = []
+    sessions = [
+        module.WorkerSessionResult(
+            11,
+            "repo-issue-11",
+            "started-but-idle",
+            False,
+            True,
+            "running",
+            (),
+        )
+    ]
+
+    def fake_runner(args, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(args)
+        return module.subprocess.CompletedProcess(args, 0, "completed\n", "")
+
+    results = module.wait_for_commandmate_workers(
+        sessions,
+        timeout_seconds=600,
+        stall_timeout_seconds=120,
+        runner=fake_runner,
+    )
+
+    assert results[0].status == "completed"
+    assert calls == [
+        [
+            "commandmatedev",
+            "wait",
+            "repo-issue-11",
+            "--timeout",
+            "600",
+            "--stall-timeout",
+            "120",
+        ]
+    ]
+
+
+def test_wait_for_commandmate_workers_classifies_unreachable() -> None:
+    module = load_script()
+    sessions = [
+        module.WorkerSessionResult(
+            11,
+            "repo-issue-11",
+            "sent",
+            None,
+            None,
+            "sent",
+            (),
+        )
+    ]
+
+    def fake_runner(args, **kwargs):  # type: ignore[no-untyped-def]
+        return module.subprocess.CompletedProcess(
+            args,
+            1,
+            "",
+            "Error: Server is not running. Start it with: commandmate start",
+        )
+
+    results = module.wait_for_commandmate_workers(
+        sessions,
+        timeout_seconds=600,
+        stall_timeout_seconds=0,
+        runner=fake_runner,
+    )
+
+    assert results[0].status == "blocked"
+    assert results[0].message.startswith("commandmate-unreachable:")
 
 
 def test_render_uat_report_includes_manual_evidence() -> None:
@@ -397,3 +506,92 @@ def test_render_pr_body_contains_required_sections() -> None:
     assert "Closes #6" in body
     assert "## Tests Run" in body
     assert "run-1" in body
+
+
+def test_create_pull_requests_pushes_branch_before_develop_pr() -> None:
+    module = load_script()
+    issue = module.Issue(
+        number=11,
+        title="[P2] Add adapter",
+        body="Update `photon_action_memory/models/photon_adapter.py`.",
+    )
+    analysis = module.analyze_issue(issue, "photon-action-memory", skip_enhance=True)
+    calls: list[list[str]] = []
+
+    def fake_runner(args, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(args)
+        if args[:3] == ["git", "rev-list", "--count"]:
+            return module.subprocess.CompletedProcess(args, 0, "1\n", "")
+        if args[:3] == ["git", "push", "-u"]:
+            return module.subprocess.CompletedProcess(args, 0, "", "")
+        if args[:3] == ["gh", "pr", "list"]:
+            return module.subprocess.CompletedProcess(args, 0, "[]\n", "")
+        if args[:3] == ["gh", "pr", "create"]:
+            return module.subprocess.CompletedProcess(
+                args,
+                0,
+                "https://github.com/Kewton/photon-action-memory/pull/42\n",
+                "",
+            )
+        return module.subprocess.CompletedProcess(args, 1, "", "unexpected")
+
+    results = module.create_pull_requests(
+        [analysis],
+        run_id="run-1",
+        dry_run=False,
+        runner=fake_runner,
+    )
+
+    assert results[0].status == "created"
+    assert results[0].pr_number == 42
+    assert ["git", "push", "-u", "origin", analysis.branch_name] in calls
+    assert calls.index(["git", "push", "-u", "origin", analysis.branch_name]) < next(
+        index for index, call in enumerate(calls) if call[:3] == ["gh", "pr", "create"]
+    )
+
+
+def test_pr_numbers_for_merge_uses_created_and_existing_prs() -> None:
+    module = load_script()
+    results = [
+        module.PullRequestResult(11, "feature/issue-11", "created", None, "https://x/pull/42", ""),
+        module.PullRequestResult(12, "feature/issue-12", "existing", 43, "https://x/pull/43", ""),
+        module.PullRequestResult(13, "feature/issue-13", "blocked", 44, "https://x/pull/44", ""),
+    ]
+
+    assert module.pr_numbers_for_merge(results) == [42, 43]
+
+
+def test_merge_pull_requests_waits_for_ci_before_merge() -> None:
+    module = load_script()
+    calls: list[list[str]] = []
+
+    def fake_runner(args, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(args)
+        if args[:3] == ["gh", "pr", "view"]:
+            return module.subprocess.CompletedProcess(
+                args,
+                0,
+                json.dumps({"isDraft": False, "mergeStateStatus": "CLEAN", "number": 42}),
+                "",
+            )
+        if args[:3] == ["gh", "pr", "checks"]:
+            return module.subprocess.CompletedProcess(args, 0, "checks passed\n", "")
+        if args[:3] == ["gh", "pr", "merge"]:
+            return module.subprocess.CompletedProcess(args, 0, "", "")
+        if args[:3] == ["git", "pull", "--ff-only"]:
+            return module.subprocess.CompletedProcess(args, 0, "", "")
+        return module.subprocess.CompletedProcess(args, 1, "", "unexpected")
+
+    results = module.merge_pull_requests(
+        [42],
+        dry_run=False,
+        merge_method="squash",
+        integration_checks=[],
+        runner=fake_runner,
+    )
+
+    assert results[0].status == "merged"
+    assert ["gh", "pr", "checks", "42", "--watch", "--interval", "10"] in calls
+    assert calls.index(["gh", "pr", "checks", "42", "--watch", "--interval", "10"]) < calls.index(
+        ["gh", "pr", "merge", "42", "--squash"]
+    )

--- a/tests/test_commandmate_codex.py
+++ b/tests/test_commandmate_codex.py
@@ -49,3 +49,17 @@ def test_build_send_command_defaults_to_no_agent() -> None:
 
     assert "--agent" not in cmd
     assert cmd[:4] == ["commandmatedev", "send", "repo-issue-1", "hello"]
+
+
+def test_build_ls_command_omits_empty_branch_prefix() -> None:
+    module = load_script()
+
+    assert module.build_ls_command(branch_prefix="feature/issue-") == [
+        "commandmatedev",
+        "ls",
+        "--branch",
+        "feature/issue-",
+        "--json",
+    ]
+    assert module.build_ls_command(branch_prefix=None) == ["commandmatedev", "ls", "--json"]
+    assert module.build_ls_command(branch_prefix="") == ["commandmatedev", "ls", "--json"]

--- a/tests/test_photon_adapter.py
+++ b/tests/test_photon_adapter.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from photon_action_memory import SCHEMA_VERSION
+from photon_action_memory.api.schema import EvidenceItem, SuggestRequest
+from photon_action_memory.api.server import build_fallback_suggestions
+from photon_action_memory.models.checkpoint import (
+    CHECKPOINT_FORMAT,
+    CheckpointInvalid,
+    load_checkpoint_manifest,
+)
+from photon_action_memory.models.photon_adapter import (
+    CHECKPOINT_ENV,
+    MlxUnavailable,
+    PhotonMLXAdapter,
+    configured_checkpoint_path,
+    is_model_available,
+)
+from photon_action_memory.models.state import ActionCandidate, PhotonScoringState
+
+
+class _FakeArray(list[float]):
+    def item(self) -> float:
+        return self[0]
+
+
+class _FakeMlx:
+    float32 = "float32"
+
+    def array(self, values: list[float], *, dtype: object | None = None) -> _FakeArray:
+        return _FakeArray(values)
+
+
+def _request(*, user_request: str = "read src/high.py") -> SuggestRequest:
+    return SuggestRequest.model_validate(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "request_id": "req-photon-adapter",
+            "agent": {"name": "codex"},
+            "repo": {"root": "/repo", "name": "example"},
+            "task": {"user_request": user_request, "mode": "act"},
+            "working_memory": {"touched_files": ["src/low.py", "src/high.py"]},
+            "recent_events": [],
+            "budget": {"max_suggestions": 2, "max_evidence_chars": 4000},
+        }
+    )
+
+
+def _write_manifest(path: Path, *, state: dict[str, object] | None = None) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "format": CHECKPOINT_FORMAT,
+                "model_version": "photon-test-mlx",
+                "state": state or {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_default_import_path_does_not_require_mlx(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(CHECKPOINT_ENV, raising=False)
+
+    assert configured_checkpoint_path() is None
+    assert is_model_available() is False
+
+
+def test_missing_mlx_dependency_is_model_unavailable(tmp_path: Path) -> None:
+    checkpoint = _write_manifest(tmp_path / "manifest.json")
+
+    assert is_model_available(checkpoint, import_module=lambda _name: _raise_mlx()) is False
+
+
+def test_checkpoint_manifest_drops_unknown_state_keys(tmp_path: Path) -> None:
+    checkpoint = _write_manifest(tmp_path / "manifest.json", state={"bias": 0.4, "extra": 1})
+
+    manifest = load_checkpoint_manifest(checkpoint)
+
+    assert manifest.state == {"bias": 0.4}
+    assert manifest.warnings == ("dropped unknown checkpoint state key: extra",)
+
+
+def test_checkpoint_manifest_strict_mode_rejects_unknown_state_keys(tmp_path: Path) -> None:
+    checkpoint = _write_manifest(tmp_path / "manifest.json", state={"bias": 0.4, "extra": 1})
+
+    with pytest.raises(CheckpointInvalid, match="unknown keys"):
+        load_checkpoint_manifest(checkpoint, strict=True)
+
+
+def test_adapter_raises_typed_error_when_mlx_missing(tmp_path: Path) -> None:
+    checkpoint = _write_manifest(tmp_path / "manifest.json")
+
+    with pytest.raises(MlxUnavailable):
+        PhotonMLXAdapter.from_checkpoint(checkpoint, import_module=lambda _name: _raise_mlx())
+
+
+def test_fake_mlx_smoke_scores_actions_files_and_evidence(tmp_path: Path) -> None:
+    checkpoint = _write_manifest(
+        tmp_path / "manifest.json",
+        state={
+            "bias": 0.1,
+            "action_weights": {"read": 0.2},
+            "file_weights": {"src/high.py": 0.4},
+            "evidence_weights": {"evt_001": 0.3},
+        },
+    )
+    adapter = PhotonMLXAdapter.from_checkpoint(
+        checkpoint,
+        import_module=lambda _name: _FakeMlx(),
+    )
+    state = PhotonScoringState(request_id="req", task_text="read src/high.py")
+
+    actions = adapter.score_actions(
+        state,
+        [
+            ActionCandidate(kind="read", target="src/low.py"),
+            ActionCandidate(kind="read", target="src/high.py"),
+        ],
+    )
+    files = adapter.score_files(state, ["src/high.py"])
+    evidence = adapter.score_evidence(
+        state,
+        [EvidenceItem(id="evt_001", kind="tool_result", summary="opened src/high.py")],
+    )
+
+    assert actions[0].score == pytest.approx(0.3)
+    assert actions[1].score == pytest.approx(0.75)
+    assert files[0].score == pytest.approx(0.55)
+    assert evidence[0].score == pytest.approx(0.4)
+
+
+def test_suggest_falls_back_when_configured_checkpoint_is_invalid(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkpoint = tmp_path / "bad.json"
+    checkpoint.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv(CHECKPOINT_ENV, str(checkpoint))
+
+    response = build_fallback_suggestions(_request())
+
+    assert response.model_version == "photon-action-memory-v0.1.0-fallback"
+    assert response.suggestions[0].target == "src/high.py"
+    assert [warning.kind for warning in response.warnings] == ["model_unavailable"]
+
+
+def test_suggest_uses_configured_fake_mlx_checkpoint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkpoint = _write_manifest(
+        tmp_path / "manifest.json",
+        state={"bias": 0.1, "file_weights": {"src/high.py": 0.7}},
+    )
+    monkeypatch.setenv(CHECKPOINT_ENV, str(checkpoint))
+    monkeypatch.setattr(
+        "photon_action_memory.models.photon_adapter.importlib.import_module",
+        lambda _name: _FakeMlx(),
+    )
+
+    response = build_fallback_suggestions(_request(user_request="choose next file"))
+
+    assert response.model_version == "photon-test-mlx"
+    assert response.suggestions[0].target == "src/high.py"
+    assert response.suggestions[0].confidence == pytest.approx(0.8)
+    assert response.warnings == []
+
+
+def _raise_mlx() -> SimpleNamespace:
+    raise ModuleNotFoundError("No module named 'mlx'", name="mlx")

--- a/workspace/v0.1.0/01_spec_requirements_architecture.md
+++ b/workspace/v0.1.0/01_spec_requirements_architecture.md
@@ -81,6 +81,8 @@ metrics report に含めない。
 ### 5.1 Sidecar API
 
 v0.1.0 では HTTP localhost を主経路とし、将来 stdio / MCP adapter を追加できる形にする。
+adapter 方針は `workspace/v0.1.0/mcp_stdio_adapter_design.md` に固定し、HTTP /
+stdio / MCP は同じ sidecar API schema を再利用する transport として扱う。
 
 必須 endpoint:
 

--- a/workspace/v0.1.0/02_branch_strategy_ci.md
+++ b/workspace/v0.1.0/02_branch_strategy_ci.md
@@ -68,7 +68,7 @@ Anvil は以下の構成を採用している。
 
 | Job | Trigger | 目的 |
 | --- | --- | --- |
-| `mlx-smoke` | `develop` push / nightly / manual | macOS runner で MLX import + tiny inference smoke |
+| `mlx-smoke` | `develop` push / nightly / manual | macOS runner で MLX import + tiny scoring smoke |
 | `integration-anvil-schema` | PR label / manual | Anvil request fixture との schema compatibility |
 | `eval-shadow` | nightly / manual | fixed fixture に対する suggestion metric |
 | `release` | tag `v*` | wheel / sdist publish artifact 作成 |

--- a/workspace/v0.1.0/03_photon_mlx_extraction_plan.md
+++ b/workspace/v0.1.0/03_photon_mlx_extraction_plan.md
@@ -114,6 +114,7 @@ photon_action_memory/
 
 - Anvil から呼べる API contract を先に固定する
 - PHOTON model なしでも有用な suggestion を返す
+- HTTP / stdio / MCP adapter が同じ sidecar schema を再利用できるようにする
 
 成果物:
 
@@ -122,6 +123,7 @@ photon_action_memory/
 - file / command / query candidate extractor
 - deterministic ranking fallback
 - fail-open behavior
+- MCP / stdio adapter design note
 
 ### Stage 2: Event store and exporter migration
 
@@ -197,6 +199,11 @@ v0.1.x では schema version を必ず含める。
 - enum 値追加は minor version 扱い
 - required field 削除 / rename は破壊的変更
 - 破壊的変更は `v0.2.0` 以降に回す
+
+HTTP / stdio / MCP は transport adapter として扱い、別 schema を作らない。
+adapter 固有の envelope は canonical DTO の外側に置き、payload body は
+`photon_action_memory.api.schema` の request / response / event / evaluation
+contract を再利用する。詳細は `mcp_stdio_adapter_design.md` にまとめる。
 
 ## 6. データ移行ポリシー
 

--- a/workspace/v0.1.0/05_development_preparation_plan.md
+++ b/workspace/v0.1.0/05_development_preparation_plan.md
@@ -528,8 +528,8 @@ shadow-mode log schema:
 
 ### Phase 5: Model and eval
 
-- [ ] [#11](https://github.com/Kewton/photon-action-memory/issues/11) MLX optional extra
-- [ ] [#11](https://github.com/Kewton/photon-action-memory/issues/11) PHOTON adapter interface
+- [x] [#11](https://github.com/Kewton/photon-action-memory/issues/11) MLX optional extra
+- [x] [#11](https://github.com/Kewton/photon-action-memory/issues/11) PHOTON adapter interface
 - [ ] [#12](https://github.com/Kewton/photon-action-memory/issues/12) checkpoint I/O
 - [ ] [#13](https://github.com/Kewton/photon-action-memory/issues/13) macOS smoke workflow
 - [x] [#9](https://github.com/Kewton/photon-action-memory/issues/9) offline eval runner

--- a/workspace/v0.1.0/05_development_preparation_plan.md
+++ b/workspace/v0.1.0/05_development_preparation_plan.md
@@ -241,12 +241,14 @@ photon_action_memory/
 - `mypy photon_action_memory tests`
 - `pytest -q`
 - `python -m build`
+- macOS MLX smoke は `develop` push / nightly / manual で標準 Ubuntu CI から分離する。
 
 完了条件:
 
 - 空の package を import できる。
 - CI workflow が Ubuntu で通る構成になっている。
 - MLX が未インストールでも import / tests が通る。
+- MLX 導入済み macOS runner で tiny scoring smoke が通る。
 - PR template に schema / sanitizer / fail-open 確認項目がある。
 
 ## 7. M1 Schema First 詳細計画

--- a/workspace/v0.1.0/05_development_preparation_plan.md
+++ b/workspace/v0.1.0/05_development_preparation_plan.md
@@ -480,6 +480,38 @@ shadow-mode log schema:
 - adoption / ignored / outcome を追跡できる。
 - eval runner は raw log を直接吐かない。
 
+## 12.5 MCP / stdio Adapter Design Note
+
+Issue #14 では、HTTP localhost sidecar 以外の統合経路として
+`workspace/v0.1.0/mcp_stdio_adapter_design.md` を追加する。
+
+adapter 方針:
+
+- `photon_action_memory.api.schema` の DTO を HTTP / stdio / MCP 共通の
+  canonical schema として再利用する。
+- HTTP は v0.1.0 の実装対象 transport とし、JSON encoding、status code、
+  timeout、health check を担当する。
+- stdio は将来の local child-process integration 用 transport とし、stdin /
+  stdout の envelope だけを担当する。
+- MCP は将来の tool / resource integration layer とし、tool arguments と
+  canonical DTO の変換、capability discovery、tool result formatting を担当する。
+- sanitizer、event store、ranking、PHOTON scorer、shadow evaluation は core
+  service の責務であり、adapter に重複実装しない。
+- secret、raw conversation log、prompt、tool stdout/stderr、absolute user path
+  を adapter 経由で渡さない。adapter debug log や error にも raw payload を
+  出さない。
+
+v0.1.0 で実装しない範囲:
+
+- stdio adapter process
+- MCP server
+- MCP resource exposure
+- adapter-specific schema / storage
+- remote MCP / remote sidecar deployment
+- raw log streaming
+- secret passthrough mode
+- adapter 経由の online training
+
 ## 13. 実装順チェックリスト
 
 ### Phase 0: Repository bootstrap
@@ -534,6 +566,7 @@ shadow-mode log schema:
 - [ ] [#13](https://github.com/Kewton/photon-action-memory/issues/13) macOS smoke workflow
 - [x] [#9](https://github.com/Kewton/photon-action-memory/issues/9) offline eval runner
 - [ ] [#10](https://github.com/Kewton/photon-action-memory/issues/10) Anvil shadow contract
+- [x] [#14](https://github.com/Kewton/photon-action-memory/issues/14) MCP / stdio adapter design note
 
 ## 14. 初回 PR の推奨スコープ
 

--- a/workspace/v0.1.0/README.md
+++ b/workspace/v0.1.0/README.md
@@ -17,6 +17,7 @@
 | `03_photon_mlx_extraction_plan.md` | `photon-mlx` からの切り出し計画 |
 | `04_work_plan.md` | v0.1.0 作業計画 |
 | `05_development_preparation_plan.md` | `photon-mlx-develop` 実ソース参照後の開発準備作業計画 |
+| `mcp_stdio_adapter_design.md` | MCP / stdio adapter の責務境界と non-goals |
 
 ## v0.1.0 の基本方針
 

--- a/workspace/v0.1.0/mcp_stdio_adapter_design.md
+++ b/workspace/v0.1.0/mcp_stdio_adapter_design.md
@@ -1,0 +1,136 @@
+# MCP / stdio adapter design note
+
+## 1. 目的
+
+v0.1.0 の主経路は HTTP localhost sidecar である。一方で、Codex 系 agent や
+editor / orchestration runtime からの統合では、HTTP を直接呼ぶより stdio や
+MCP tool として公開する方が扱いやすい場合がある。
+
+このメモは、将来の stdio / MCP adapter が既存 sidecar API schema を再利用し、
+transport ごとに別 contract を増やさないための責務境界を固定する。
+
+## 2. 基本方針
+
+- `photon_action_memory.api.schema` の DTO を canonical schema とする。
+- HTTP / stdio / MCP は transport adapter であり、action memory の business
+  logic を持たない。
+- adapter は transport 固有の envelope を canonical DTO に変換し、schema
+  validation 後に core service へ渡す。
+- `schema_version`、`request_id`、`session_id`、`sidecar_status`、warning
+  形式は transport によらず同じ意味で扱う。
+- Anvil や特定 agent の拡張情報は `agent` と `metadata` に閉じ込め、core
+  schema を adapter 固有にしない。
+
+## 3. 責務境界
+
+### Core service
+
+Core service は transport 非依存の処理を担当する。
+
+- schema validation
+- sanitizer
+- event store append / read
+- deterministic fallback ranking
+- optional PHOTON scorer 呼び出し
+- shadow evaluation record handling
+- fail-open response shape の生成
+
+### HTTP localhost sidecar
+
+HTTP は v0.1.0 の唯一の実装対象 transport とする。
+
+- `GET /health`
+- `POST /v1/events`
+- `POST /v1/suggest`
+- `POST /v1/summarize`
+- `POST /v1/evaluate`
+
+HTTP layer は request / response の JSON encoding、status code、timeout、
+local process health check を扱う。ranking、storage、redaction policy は
+core service に委譲する。
+
+### stdio adapter
+
+stdio adapter は将来の local child-process integration 用 transport とする。
+
+- stdin から request envelope を受け取り、stdout に response envelope を返す。
+- payload body は HTTP endpoint と同じ canonical DTO を使う。
+- adapter 固有 field は `method`、`id`、`payload` などの envelope に限定する。
+- long-running session state や event store を adapter 内に持たない。
+- stderr は diagnostics 専用にし、payload、secret、raw log を出さない。
+
+stdio adapter の想定 mapping:
+
+| stdio method | canonical DTO / operation |
+| --- | --- |
+| `health` | health response |
+| `events.append` | `EventRequest` / `/v1/events` 相当 |
+| `suggest` | `SuggestRequest` / `SuggestResponse` |
+| `summarize` | summarize request / response contract |
+| `evaluate` | `EvaluateRequest` / evaluation response contract |
+
+### MCP adapter
+
+MCP adapter は将来の tool / resource integration layer とする。
+
+- MCP tool arguments を canonical DTO に変換する。
+- MCP tool result は canonical response DTO を JSON として返す。
+- MCP の tool description / capability discovery は adapter が担当する。
+- suggestion、event persistence、ranking、sanitizer は core service に委譲する。
+- raw session history や raw tool output を MCP resource として公開しない。
+
+MCP tool の想定 mapping:
+
+| MCP tool | canonical DTO / operation |
+| --- | --- |
+| `photon_health` | health response |
+| `photon_record_event` | `EventRequest` / `/v1/events` 相当 |
+| `photon_suggest` | `SuggestRequest` / `SuggestResponse` |
+| `photon_summarize` | summarize request / response contract |
+| `photon_evaluate` | `EvaluateRequest` / evaluation response contract |
+
+## 4. Privacy / safety policy
+
+adapter は secret や raw log を迂回路として渡してはならない。
+
+- raw conversation log、prompt、tool stdout/stderr、command transcript をそのまま
+  payload に入れない。
+- API key、token、password、credential、署名付き URL、absolute user home path
+  を raw のまま渡さない。
+- adapter debug log に request / response payload 全体を出さない。
+- validation error や transport error は raw payload を echo しない。
+- 永続化前の sanitizer 適用は HTTP / stdio / MCP で同じ rule にする。
+- adapter が受け取る `recent_events` は sanitized summary / artifact reference
+  に限定する。
+
+この方針により、HTTP を使わない統合経路でも event store、dataset exporter、
+eval runner の privacy boundary を弱めない。
+
+## 5. v0.1.0 で実装しない範囲
+
+Issue #14 は design note のみを追加する。v0.1.0 では以下を実装しない。
+
+- stdio adapter process
+- MCP server
+- MCP resource exposure
+- adapter-specific schema
+- adapter-specific event store
+- remote MCP / remote sidecar deployment
+- transport negotiation
+- editor plugin integration
+- raw log streaming
+- secret passthrough mode
+- adapter 経由の online training
+
+v0.1.0 の実装優先度は、canonical schema、sanitizer、local HTTP sidecar、
+deterministic fallback、shadow evaluation の順に維持する。
+
+## 6. 将来の実装チェック
+
+stdio / MCP 実装 issue では、最低限以下を確認する。
+
+- HTTP fixture と同じ `SuggestRequest` / `SuggestResponse` が round-trip する。
+- adapter envelope を外すと canonical DTO として validation できる。
+- secret / absolute path / raw tool output が adapter log に残らない。
+- sidecar unavailable 時も fail-open response shape を返す。
+- adapter 側に ranking / storage logic が重複していない。


### PR DESCRIPTION
## Summary
- Stop sending the artificial `a` prompt during CommandMate worker startup polling.
- Report idle or unreachable CommandMate sessions explicitly instead of starting/stopping the server or inferring shutdown from sandboxed localhost failures.
- Extend orchestration publishing to push branches, create develop PRs, wait for CI, and merge when the merge phase is requested.

## Verification
- `python -m pytest -q tests/test_codex_orchestrate.py tests/test_commandmate_codex.py`

## Notes
- Untracked local files such as `.env`, `data/`, and `workspace/` artifacts were not included in this commit.