### PR TITLE
Add release workflow and MIT license

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,37 @@
+---
+description: "PHOTON Action Memory のリリースPR、タグ、GitHub Releaseを作成する"
+argument-hint: "patch|minor|major|X.Y.Z"
+---
+
+# Release Command
+
+`/release` は PHOTON Action Memory のリリースを作成するためのコマンドです。
+
+詳細な手順と安全ルールは `.codex/skills/release/SKILL.md` を正とします。
+
+## 使用方法
+
+```bash
+/release patch
+/release minor
+/release major
+/release 1.2.3
+```
+
+## 実行方針
+
+- `main` を release base にする。
+- `release/vX.Y.Z` branch を作成する。
+- `pyproject.toml` と `photon_action_memory/__init__.py` の version を更新する。
+- `CHANGELOG.md` を更新する。
+- `ruff format --check .`、`ruff check .`、`mypy photon_action_memory tests`、
+  `pytest -q`、`python -m build` を通す。
+- release PR を `main` 向けに作成する。
+- PR が `main` に merge された後で `vX.Y.Z` tag を push する。
+- tag push により `.github/workflows/release.yml` が GitHub Release を作成する。
+
+## 注意
+
+- CommandMate の start/stop はユーザーが明示した場合だけ行う。
+- `.env`、local DB、raw logs、workspace run artifacts は release commit に含めない。
+- tag 作成は release PR merge 後に行う。

--- a/.codex/skills/release/SKILL.md
+++ b/.codex/skills/release/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: release
+description: Create a PHOTON Action Memory release branch, version bump, changelog update, tag, and GitHub Release.
+---
+
+# Release
+
+Use this skill when the user invokes:
+
+- `/release patch`
+- `/release minor`
+- `/release major`
+- `/release <version>`
+
+This repository releases from `main`. Normal feature work may flow through
+`develop`, but release tags must point at code already merged to `main` or at a
+release PR merged into `main`.
+
+## Safety Rules
+
+- Do not start or stop CommandMate unless the user explicitly asks.
+- Do not infer that CommandMate is down from sandboxed localhost failures.
+- Do not release with uncommitted tracked changes in the release worktree.
+- Do not tag before the release PR is merged to `main`.
+- Do not force-push, delete tags, or use destructive cleanup unless explicitly approved.
+- Keep `.env`, local databases, workspace run artifacts, and raw logs out of release commits.
+
+## Phase 1: Prepare Release PR
+
+### 1. Preflight
+
+Run from the main integration worktree or a clean release worktree:
+
+```bash
+git branch --show-current
+git status --short
+git fetch origin main --tags
+```
+
+If the current branch is not `main`, verify that a `main` worktree exists:
+
+```bash
+git worktree list
+```
+
+Use `main` as the release branch base.
+
+### 2. Determine Version
+
+Read the current version from both places and confirm they match:
+
+```bash
+python - <<'PY'
+import re
+from pathlib import Path
+
+pyproject = Path("pyproject.toml").read_text()
+init = Path("photon_action_memory/__init__.py").read_text()
+print(re.search(r'^version = "([^"]+)"', pyproject, re.M).group(1))
+print(re.search(r'__version__ = "([^"]+)"', init).group(1))
+PY
+```
+
+Calculate the next version:
+
+- `patch`: increment PATCH.
+- `minor`: increment MINOR and reset PATCH to 0.
+- `major`: increment MAJOR and reset MINOR/PATCH to 0.
+- explicit version: use the provided `X.Y.Z`.
+
+Reject non-SemVer versions.
+
+### 3. Check Tag Availability
+
+```bash
+git rev-parse "v$new_version"
+git ls-remote --tags origin "v$new_version"
+```
+
+If either command finds an existing tag, stop and report the collision.
+
+### 4. Create Release Worktree
+
+```bash
+WORKTREE_DIR="../photon-action-memory-release-v$new_version"
+git worktree add -b "release/v$new_version" "$WORKTREE_DIR" origin/main
+```
+
+### 5. Update Release Files
+
+In the release worktree:
+
+- Update `pyproject.toml` project version.
+- Update `photon_action_memory/__init__.py` `__version__`.
+- Update `CHANGELOG.md`:
+  - move relevant `[Unreleased]` entries under `[X.Y.Z] - YYYY-MM-DD`;
+  - leave an empty `[Unreleased]` section;
+  - update compare links.
+- Update README release/download text if the current version is mentioned.
+
+### 6. Run Checks
+
+Run:
+
+```bash
+ruff format --check .
+ruff check .
+mypy photon_action_memory tests
+pytest -q
+python -m build
+```
+
+If a check fails, fix it in the release worktree or stop with the failure.
+
+### 7. Commit, Push, PR
+
+```bash
+git add pyproject.toml photon_action_memory/__init__.py CHANGELOG.md README.md
+git commit -m "chore: release v$new_version"
+git push -u origin "release/v$new_version"
+```
+
+Create a PR to `main` with:
+
+- title: `chore: release v$new_version`
+- body containing the changelog section and the checks run.
+
+Prefer the GitHub connector for PR creation. Use `gh pr create` only when the
+connector cannot create the PR and `gh` is authenticated.
+
+## Phase 2: Tag After Merge
+
+After the user confirms the release PR was merged:
+
+```bash
+git fetch origin main --tags
+git checkout main
+git pull --ff-only origin main
+git tag "v$new_version"
+git push origin "v$new_version"
+```
+
+The tag push triggers `.github/workflows/release.yml`, which builds Python
+distributions with `python -m build` and attaches `dist/*` to a GitHub Release.
+
+## Cleanup
+
+Only after tag push and release workflow success:
+
+```bash
+git worktree remove "../photon-action-memory-release-v$new_version"
+git branch -d "release/v$new_version"
+git push origin --delete "release/v$new_version"
+```
+
+Use only non-forced deletion by default.
+
+## Verification
+
+Confirm:
+
+```bash
+git tag -l "v$new_version"
+gh release view "v$new_version"
+gh run list --limit 3
+```
+
+If `gh` is unavailable or unauthenticated, use the GitHub connector or report
+that local release verification could not be completed.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+env:
+  PYTHON_VERSION: "3.12"
+
+jobs:
+  build:
+    name: Build Python package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install build tools
+        run: |
+          python -m pip install -U pip build
+
+      - name: Build distributions
+        run: python -m build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: python-distributions
+          path: dist/*
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: python-distributions
+          path: dist
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project uses [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-04-30
+
+### Added
+
+- Initial PHOTON Action Memory package.
+- Local-first sidecar schema, event ingestion, suggestion API, and fallback ranking.
+- Optional PHOTON / MLX adapter surface.
+- Sanitizer, local event store, dataset exporter, evaluation metrics, and Anvil fixtures.
+
+[unreleased]: https://github.com/Kewton/photon-action-memory/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/Kewton/photon-action-memory/releases/tag/v0.1.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Kewton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,29 @@ This repository is in the initial design and implementation phase.
 
 The v0.1.0 development bootstrap is organized under `workspace/v0.1.0/`.
 
+## License
+
+PHOTON Action Memory is released under the MIT License. See `LICENSE`.
+
+## Release
+
+Releases are tagged as `vX.Y.Z`. Pushing a release tag triggers the GitHub
+Actions release workflow, builds the Python source distribution and wheel, and
+attaches the generated artifacts to a GitHub Release.
+
+Use the repository release command when preparing a new release:
+
+```text
+/release patch
+/release minor
+/release major
+/release 1.2.3
+```
+
+The release flow updates `pyproject.toml`, `photon_action_memory/__init__.py`,
+and `CHANGELOG.md`, opens a release PR to `main`, and creates the tag only after
+the PR is merged.
+
 ## Development
 
 Requirements:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,14 @@ license = { text = "MIT" }
 authors = [
   { name = "Kewton" },
 ]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.12",
+  "Typing :: Typed",
+]
 dependencies = [
   "fastapi>=0.115",
   "httpx>=0.27",
@@ -58,4 +66,3 @@ packages = ["photon_action_memory"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-ra"
-


### PR DESCRIPTION
## Summary
- Add MIT `LICENSE` and Python package metadata classifiers for public distribution.
- Add release documentation, changelog, and `/release` command guidance.
- Add a tag-triggered GitHub Actions workflow that builds wheel/sdist artifacts and creates a GitHub Release.

## Verification
- `python -m pytest -q tests/test_import.py`
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m mypy photon_action_memory tests`
- `python -m pytest -q`
- `python -m build`

## Notes
- Existing untracked local files such as `.env`, `data/`, `workspace/management/orchestrate-issues-6-10.json`, and `workspace/v0.2.0/` are intentionally excluded.