### PR TITLE
#31 Materialize v0.2.0 docs and schema diff

### DIFF
--- a/dev-reports/issue-31/design.md
+++ b/dev-reports/issue-31/design.md
@@ -1,0 +1,73 @@
+# Design Note — Issue #31: Materialize v0.2.0 Docs and Schema Diff
+
+## Issue
+
+[P0][v0.2][M0] Materialize v0.2.0 docs and schema diff
+
+## Objective
+
+Expand `workspace/v0.2.0/plan.md` into formal v0.2.0 documentation defining the Action Context Firewall. M0 is a documentation-only milestone; no implementation code is changed.
+
+## Source
+
+All content derives from `workspace/v0.2.0/plan.md`, which contains the complete v0.2.0 design authored by the project. The plan embeds shell heredoc commands that define the target file content. This task materializes those files as proper Markdown documents.
+
+## Design Decisions
+
+### 1. Documentation-only scope
+
+M0 produces docs only. No Python source files are created or modified. The schema definitions in `03_schema_and_api.md` are JSON examples for documentation purposes, not implemented code.
+
+### 2. Markdown formatting over raw text
+
+The plan.md content is structured as plain text with implicit sections. The materialized docs apply Markdown formatting (headers, tables, code blocks, lists) to make the content navigable and readable on GitHub.
+
+### 3. File boundaries match plan.md
+
+Each file maps directly to a `cat > workspace/v0.2.0/<file> <<'EOF'` block in plan.md. No content is invented or added beyond what plan.md specifies.
+
+### 4. Dev-reports are issue-scoped
+
+`dev-reports/issue-31/` contains three files:
+- `design.md` — this document
+- `implementation-summary.md` — what was written and why
+- `verification.md` — acceptance criteria check
+
+## Key Design Points from plan.md
+
+### Action Context Firewall
+
+v0.2.0 reframes the sidecar from "suggest next action" to "control what enters the prompt." The firewall enforces:
+
+- raw tool output does not enter the prompt by default
+- only ContextPack items are prompt-visible
+- evidence is referenced by ID and expanded only on demand
+
+### Central schemas
+
+| Schema | Role |
+|--------|------|
+| ActionChunk | Groups tool events into meaningful action units |
+| ActionSummary | Structured summary with facts/hypotheses/failed_attempts separated |
+| EvidenceRef | Pointer to evidence that can be expanded on demand |
+| ContextPack | The only memory allowed into the LLM prompt |
+| ContextAdmissionDecision | Records each admit/omit/deny decision |
+
+### Raw tool log non-admission policy
+
+The default admission policy is:
+
+```yaml
+raw_evidence_policy: deny_by_default
+allow_full_stdout: false
+allow_full_stderr: false
+allow_full_file_content: false
+allow_stale_summary: false
+allow_ungrounded_fact: false
+```
+
+This is the defining invariant of v0.2.0.
+
+### v0.3.0 deferral
+
+MCP/stdio adapter, multi-agent coordination, and online learning are explicitly deferred to v0.3.0+. This keeps M0 scope clean.

--- a/dev-reports/issue-31/implementation-summary.md
+++ b/dev-reports/issue-31/implementation-summary.md
@@ -1,0 +1,35 @@
+# Implementation Summary — Issue #31
+
+## What was done
+
+Materialized `workspace/v0.2.0/plan.md` into 7 workspace docs and 3 dev-report files.
+
+## Files written
+
+### workspace/v0.2.0/
+
+| File | Content |
+|------|---------|
+| `README.md` | v0.2.0 overview, one-sentence concept, v0.1.0 delta table, 5 core elements, completion criteria |
+| `01_concept_and_delta.md` | Action-induced context pollution problem, v0.2.0 hypothesis, basic policy, 10 invariants |
+| `02_requirements_and_scope.md` | Goal, in-scope/out-of-scope, FR-1 through FR-7, NFRs, admission policy, local LLM requirements |
+| `03_schema_and_api.md` | ActionChunk, EvidenceRef, ActionSummary, ContextAdmissionDecision, ContextPack schemas; 3 new API endpoints with request/response examples |
+| `04_architecture.md` | Logical architecture, data flow, PHOTON hierarchy, recursive state update, Context Admission Controller, Evidence Expander, Staleness Guard, deterministic fallback, package structure, Anvil integration flow, prompt rendering |
+| `05_evaluation.md` | Evaluation conditions, core metrics, 4 new metric groups (context pollution, summary quality, evidence expansion, agent loop), local LLM metrics, 3 evaluation modes, acceptance criteria, baselines, metric definitions, eval report shape |
+| `06_work_plan.md` | M0–M8 milestone definitions, issue breakdown table, recommended implementation order, risk/mitigation table, v0.2.0 release checklist, v0.3.0 deferral list |
+
+### dev-reports/issue-31/
+
+| File | Content |
+|------|---------|
+| `design.md` | Design decisions, source description, key design points |
+| `implementation-summary.md` | This file |
+| `verification.md` | Acceptance criteria check |
+
+## Source fidelity
+
+All content derives from `workspace/v0.2.0/plan.md`. No content was invented. The only additions are Markdown formatting (tables, code blocks, headers) to make the content navigable.
+
+## No code changes
+
+M0 is documentation only. No Python source files, schemas, or tests were created or modified.

--- a/dev-reports/issue-31/verification.md
+++ b/dev-reports/issue-31/verification.md
@@ -1,0 +1,97 @@
+# Verification — Issue #31
+
+## Acceptance Criteria Check
+
+### AC-1: v0.1.0 delta is clearly documented
+
+**Status: PASS**
+
+`workspace/v0.2.0/README.md` contains a comparison table across 9 dimensions (中心機能, memory の役割, tool log の扱い, summary, evidence, prompt 注入, ranking, evaluation, PHOTON らしさ).
+
+`workspace/v0.2.0/01_concept_and_delta.md` documents the delta with:
+- the problem (action-induced context pollution)
+- v0.1.0 vs v0.2.0 question/output comparison
+- 10 invariants that are new in v0.2.0
+
+### AC-2: Action Context Firewall is defined
+
+**Status: PASS**
+
+The concept is defined in `workspace/v0.2.0/README.md`:
+
+> PHOTON Action Memory v0.2.0 is an Action Context Firewall that compresses noisy coding-agent tool loops into compact, evidence-grounded action states, and expands details only on demand.
+
+`workspace/v0.2.0/01_concept_and_delta.md` expands this with the basic policy (default: summary-only, denied: raw tool output) and 10 invariants.
+
+`workspace/v0.2.0/04_architecture.md` defines the Context Admission Controller as the architectural component enforcing the firewall.
+
+### AC-3: raw tool log non-admission policy is documented
+
+**Status: PASS**
+
+`workspace/v0.2.0/02_requirements_and_scope.md` section 6 (Admission Policy) defines:
+
+```yaml
+raw_evidence_policy: deny_by_default
+allow_full_stdout: false
+allow_full_stderr: false
+allow_full_file_content: false
+allow_stale_summary: false
+allow_ungrounded_fact: false
+```
+
+The denied list explicitly names: raw grep output, raw ripgrep output, full test stdout, full build log, repeated failed command output, full file content, secret-like string, absolute home path, token-like value, stale summary, ungrounded fact.
+
+### AC-4: ActionSummary / EvidenceRef / ContextPack schemas are documented
+
+**Status: PASS**
+
+`workspace/v0.2.0/03_schema_and_api.md` defines all schemas with JSON examples:
+
+| Schema | Section |
+|--------|---------|
+| ActionChunk | Section 3 |
+| EvidenceRef | Section 4 |
+| ActionSummary | Section 5 |
+| ContextAdmissionDecision | Section 6 |
+| ContextPack | Section 7 |
+
+All schemas include `schema_version: "action-memory.v0.2"`.
+
+ActionSummary separates: `actions_done`, `facts`, `hypotheses`, `failed_attempts`, `avoid`, `next_hints`, `token_cost`, `validity`.
+
+### AC-5: v0.3.0+ deferred scope is explicit
+
+**Status: PASS**
+
+`workspace/v0.2.0/02_requirements_and_scope.md` section 3 (Out of Scope) explicitly lists deferred items including MCP/stdio adapter.
+
+`workspace/v0.2.0/06_work_plan.md` section 7 (v0.3.0 Candidates) lists 8 items deferred to v0.3.0+:
+- MCP / stdio adapter
+- multi-agent memory sharing
+- repo-local continuous adaptation
+- online learning with rollback
+- richer graph index integration
+- cross-repo action pattern transfer
+- auto-generated eval tasks
+- production canary dashboards
+
+## Expected Files Check
+
+| File | Status |
+|------|--------|
+| `workspace/v0.2.0/README.md` | Created |
+| `workspace/v0.2.0/01_concept_and_delta.md` | Created |
+| `workspace/v0.2.0/02_requirements_and_scope.md` | Created |
+| `workspace/v0.2.0/03_schema_and_api.md` | Created |
+| `workspace/v0.2.0/04_architecture.md` | Created |
+| `workspace/v0.2.0/05_evaluation.md` | Created |
+| `workspace/v0.2.0/06_work_plan.md` | Created |
+| `dev-reports/issue-31/design.md` | Created |
+| `dev-reports/issue-31/implementation-summary.md` | Created |
+| `dev-reports/issue-31/verification.md` | Created |
+
+## Result
+
+All 5 acceptance criteria: **PASS**  
+All 10 expected files: **Created**

--- a/workspace/v0.2.0/01_concept_and_delta.md
+++ b/workspace/v0.2.0/01_concept_and_delta.md
@@ -1,0 +1,145 @@
+# 01. Concept and Delta from v0.1.0
+
+## 1. 背景
+
+Coding Agent は、問題解決のために多くの tool action を実行する。
+
+代表例:
+
+- grep / ripgrep
+- file read
+- test
+- build
+- lint
+- edit
+- diff inspection
+- stack trace inspection
+- repo structure inspection
+
+これらの action は有用だが、同時に大量の raw context を発生させる。
+
+- grep の全文出力
+- test stdout / stderr
+- build log
+- stack trace
+- file content
+- 過去の失敗仮説
+- 既に読んだ file の断片
+- 既に試した command
+
+この raw context をそのまま prompt に入れ続けると、次の問題が起こる。
+
+1. token cost が増える
+2. local LLM の prefill latency が増える
+3. VRAM / KV cache を圧迫する
+4. 小型モデルが不要情報に引っ張られる
+5. 失敗した仮説が事実のように残る
+6. 同じ search/read/test を繰り返す
+7. task drift が起こる
+8. session が長くなるほど prompt が汚れる
+
+v0.2.0 では、この問題を **action-induced context pollution** と呼ぶ。
+
+## 2. v0.2.0 の仮説
+
+v0.2.0 の仮説は次である。
+
+Coding Agent は、過去の tool/action について raw log 全体を知る必要はない。多くの場合、必要なのは以下の概要である。
+
+- 何をしたか
+- 何が分かったか
+- 何が未解決か
+- 何を避けるべきか
+- どの evidence を必要時に展開できるか
+- 次に何をすべきか
+
+したがって、v0.2.0 では raw tool log を prompt に入れない。raw log は local event store に保存し、prompt には ActionSummary / ContextPack のみを入れる。
+
+## 3. v0.2.0 の基本方針
+
+```
+Default:         summary-only
+When needed:     summary + selected evidence snippet
+Denied by default:
+  - raw tool stdout/stderr
+  - full grep output
+  - full test output
+  - full build log
+  - full file content already summarized
+  - stale summary
+  - ungrounded hypothesis
+  - repeated failed command output
+```
+
+## 4. v0.1.0 から v0.2.0 への進化
+
+### v0.1.0
+
+```
+Question:
+  現在の task state, repo state, recent tool results, past sessions から、
+  agent は次に何をすべきか？
+Output:
+  suggestions
+  evidence
+  warnings
+```
+
+### v0.2.0
+
+```
+Question:
+  次の LLM prompt に何を入れるべきか？
+  何を入れてはいけないか？
+  summary だけで足りるか？
+  evidence を展開すべきか？
+  古い情報や失敗仮説が context を汚していないか？
+Output:
+  ContextPack
+  ActionSummary
+  EvidenceRef
+  ContextAdmissionDecision
+  SummaryValidationResult
+```
+
+## 5. 新しい設計メッセージ
+
+v0.2.0 は「より多く覚える memory」ではない。
+
+```
+v0.1.0: remember useful actions
+v0.2.0: remember useful actions without polluting context
+```
+
+より短く表現すると次である。
+
+> 覚えるための memory ではなく、  
+> 汚さずに動くための memory。
+
+## 6. 差別化ポイント
+
+v0.2.0 の差別化は、次に集約する。
+
+- retrieval memory ではなく action-state controller
+- context を増やすのではなく context を制限する
+- raw log ではなく evidence-grounded summary を prompt に入れる
+- summary から必要時だけ evidence へ top-down に降りる
+- next action と context admission を同じ SessionActionState から制御する
+- local LLM の限られた context / VRAM / attention を守る
+
+## 7. 強い不変条件
+
+v0.2.0 では次の invariant を守る。
+
+| Invariant | 内容 |
+|-----------|------|
+| Invariant 1 | raw event は local store に保存してよいが、prompt には直接入れない。 |
+| Invariant 2 | prompt に入る memory item は summary / warning / selected evidence のみ。 |
+| Invariant 3 | fact-like statement は evidence_id なしに prompt-visible にしない。 |
+| Invariant 4 | hypothesis は hypothesis として明示し、fact と混ぜない。 |
+| Invariant 5 | failed action は done ではなく failed_attempts / avoid として扱う。 |
+| Invariant 6 | commit hash / file fingerprint が変わったら summary を stale にする。 |
+| Invariant 7 | detail は evidence_id から on-demand に展開する。 |
+| Invariant 8 | ContextPack は token budget と pollution budget を持つ。 |
+| Invariant 9 | sidecar は final decision maker ではなく advisor である。 |
+| Invariant 10 | sidecar failure 時も agent は fail-open で継続する。 |

--- a/workspace/v0.2.0/02_requirements_and_scope.md
+++ b/workspace/v0.2.0/02_requirements_and_scope.md
@@ -1,0 +1,208 @@
+# 02. Requirements and Scope
+
+## 1. Goal
+
+v0.2.0 の goal は次である。
+
+PHOTON Action Memory を Action Context Firewall として拡張し、Coding Agent の tool/action loop から発生する raw context を prompt から隔離し、summary-only default と evidence-on-demand によって、token cost、context pollution、repeated exploration、failed retry を削減する。
+
+## 2. In Scope
+
+- ActionChunk schema
+- ActionSummary schema
+- EvidenceRef schema
+- ContextPack schema
+- ContextAdmissionDecision schema
+- SummaryValidationResult schema
+- StalenessPolicy schema
+- `POST /v1/context/pack` API
+- `POST /v1/evidence/expand` API
+- `POST /v1/summary/validate` API
+- `/v1/summarize` の v0.2.0 schema 拡張
+- raw tool log non-admission policy
+- Context Admission Controller
+- Evidence Expander
+- Summary Fidelity Checker
+- Staleness Guard
+- Token Budget Manager
+- Context Pollution Metrics
+- Anvil prompt construction 前の shadow-mode integration
+- deterministic fallback for context packing
+- PHOTON context scoring interface
+- local LLM oriented eval metrics
+
+## 3. Out of Scope
+
+以下は v0.2.0 の対象外とし、v0.3.0 以降で扱う。
+
+- main coding agent の置き換え
+- final answer generation
+- destructive command の自動承認
+- edit command の自動承認
+- remote multi-tenant SaaS 前提の運用
+- raw secret / token / private path の保存
+- raw transcript を常時 prompt に入れる設計
+- online learning による即時モデル更新
+- **MCP / stdio adapter の本格実装** (→ v0.3.0)
+- multi-agent coordination
+- repository index / vector DB / graph DB のフル実装
+
+## 4. Functional Requirements
+
+### FR-1: Event ingestion
+
+`POST /v1/events` は v0.1.0 から継続する。
+
+追加要件:
+
+- sanitizer を event store 前に必ず通す
+- raw output は保存前に redaction される
+- raw output の prompt admission は **default deny**
+- event は ActionChunk の材料になる
+
+### FR-2: Action chunking
+
+複数の EventRecord を action 単位にまとめる。
+
+例:
+
+- repo-wide search chunk
+- file inspection chunk
+- failure reproduction chunk
+- edit attempt chunk
+- test verification chunk
+- answer preparation chunk
+
+### FR-3: Action summary
+
+ActionChunk から ActionSummary を生成する。
+
+ActionSummary は以下を分離する。
+
+- `actions_done`
+- `facts`
+- `hypotheses`
+- `failed_attempts`
+- `avoid`
+- `next_hints`
+- `evidence_refs`
+- `staleness`
+
+### FR-4: Context pack generation
+
+`POST /v1/context/pack` は、次の LLM prompt に入れる memory を返す。
+
+```
+Input:
+  current task
+  working memory
+  recent events
+  action summaries
+  token budget
+  admission policy
+Output:
+  ContextPack
+```
+
+### FR-5: Evidence expansion
+
+`POST /v1/evidence/expand` は evidence_id から必要最小限の detail を返す。
+
+制約:
+
+- `max_expand_chars` を守る
+- sanitizer を再適用する
+- raw output 全文は返さない
+- selected snippet / line range / summarized stderr のみ返す
+
+### FR-6: Summary validation
+
+`POST /v1/summary/validate` は、summary が raw events と整合しているか検証する。
+
+検証対象:
+
+- evidence_id が存在するか
+- fact が evidence に支えられているか
+- hypothesis が fact と混ざっていないか
+- summary が stale でないか
+- file fingerprint が変わっていないか
+- failed action が successful action として扱われていないか
+
+### FR-7: Suggestion compatibility
+
+`POST /v1/suggest` は v0.1.0 と互換を保つ。
+
+追加要件:
+
+- suggest response は ContextPack と連携できる
+- suggestion は context admission の結果を参照できる
+- evidence は EvidenceRef として返す
+
+## 5. Non-functional Requirements
+
+| 項目 | 要件 |
+|------|------|
+| Local-first | default は localhost / local state のみ |
+| Fail-open | sidecar failure 時に agent 本体を止めない |
+| Low latency | no-model context pack は p50 200ms 未満を目標 |
+| Model optional | PHOTON model unavailable 時は deterministic fallback |
+| Privacy | raw secret / token / private home path を保存しない |
+| Prompt hygiene | raw tool output は default deny |
+| Determinism | fallback packing は deterministic |
+| Observability | admission / omission / expansion / outcome を記録 |
+| Compatibility | Anvil 以外の agent にも使える neutral schema |
+| Local LLM friendly | context budget を小さく固定できる |
+
+## 6. Admission Policy
+
+### Default policy
+
+```yaml
+raw_evidence_policy: deny_by_default
+default_detail_level: summary_only
+allow_selected_snippet: true
+allow_full_stdout: false
+allow_full_stderr: false
+allow_full_file_content: false
+allow_stale_summary: false
+allow_ungrounded_fact: false
+```
+
+### Allowed prompt-visible memory
+
+- task summary
+- current constraints
+- action summary
+- fact with `evidence_id`
+- hypothesis with `evidence_id` and status
+- avoid guidance
+- warning
+- selected evidence snippet
+
+### Denied prompt-visible memory
+
+- raw grep output
+- raw ripgrep output
+- full test stdout
+- full build log
+- repeated failed command output
+- full file content
+- secret-like string
+- absolute home path
+- token-like value
+- stale summary
+- ungrounded fact
+
+## 7. Local LLM Specific Requirements
+
+v0.2.0 は local LLM 特化 coding agent で特に価値を出す。
+
+追加要件:
+
+- `max_memory_tokens` を明示的に設定できる
+- `prompt_tokens_per_turn` を記録する
+- context pack tokens を記録する
+- `tokens_saved_vs_full_transcript` を記録する
+- `prefill_time_ms` を外部 agent から optional に受け取れる
+- `peak_vram_mb` を external metric として紐づけられる
+- model size / quantization / context length を eval metadata に残せる

--- a/workspace/v0.2.0/03_schema_and_api.md
+++ b/workspace/v0.2.0/03_schema_and_api.md
@@ -1,0 +1,442 @@
+# 03. Schema and API
+
+## 1. Existing APIs from v0.1.0
+
+v0.2.0 でも以下は維持する。
+
+```
+GET  /health
+POST /v1/events
+POST /v1/suggest
+POST /v1/summarize
+POST /v1/evaluate
+```
+
+v0.2.0 では以下を追加する。
+
+```
+POST /v1/context/pack
+POST /v1/evidence/expand
+POST /v1/summary/validate
+```
+
+## 2. Schema Version
+
+v0.2.0 の schema version は次とする。
+
+```
+action-memory.v0.2
+```
+
+すべての request / response は `schema_version` を持つ。
+
+## 3. ActionChunk
+
+ActionChunk は、複数の EventRecord を意味のある action 単位にまとめたもの。
+
+```json
+{
+  "schema_version": "action-memory.v0.2",
+  "chunk_id": "chunk_017",
+  "session_id": "sess_001",
+  "turn_id": "turn_006",
+  "repo_id": "repo_001",
+  "commit": "abc123",
+  "kind": "repo_search|file_inspection|failure_reproduction|edit_attempt|test_verification|answer_prep|other",
+  "event_ids": ["evt_041", "evt_042", "evt_043"],
+  "started_at": "2026-04-30T10:00:00Z",
+  "ended_at": "2026-04-30T10:02:00Z",
+  "summary": "Searched SessionStore and found primary implementation in src/session/store.rs.",
+  "outcome": "useful|failed|partial|irrelevant|unknown",
+  "risk": "low|medium|high",
+  "redaction_status": "sanitized"
+}
+```
+
+## 4. EvidenceRef
+
+EvidenceRef は、prompt に全文を入れずに参照可能にする evidence pointer である。
+
+```json
+{
+  "schema_version": "action-memory.v0.2",
+  "evidence_id": "evt_052",
+  "source_event_id": "evt_052",
+  "source_chunk_id": "chunk_018",
+  "kind": "tool_result|file_read|test_output|build_output|diff|case|summary",
+  "summary": "cargo test session_persistence failed with serialization mismatch.",
+  "locator": {
+    "file": "tests/session_persistence.rs",
+    "line_start": 42,
+    "line_end": 57,
+    "command": "cargo test session_persistence"
+  },
+  "redaction_status": "sanitized",
+  "expand_policy": "on_demand_only",
+  "max_expand_chars": 1200,
+  "staleness": {
+    "status": "valid",
+    "reason": null
+  }
+}
+```
+
+## 5. ActionSummary
+
+ActionSummary は v0.2.0 の中核 schema である。
+
+```json
+{
+  "schema_version": "action-memory.v0.2",
+  "summary_id": "sum_001",
+  "session_id": "sess_001",
+  "repo_id": "repo_001",
+  "commit": "abc123",
+  "task_signature": "fix-session-persistence-test",
+  "summary_level": "turn|chunk|session|case",
+  "source_chunk_ids": ["chunk_017", "chunk_018"],
+  "actions_done": [
+    {
+      "kind": "search",
+      "target": "SessionStore",
+      "outcome": "primary implementation found",
+      "status": "useful",
+      "evidence_ids": ["evt_041"]
+    },
+    {
+      "kind": "test",
+      "command": "cargo test session_persistence",
+      "outcome": "failed with serialization mismatch",
+      "status": "unresolved",
+      "evidence_ids": ["evt_052"]
+    }
+  ],
+  "facts": [
+    {
+      "text": "SessionStore implementation is in src/session/store.rs.",
+      "evidence_ids": ["evt_041"],
+      "confidence": 0.95
+    }
+  ],
+  "hypotheses": [
+    {
+      "text": "The failure may be related to the serde path.",
+      "evidence_ids": ["evt_052"],
+      "confidence": 0.62,
+      "status": "open"
+    }
+  ],
+  "failed_attempts": [
+    {
+      "action": "rerun cargo test session_persistence without code changes",
+      "outcome": "same failure",
+      "evidence_ids": ["evt_052"],
+      "retry_policy": "avoid_until_files_changed"
+    }
+  ],
+  "avoid": [
+    {
+      "action": "repo-wide grep for SessionStore",
+      "reason": "already performed successfully",
+      "valid_until": "files_changed",
+      "evidence_ids": ["evt_041"]
+    }
+  ],
+  "next_hints": [
+    {
+      "kind": "read",
+      "target": "src/session/store.rs",
+      "reason": "primary implementation file",
+      "confidence": 0.78
+    },
+    {
+      "kind": "inspect",
+      "target": "tests/session_persistence.rs",
+      "reason": "failing test location",
+      "confidence": 0.74
+    }
+  ],
+  "token_cost": {
+    "estimated_summary_tokens": 240,
+    "estimated_raw_tokens": 5200,
+    "tokens_saved_vs_raw": 4960
+  },
+  "validity": {
+    "status": "valid|stale|partial|contradicted",
+    "reason": null
+  }
+}
+```
+
+## 6. ContextAdmissionDecision
+
+ContextAdmissionDecision は、ある memory item を prompt に入れるかどうかの判断を表す。
+
+```json
+{
+  "schema_version": "action-memory.v0.2",
+  "decision_id": "adm_001",
+  "item_id": "sum_001",
+  "item_kind": "action_summary|evidence_ref|warning|raw_event",
+  "decision": "admit|omit|expand|defer|deny",
+  "reason": "useful_recent_task_state",
+  "risk": "low|medium|high",
+  "estimated_tokens": 180,
+  "policy": {
+    "raw_evidence_policy": "deny_by_default",
+    "detail_level": "summary_only"
+  }
+}
+```
+
+## 7. ContextPack
+
+ContextPack は、agent prompt に入れてよい memory の唯一の入口である。
+
+```json
+{
+  "schema_version": "action-memory.v0.2",
+  "request_id": "turn_123",
+  "session_id": "sess_001",
+  "repo_id": "repo_001",
+  "mode": "summary_only|summary_plus_evidence|none",
+  "items": [
+    {
+      "kind": "action_summary",
+      "id": "sum_001",
+      "text": "Searched SessionStore; primary implementation found in src/session/store.rs. cargo test session_persistence failed with serialization mismatch.",
+      "evidence_ids": ["evt_041", "evt_052"],
+      "admission_reason": "useful_recent_task_state"
+    },
+    {
+      "kind": "avoid",
+      "id": "avoid_001",
+      "text": "Do not rerun repo-wide grep for SessionStore unless files changed.",
+      "evidence_ids": ["evt_041"],
+      "admission_reason": "repeat_exploration_guard"
+    },
+    {
+      "kind": "hypothesis",
+      "id": "hyp_001",
+      "text": "The serde path may be related, but this is not confirmed.",
+      "evidence_ids": ["evt_052"],
+      "admission_reason": "open_hypothesis"
+    }
+  ],
+  "omitted": [
+    {
+      "kind": "raw_tool_output",
+      "id": "evt_052_raw",
+      "reason": "raw output exceeds budget; summary is sufficient"
+    }
+  ],
+  "warnings": [
+    {
+      "kind": "stale_risk|missing_evidence|repeat_failure|drift",
+      "message": "One previous test command failed and should not be repeated without code changes."
+    }
+  ],
+  "token_budget": {
+    "max_tokens": 800,
+    "estimated_tokens": 260,
+    "tokens_saved_vs_raw": 5200
+  }
+}
+```
+
+## 8. POST /v1/context/pack
+
+### Request
+
+```json
+{
+  "schema_version": "action-memory.v0.2",
+  "request_id": "turn_123",
+  "agent": {
+    "name": "anvil",
+    "version": "0.2.x"
+  },
+  "repo": {
+    "root": "/path/to/repo",
+    "name": "Anvil",
+    "branch": "feature/example",
+    "commit": "abc123"
+  },
+  "task": {
+    "user_request": "Fix failing session persistence test.",
+    "mode": "plan|act|answer",
+    "summary": "Fix failing session persistence test."
+  },
+  "working_memory": {
+    "active_task": "Fix failing session persistence test.",
+    "constraints": [],
+    "touched_files": [],
+    "unresolved_errors": [],
+    "active_precautions": []
+  },
+  "recent_event_ids": ["evt_041", "evt_052"],
+  "candidate_summary_ids": ["sum_001"],
+  "budget": {
+    "max_memory_tokens": 800,
+    "max_evidence_chars": 1200,
+    "raw_evidence_policy": "deny_by_default",
+    "detail_level": "summary_only"
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "schema_version": "action-memory.v0.2",
+  "request_id": "turn_123",
+  "model_version": "photon-action-memory-v0.2.0",
+  "sidecar_status": "ok",
+  "context_pack": {
+    "schema_version": "action-memory.v0.2",
+    "request_id": "turn_123",
+    "session_id": "sess_001",
+    "repo_id": "repo_001",
+    "mode": "summary_only",
+    "items": [],
+    "omitted": [],
+    "warnings": [],
+    "token_budget": {
+      "max_tokens": 800,
+      "estimated_tokens": 0,
+      "tokens_saved_vs_raw": 0
+    }
+  },
+  "admission_decisions": []
+}
+```
+
+## 9. POST /v1/evidence/expand
+
+### Request
+
+```json
+{
+  "schema_version": "action-memory.v0.2",
+  "request_id": "expand_001",
+  "evidence_ids": ["evt_052"],
+  "reason": "Need exact failure message before deciding next test.",
+  "budget": {
+    "max_chars_per_evidence": 1200,
+    "max_total_chars": 2000
+  },
+  "policy": {
+    "redact_again": true,
+    "allow_raw_full_output": false,
+    "allow_selected_snippet": true
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "schema_version": "action-memory.v0.2",
+  "request_id": "expand_001",
+  "expanded": [
+    {
+      "evidence_id": "evt_052",
+      "kind": "test_output",
+      "summary": "cargo test session_persistence failed with serialization mismatch.",
+      "snippet": "selected sanitized stderr snippet here",
+      "locator": {
+        "command": "cargo test session_persistence",
+        "file": "tests/session_persistence.rs",
+        "line_start": 42,
+        "line_end": 57
+      },
+      "redaction_status": "sanitized",
+      "truncated": true
+    }
+  ],
+  "omitted": [
+    {
+      "evidence_id": "evt_052_raw",
+      "reason": "full raw output denied by policy"
+    }
+  ]
+}
+```
+
+## 10. POST /v1/summary/validate
+
+### Request
+
+```json
+{
+  "schema_version": "action-memory.v0.2",
+  "request_id": "validate_001",
+  "summary_ids": ["sum_001"],
+  "checks": [
+    "evidence_exists",
+    "fact_grounding",
+    "hypothesis_labeling",
+    "staleness",
+    "failed_action_classification",
+    "redaction_status"
+  ]
+}
+```
+
+### Response
+
+```json
+{
+  "schema_version": "action-memory.v0.2",
+  "request_id": "validate_001",
+  "results": [
+    {
+      "summary_id": "sum_001",
+      "status": "valid",
+      "score": 0.94,
+      "issues": [],
+      "checked_at": "2026-04-30T10:05:00Z"
+    }
+  ]
+}
+```
+
+## 11. POST /v1/summarize update
+
+v0.2.0 では `/v1/summarize` は ActionSummary を返す。
+
+### Request
+
+```json
+{
+  "schema_version": "action-memory.v0.2",
+  "request_id": "summarize_001",
+  "session_id": "sess_001",
+  "chunk_ids": ["chunk_017", "chunk_018"],
+  "summary_level": "chunk|turn|session",
+  "policy": {
+    "require_evidence_ids": true,
+    "separate_fact_and_hypothesis": true,
+    "include_failed_attempts": true,
+    "include_avoid_guidance": true
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "schema_version": "action-memory.v0.2",
+  "request_id": "summarize_001",
+  "summary": {
+    "summary_id": "sum_001"
+  },
+  "validation": {
+    "status": "valid",
+    "score": 0.94
+  }
+}
+```

--- a/workspace/v0.2.0/04_architecture.md
+++ b/workspace/v0.2.0/04_architecture.md
@@ -1,0 +1,325 @@
+# 04. Architecture
+
+## 1. Logical Architecture
+
+```
+Coding Agent
+├── executes tools
+├── sends sanitized events
+├── asks for suggestions
+├── asks for context pack before LLM call
+└── expands evidence only when needed
+        ↓
+PHOTON Action Memory Sidecar
+├── API Layer
+├── Schema Validator
+├── Sanitizer
+├── Event Store
+├── Action Chunker
+├── Action Summary Builder
+├── Summary Canonicalizer
+├── Staleness Guard
+├── Context Admission Controller
+├── Token Budget Manager
+├── Evidence Expander
+├── Candidate Retriever
+├── PHOTON Model Adapter
+├── Action Ranker
+├── Context Ranker
+├── Summary Fidelity Checker
+└── Eval Logger
+        ↓
+Local State
+├── events.sqlite
+├── action_chunks.jsonl
+├── action_summaries.jsonl
+├── evidence_refs.jsonl
+├── context_packs.jsonl
+├── cases.jsonl
+├── eval_runs/
+└── model_cache/
+```
+
+## 2. Main Data Flow
+
+### Tool result ingestion
+
+1. Agent executes tool.
+2. Agent sends result to `POST /v1/events`.
+3. Sidecar validates schema.
+4. Sanitizer redacts secret / token / private path / control chars.
+5. Sanitized event is stored in `events.sqlite`.
+6. Event is linked to `session_id`, `turn_id`, `repo_id`, `commit`.
+
+### Action chunking
+
+1. Recent events are grouped by intent / turn / time / tool type.
+2. Sidecar creates ActionChunk.
+3. ActionChunk records `event_ids` and coarse outcome.
+4. Chunk is stored in `action_chunks.jsonl` or SQLite table.
+
+### Summary update
+
+1. ActionChunk is converted into ActionSummary.
+2. Facts, hypotheses, failed attempts, avoid guidance are separated.
+3. Every fact-like statement receives `evidence_ids`.
+4. Summary is validated.
+5. Summary is stored as compact action state.
+
+### Prompt construction
+
+1. Before next LLM call, agent calls `POST /v1/context/pack`.
+2. Context Admission Controller selects prompt-visible items.
+3. Raw tool output is denied by default.
+4. Token Budget Manager enforces `max_memory_tokens`.
+5. ContextPack is returned.
+6. Agent inserts ContextPack into prompt.
+
+### Evidence expansion
+
+1. If agent needs detail, it calls `POST /v1/evidence/expand`.
+2. Evidence Expander retrieves local event detail.
+3. Sanitizer runs again.
+4. Only selected snippet is returned.
+5. Expansion decision is logged.
+
+## 3. PHOTON-style Hierarchy
+
+v0.2.0 uses a hierarchy of action states.
+
+```
+Raw Event
+  ↓
+ActionChunk
+  ↓
+ActionSummary
+  ↓
+SessionActionState
+  ↓
+ContextPack
+  ↓
+LLM Prompt
+```
+
+Details are available only through the reverse path.
+
+```
+LLM asks for detail
+  ↓
+evidence_id
+  ↓
+EvidenceRef
+  ↓
+selected sanitized snippet
+```
+
+## 4. Recursive State Update
+
+v0.2.0 should avoid re-summarizing the entire session on every turn.
+
+Preferred update:
+
+```
+S_t = update(S_{t-1}, ActionChunk_t)
+```
+
+Where:
+
+- `S_t` — current SessionActionState
+- `S_{t-1}` — previous SessionActionState
+- `ActionChunk_t` — new action chunk produced by recent tool events
+
+This supports long-running sessions because the sidecar updates compact state incrementally.
+
+## 5. Context Admission Controller
+
+The Context Admission Controller decides whether each memory item should enter the prompt.
+
+**Inputs:**
+
+- task summary
+- working memory
+- recent events
+- ActionSummary candidates
+- EvidenceRef candidates
+- previous ContextPack
+- token budget
+- admission policy
+- staleness status
+
+**Outputs:**
+
+- `admit`
+- `omit`
+- `expand`
+- `defer`
+- `deny`
+
+**Decision factors:**
+
+- relevance to current task
+- recency
+- evidence grounding
+- staleness
+- risk
+- token cost
+- duplication with already admitted context
+- whether detail is needed
+- whether summary is sufficient
+
+## 6. Evidence Expander
+
+Evidence Expander is the only path from summary to detail.
+
+Rules:
+
+- full raw output is denied by default
+- sanitizer runs again before returning text
+- selected snippets are preferred
+- `max_expand_chars` must be enforced
+- command output should be summarized if too long
+- line ranges should be included when available
+
+## 7. Staleness Guard
+
+Summary and evidence can become stale.
+
+**Staleness triggers:**
+
+- commit hash changed
+- referenced file changed
+- referenced line range changed
+- branch changed
+- task signature changed
+- test command result contradicted by later event
+- summary contradicted by newer evidence
+
+**Staleness status:**
+
+```
+valid
+stale
+partial
+contradicted
+unknown
+```
+
+Stale summaries are denied by default unless explicitly requested for historical context.
+
+## 8. Deterministic Fallback
+
+PHOTON model is optional.
+
+When model is unavailable:
+
+- context pack still works
+- ranking uses deterministic heuristics
+- evidence expansion still works
+- summary validation still works
+- sidecar remains useful
+
+**Fallback heuristics:**
+
+- recent successful search results are useful
+- repeated identical search/read is less useful
+- failed command without file change should be avoided
+- exact error-linked files rank high
+- touched files rank high
+- stale summaries are omitted
+- facts with evidence rank above ungrounded statements
+
+## 9. Package Structure
+
+```
+photon_action_memory/
+├── api/
+│   ├── schema.py
+│   ├── server.py
+│   └── client.py
+├── memory/
+│   ├── store.py
+│   ├── sanitizer.py
+│   ├── compaction.py
+│   ├── chunks.py
+│   ├── summaries.py
+│   ├── evidence.py
+│   └── staleness.py
+├── context/
+│   ├── admission.py
+│   ├── budget.py
+│   ├── pack.py
+│   ├── policies.py
+│   └── render.py
+├── ranking/
+│   ├── candidates.py
+│   ├── fallback.py
+│   ├── ranker.py
+│   └── context_ranker.py
+├── models/
+│   ├── photon_adapter.py
+│   ├── state.py
+│   ├── checkpoint.py
+│   └── context_scorer.py
+├── eval/
+│   ├── metrics.py
+│   ├── runner.py
+│   ├── pollution.py
+│   ├── summary_fidelity.py
+│   └── local_llm.py
+└── training/
+    ├── exporters/
+    ├── labels.py
+    ├── datasets.py
+    └── train.py
+```
+
+## 10. Anvil Integration Flow
+
+1. Anvil executes a tool.
+2. Anvil sends sanitized event to PHOTON Action Memory.
+3. Sidecar stores event locally.
+4. Sidecar updates ActionChunk / ActionSummary.
+5. Before next LLM call, Anvil calls `POST /v1/context/pack`.
+6. Anvil inserts ContextPack into prompt.
+7. Anvil calls `POST /v1/suggest` if next action guidance is needed.
+8. If exact detail is needed, Anvil calls `POST /v1/evidence/expand`.
+9. Anvil logs adoption / ignored / outcome through `POST /v1/evaluate`.
+
+## 11. Prompt Rendering
+
+ContextPack should be rendered compactly.
+
+Example:
+
+```
+## Action Memory
+Task:
+- Fix failing session persistence test.
+Done:
+- Searched SessionStore and found primary implementation in src/session/store.rs. [evt_041]
+- Ran cargo test session_persistence; failure reproduced as serialization mismatch. [evt_052]
+Facts:
+- SessionStore implementation is in src/session/store.rs. [evt_041]
+Open hypotheses:
+- serde path may be involved, but this is not confirmed. [evt_052]
+Avoid:
+- Do not rerun repo-wide grep for SessionStore unless files changed. [evt_041]
+Next useful actions:
+- Read src/session/store.rs.
+- Inspect tests/session_persistence.rs.
+Evidence detail:
+- Use evidence_id evt_052 only if the exact failure snippet is needed.
+```
+
+## 12. Security and Privacy
+
+Security requirements:
+
+- sanitizer runs before event store
+- sanitizer runs again before evidence expansion
+- raw secret-like strings are redacted
+- absolute home paths are redacted
+- token-like strings are redacted
+- raw logs are not committed
+- eval reports do not include per-turn raw logs
+- exported datasets are sanitized

--- a/workspace/v0.2.0/05_evaluation.md
+++ b/workspace/v0.2.0/05_evaluation.md
@@ -1,0 +1,270 @@
+# 05. Evaluation Plan
+
+## 1. Evaluation Goal
+
+v0.2.0 should prove that Context Firewall improves coding-agent loops by reducing context pollution and token cost without reducing task success.
+
+The main comparison is:
+
+| Condition | Description |
+|-----------|-------------|
+| A | no memory |
+| B | full transcript context |
+| C | static summary memory |
+| D | retrieval memory |
+| E | PHOTON Action Memory summary-only |
+| F | PHOTON Action Memory summary + evidence-on-demand |
+
+Expected best configuration: **F. summary + evidence-on-demand**
+
+## 2. Core Metrics from v0.1.0
+
+Continue to measure:
+
+- `first_useful_file_hit_rate`
+- `tool_call_reduction`
+- `repeated_exploration_rate`
+- `test_build_time_to_first`
+- `failed_action_retry_rate`
+- `context_evidence_precision`
+- `fail_open_incident_count`
+
+## 3. New v0.2.0 Metrics
+
+### Context pollution metrics
+
+| Metric | Description |
+|--------|-------------|
+| `raw_tool_tokens_in_prompt` | Tokens from raw tool stdout/stderr in prompt |
+| `summary_tokens_in_prompt` | Tokens from ActionSummary in prompt |
+| `context_pack_tokens` | Total ContextPack token count |
+| `tokens_saved_vs_raw` | Tokens saved compared to raw tool output |
+| `tokens_saved_vs_full_transcript` | Tokens saved compared to full transcript |
+| `context_pollution_rate` | Rate of raw context leaking into prompt |
+| `duplicate_context_rate` | Rate of duplicate context items admitted |
+| `stale_summary_incidents` | Count of stale summaries admitted |
+| `ungrounded_fact_rate` | Facts without evidence_id in prompt |
+| `hypothesis_as_fact_rate` | Hypotheses rendered as facts |
+
+### Summary quality metrics
+
+| Metric | Description |
+|--------|-------------|
+| `summary_fidelity` | Claims supported by linked evidence_ids |
+| `evidence_grounding_rate` | prompt_visible_fact_count_with_evidence / prompt_visible_fact_count |
+| `evidence_reconstructability` | Evidence can be retrieved and expanded |
+| `fact_hypothesis_separation_score` | Facts and hypotheses kept separate |
+| `failed_action_classification_accuracy` | Failed actions classified correctly |
+| `avoid_guidance_precision` | Avoid guidance correctly applied |
+| `summary_staleness_detection_accuracy` | Stale summaries correctly detected |
+
+### Evidence expansion metrics
+
+| Metric | Description |
+|--------|-------------|
+| `evidence_expansion_precision` | Expanded evidence was actually needed |
+| `evidence_expansion_recall` | Needed evidence was expandable |
+| `detail_needed_but_missing_rate` | Agent needed detail but no expandable evidence existed |
+| `unnecessary_expansion_rate` | Evidence expanded when summary was sufficient |
+| `expanded_chars_per_turn` | Average chars expanded per turn |
+| `redaction_regression_count` | Redaction failures in expansion |
+
+### Agent loop metrics
+
+| Metric | Description |
+|--------|-------------|
+| `repeated_search_rate` | Rate of repeated search actions |
+| `repeated_read_rate` | Rate of repeated file reads |
+| `repeated_failed_command_rate` | Rate of repeated failed commands |
+| `time_to_first_useful_file` | Time until first relevant file read |
+| `time_to_first_useful_test` | Time until first useful test run |
+| `time_to_first_passing_test` | Time until first passing test |
+| `task_success_rate` | Task completion rate |
+| `human_correction_rate` | Rate of human corrections needed |
+| `agent_drift_rate` | Rate of off-task agent actions |
+
+### Local LLM metrics
+
+| Metric | Description |
+|--------|-------------|
+| `prompt_tokens_per_turn` | Total prompt tokens per turn |
+| `prefill_time_ms` | Prefill latency in milliseconds |
+| `decode_tokens_per_second` | Decode throughput |
+| `peak_vram_mb` | Peak VRAM usage in MB |
+| `cpu_fallback_rate` | Rate of GPU→CPU fallback |
+| `context_length_used` | Fraction of context window used |
+| `model_size` | Model parameter count |
+| `quantization` | Quantization format |
+| `local_inference_backend` | Backend (llama.cpp, vllm, etc.) |
+
+## 4. Evaluation Modes
+
+### Offline replay
+
+Use fixed sanitized fixtures.
+
+```
+Input:   historical agent event logs
+Replay:  feed events to sidecar
+         generate ActionSummary
+         generate ContextPack
+         compare with actual next action and outcome
+Output:  aggregate metrics only
+```
+
+Do not include raw logs in reports.
+
+### Shadow-mode
+
+Agent receives ContextPack / suggestions but is not forced to use them.
+
+Record:
+
+- `request_id`
+- `context_pack_id`
+- admitted item ids
+- omitted item ids
+- expanded evidence ids
+- actual next action
+- suggestion match
+- ignored reason
+- outcome
+- latency
+- token usage
+
+### Canary
+
+Only low-risk context injection is allowed.
+
+**Allowed:**
+
+- read candidates
+- search query candidates
+- test command candidates
+- avoid repeated search/read warnings
+- summary-only memory
+
+**Denied:**
+
+- destructive shell command
+- edit auto-approval
+- security-sensitive operation
+- raw full stdout injection
+- raw full stderr injection
+
+## 5. Acceptance Criteria
+
+### Minimum acceptance
+
+- ContextPack can be generated without PHOTON model.
+- `raw_tool_tokens_in_prompt` is near zero under default policy.
+- `tokens_saved_vs_full_transcript` is measurable.
+- `summary_fidelity` can be computed on fixtures.
+- Stale summaries are omitted by default.
+- Sidecar remains fail-open.
+
+### Target acceptance
+
+- `repeated_exploration_rate` decreases versus no memory.
+- `failed_action_retry_rate` decreases versus no memory.
+- `prompt_tokens_per_turn` decreases versus full transcript.
+- `task_success_rate` does not decrease versus full transcript.
+- `evidence_expansion_precision` is high enough to justify expansions.
+- summary + evidence-on-demand outperforms summary-only on detail-heavy tasks.
+
+### Stretch acceptance
+
+- local LLM `prefill_time_ms` decreases versus full transcript.
+- `peak_vram_mb` decreases or remains stable under long sessions.
+- Smaller local models become usable on tasks that previously required larger context.
+- PHOTON context scoring beats deterministic fallback.
+
+## 6. Baselines
+
+Required baselines:
+
+1. No memory
+2. Full transcript
+3. Static session summary
+4. Lexical retrieval
+5. Vector retrieval, if available
+6. Deterministic ActionSummary fallback
+7. PHOTON Action Memory without Context Admission
+8. PHOTON Action Memory with Context Firewall
+
+## 7. Metric Definitions
+
+### raw_tool_tokens_in_prompt
+
+Number of prompt tokens that originate from raw tool stdout/stderr, raw grep output, raw build output, or raw file content.
+
+**Target:** default policy: approximately 0
+
+### tokens_saved_vs_raw
+
+```
+estimated_raw_tokens - context_pack_tokens
+```
+
+### summary_fidelity
+
+Ratio of summary claims that are supported by linked evidence_ids.
+
+### evidence_grounding_rate
+
+```
+prompt_visible_fact_count_with_evidence_id / prompt_visible_fact_count
+```
+
+### hypothesis_as_fact_rate
+
+```
+hypothesis_claims_rendered_as_fact / hypothesis_claims
+```
+
+### detail_needed_but_missing_rate
+
+```
+turns_where_agent_needed_detail_but_context_pack_had_no_expandable_evidence
+/
+turns_where_detail_was_needed
+```
+
+## 8. Eval Report Shape
+
+Eval reports should be aggregate-only.
+
+```json
+{
+  "schema_version": "action-memory.eval.v0.2",
+  "run_id": "eval_20260430_001",
+  "dataset": {
+    "name": "sanitized_anvil_shadow_fixture",
+    "split": "test",
+    "num_sessions": 20,
+    "num_turns": 400
+  },
+  "conditions": [
+    "no_memory",
+    "full_transcript",
+    "summary_only",
+    "summary_plus_evidence"
+  ],
+  "metrics": {
+    "summary_plus_evidence": {
+      "task_success_rate": 0.0,
+      "prompt_tokens_per_turn": 0.0,
+      "raw_tool_tokens_in_prompt": 0.0,
+      "tokens_saved_vs_full_transcript": 0.0,
+      "repeated_exploration_rate": 0.0,
+      "failed_action_retry_rate": 0.0,
+      "summary_fidelity": 0.0
+    }
+  },
+  "privacy": {
+    "contains_raw_logs": false,
+    "contains_prompts": false,
+    "contains_tool_outputs": false
+  }
+}
+```

--- a/workspace/v0.2.0/06_work_plan.md
+++ b/workspace/v0.2.0/06_work_plan.md
@@ -1,0 +1,264 @@
+# 06. Work Plan
+
+## 1. Goal
+
+v0.2.0 の goal は、PHOTON Action Memory に Action Context Firewall を実装し、summary-only default と evidence-on-demand によって、Coding Agent の prompt を汚さずに長時間 tool loop を支えること。
+
+## 2. Milestones
+
+### M0: v0.2.0 documentation and schema diff
+
+成果物:
+
+```
+workspace/v0.2.0/README.md
+workspace/v0.2.0/01_concept_and_delta.md
+workspace/v0.2.0/02_requirements_and_scope.md
+workspace/v0.2.0/03_schema_and_api.md
+workspace/v0.2.0/04_architecture.md
+workspace/v0.2.0/05_evaluation.md
+workspace/v0.2.0/06_work_plan.md
+```
+
+完了条件:
+
+- v0.1.0 との差分が明文化されている
+- Action Context Firewall の定義がある
+- raw tool log non-admission policy がある
+- ActionSummary / EvidenceRef / ContextPack の schema がある
+
+### M1: Schema implementation
+
+成果物:
+
+- ActionChunk schema
+- ActionSummary schema
+- EvidenceRef schema
+- ContextPack schema
+- ContextAdmissionDecision schema
+- SummaryValidationResult schema
+- StalenessPolicy schema
+- JSON fixture tests
+
+完了条件:
+
+- all schemas have `schema_version`
+- optional unknown fields do not break validation
+- missing required fields produce validation error
+- fact / hypothesis / failed_attempt / avoid can be represented separately
+
+### M2: Action chunking and summary builder
+
+成果物:
+
+- ActionChunker
+- ActionSummaryBuilder
+- SummaryCanonicalizer
+- SummaryStateUpdater
+- deterministic summary fallback
+
+完了条件:
+
+- recent EventRecords can be grouped into ActionChunk
+- ActionChunk can produce ActionSummary
+- all facts have `evidence_ids`
+- failed actions are not misclassified as successful actions
+- previous summary can be updated incrementally
+
+### M3: ContextPack API
+
+成果物:
+
+- `POST /v1/context/pack`
+- ContextAdmissionController
+- TokenBudgetManager
+- PromptPackRenderer
+- admission / omission logging
+
+完了条件:
+
+- summary-only ContextPack can be returned
+- raw tool output is omitted by default
+- `max_memory_tokens` is enforced
+- `tokens_saved_vs_raw` is computed
+- sidecar remains fail-open
+
+### M4: Evidence-on-demand
+
+成果物:
+
+- `POST /v1/evidence/expand`
+- EvidenceExpander
+- snippet selector
+- redaction re-check
+- expansion logging
+
+完了条件:
+
+- `evidence_id` can be expanded into selected snippet
+- full raw output is denied by default
+- `max_expand_chars` is enforced
+- sanitizer runs before response
+
+### M5: Summary validation and staleness guard
+
+成果物:
+
+- `POST /v1/summary/validate`
+- SummaryFidelityChecker
+- StalenessGuard
+- file fingerprint tracker
+- contradiction detector, minimal version
+
+完了条件:
+
+- missing `evidence_id` is detected
+- stale summary is detected on commit/file change
+- hypothesis-as-fact issue is detected
+- `summary_fidelity` metric is computed
+
+### M6: Evaluation
+
+成果物:
+
+- context pollution metrics
+- summary fidelity metrics
+- local LLM metrics hooks
+- offline replay runner
+- aggregate eval report
+
+完了条件:
+
+- full transcript vs summary-only vs summary+evidence can be compared
+- `raw_tool_tokens_in_prompt` is reported
+- `tokens_saved_vs_full_transcript` is reported
+- `repeated_exploration_rate` is reported
+- `failed_action_retry_rate` is reported
+- eval report contains no raw logs/prompts/tool outputs
+
+### M7: Anvil shadow integration
+
+成果物:
+
+- Anvil context pack integration contract
+- prompt construction hook proposal
+- context pack fixture
+- evaluate request fixture
+- canary mode config
+
+完了条件:
+
+- Anvil can call `/v1/context/pack` before LLM prompt construction
+- Anvil can call `/v1/evidence/expand` when detail is needed
+- ContextPack adoption / ignored / outcome can be logged
+- only low-risk context injection is enabled in canary
+
+### M8: PHOTON context scoring
+
+成果物:
+
+- `context_admission_score` interface
+- `evidence_expansion_score` interface
+- `summary_usefulness_score` interface
+- `staleness_risk_score` interface
+- deterministic fallback comparison
+
+完了条件:
+
+- model unavailable path works
+- PHOTON scorer can be plugged in
+- scoring path has smoke tests
+- fallback and PHOTON scoring can be compared in eval
+
+## 3. Issue Breakdown
+
+| Priority | Issue | Description |
+|----------|-------|-------------|
+| P0 | Define v0.2 schema models | ActionChunk, ActionSummary, EvidenceRef, ContextPack |
+| P0 | Add JSON fixtures | valid/invalid fixtures for new schemas |
+| P0 | Implement ActionChunker | group events into action chunks |
+| P0 | Implement ActionSummaryBuilder | structured summary with evidence_ids |
+| P0 | Implement ContextPack API | prompt-visible memory pack |
+| P0 | Enforce raw tool log default deny | admission policy |
+| P1 | Implement EvidenceExpander | evidence_id to selected snippet |
+| P1 | Implement SummaryValidation | fidelity and grounding checks |
+| P1 | Implement StalenessGuard | commit/file fingerprint based invalidation |
+| P1 | Add context pollution metrics | raw_tool_tokens, tokens_saved |
+| P1 | Add eval runner update | compare full transcript vs summary modes |
+| P2 | Add Anvil integration contract | context pack before prompt |
+| P2 | Add local LLM metrics hooks | prefill, vram, context length metadata |
+| P2 | Add PHOTON context scorer | context admission / expansion scoring |
+| P2 | Add canary config | low-risk injection only |
+
+## 4. Recommended Implementation Order
+
+1. docs
+2. schema
+3. fixtures
+4. sanitizer policy update
+5. ActionChunker
+6. ActionSummaryBuilder
+7. ContextPack API
+8. EvidenceExpander
+9. SummaryValidation
+10. StalenessGuard
+11. eval metrics
+12. Anvil shadow integration
+13. PHOTON context scorer
+
+理由:
+
+- schema が先にないと integration と eval が進まない
+- sanitizer policy は event store / evidence expansion 前に固める必要がある
+- ContextPack は v0.2.0 の中心 API
+- EvidenceExpander は ContextPack の後に実装する方が自然
+- PHOTON scorer は deterministic fallback の後でよい
+
+## 5. Risk and Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| summary が過圧縮して重要 detail を失う | evidence-on-demand と `detail_needed_but_missing_rate` を測る |
+| summary が嘘を含む | `evidence_ids` 必須、`summary_fidelity` を測る |
+| hypothesis が fact と混ざる | schema で facts / hypotheses を分離する |
+| stale summary が prompt に入る | StalenessGuard で default deny |
+| prompt がうるさくなる | `max_memory_tokens` と admission threshold |
+| PHOTON model が未成熟 | deterministic fallback を維持 |
+| context pack が遅い | no-model path p50 200ms 目標 |
+| raw secret が漏れる | sanitizer before store + before expand |
+| Anvil 専用になる | neutral schema + adapter |
+| eval report に raw logs が混ざる | aggregate-only report policy |
+
+## 6. v0.2.0 Release Checklist
+
+- [ ] workspace/v0.2.0 docs committed
+- [ ] v0.2 schema implemented
+- [ ] JSON fixtures added
+- [ ] sanitizer policy updated
+- [ ] ActionChunker implemented
+- [ ] ActionSummaryBuilder implemented
+- [ ] ContextPack API implemented
+- [ ] EvidenceExpander implemented
+- [ ] SummaryValidation implemented
+- [ ] StalenessGuard implemented
+- [ ] Context pollution metrics added
+- [ ] Offline eval updated
+- [ ] Anvil shadow contract drafted
+- [ ] deterministic fallback passes tests
+- [ ] model-unavailable path passes tests
+- [ ] raw tool output default deny tested
+- [ ] fail-open behavior tested
+- [ ] privacy regression tested
+
+## 7. v0.3.0 Candidates
+
+v0.2.0 で扱わず、v0.3.0 以降に送る候補:
+
+- MCP / stdio adapter
+- multi-agent memory sharing
+- repo-local continuous adaptation
+- online learning with rollback
+- richer graph index integration
+- cross-repo action pattern transfer
+- auto-generated eval tasks
+- production canary dashboards

--- a/workspace/v0.2.0/README.md
+++ b/workspace/v0.2.0/README.md
@@ -1,0 +1,110 @@
+# PHOTON Action Memory v0.2.0 Plan
+
+## 目的
+
+v0.2.0 の目的は、PHOTON Action Memory を v0.1.0 の **Action Memory Sidecar** から、より強い **Action Context Firewall** へ拡張することである。
+
+v0.1.0 では、Coding Agent の tool loop、repo exploration、test result、past session から、次に読む file、実行する command、参照すべき evidence、避けるべき repeated action を提案する sidecar MVP を成立させる。
+
+v0.2.0 では、これに加えて、agent の action によって発生する raw context を prompt に直接流さない。代わりに、tool/action 履歴を階層的な action state に圧縮し、agent には概要だけを渡し、必要時だけ evidence を展開する。
+
+## 一文でのコンセプト
+
+```
+PHOTON Action Memory v0.2.0 is an Action Context Firewall
+that compresses noisy coding-agent tool loops into compact,
+evidence-grounded action states, and expands details only on demand.
+```
+
+日本語では次のように定義する。
+
+> PHOTON Action Memory v0.2.0 は、  
+> Coding Agent の tool/action loop から発生する raw context を隔離し、  
+> やったこと・分かったこと・未解決のこと・避けるべきことを  
+> 構造化 summary として保持し、  
+> 必要時だけ evidence_id から詳細を展開する  
+> **Action Context Firewall** である。
+
+## v0.1.0 との差分
+
+| 観点 | v0.1.0 | v0.2.0 |
+|------|--------|--------|
+| 中心機能 | next action / file / command / evidence の suggestion | context pollution を防ぐ Context Firewall |
+| memory の役割 | L3 Action Memory Cache | L3 Action Memory Cache + Action Context Firewall |
+| tool log の扱い | event store に蓄積し、suggestion に利用 | raw tool log は prompt 非注入を原則化 |
+| summary | compact memory の初期機能 | ActionSummary を正式な中核 schema に昇格 |
+| evidence | suggestion の根拠として返す | evidence_id として保持し、必要時だけ展開 |
+| prompt 注入 | suggestion / evidence / warning を返す | ContextPack だけを prompt 注入対象にする |
+| ranking | next action / file / evidence ranking | action ranking + context admission + evidence expansion ranking |
+| evaluation | tool-call reduction, repeated exploration, hit rate | 追加で context pollution, summary fidelity, token saving を評価 |
+| PHOTON らしさ | action/file/evidence scoring | hierarchical action state, recursive update, evidence-on-demand |
+
+## v0.2.0 の中核
+
+v0.2.0 の中核は次の 5 つである。
+
+1. **ActionChunk** — tool events を action 単位に chunk 化する。
+2. **ActionSummary** — やったこと、分かったこと、仮説、失敗、避けるべきこと、次の候補を構造化する。
+3. **ContextPack** — 次の LLM prompt に入れる summary / warning / selected evidence を決める。
+4. **Evidence-on-Demand** — summary だけで足りない場合に evidence_id から必要最小限の詳細だけ展開する。
+5. **Summary Fidelity / Context Pollution Eval** — summary が raw event と整合しているか、不要な raw context を防げているか評価する。
+
+## PHOTON 理論との対応
+
+| PHOTON model | PHOTON Action Memory v0.2.0 |
+|---|---|
+| token-level sequence | tool/action/event sequence |
+| low-rate contextual states | compact ActionSummary / SessionActionState |
+| bottom-up compression | raw tool events → ActionChunk → ActionSummary |
+| top-down reconstruction | evidence_id → selected evidence expansion |
+| recursive generation | previous SessionActionState + new ActionChunk → updated state |
+| multi-resolution scanning | summary / evidence snippet / raw local event の階層 |
+| reduced KV-cache traffic | prompt に入る raw tokens の削減 |
+
+重要なのは、単なる自然文要約ではないことである。
+
+v0.2.0 では、summary は以下を満たす必要がある。
+
+- evidence_id を持つ
+- fact と hypothesis を分離する
+- failed action と successful action を分離する
+- stale 判定できる
+- 必要時に raw evidence へ戻れる
+- token budget と risk budget を持つ
+
+## 完了定義
+
+v0.2.0 は、以下を満たしたら完了とする。
+
+1. raw tool output が default で prompt に入らない。
+2. prompt-visible memory は ContextPack 経由のみになる。
+3. ActionSummary が以下を分離して持つ。
+   - `actions_done`
+   - `facts`
+   - `hypotheses`
+   - `failed_attempts`
+   - `avoid`
+   - `next_hints`
+4. facts / hypotheses / failed_attempts は `evidence_ids` を持つ。
+5. evidence は必要時だけ `/v1/evidence/expand` で展開される。
+6. stale summary が commit hash / file fingerprint / timestamp で無効化される。
+7. ContextPack が token budget を守る。
+8. full transcript context と比べて `tokens_saved_vs_raw` を測定できる。
+9. `summary_fidelity` を測定できる。
+10. `raw_tool_tokens_in_prompt` を測定できる。
+11. Anvil shadow-mode で ContextPack の採用・無視・結果を追跡できる。
+12. PHOTON model unavailable 時は deterministic fallback に戻る。
+13. sidecar failure 時も agent 本体は fail-open で継続する。
+
+## ドキュメント構成
+
+```
+workspace/v0.2.0/
+├── README.md
+├── 01_concept_and_delta.md
+├── 02_requirements_and_scope.md
+├── 03_schema_and_api.md
+├── 04_architecture.md
+├── 05_evaluation.md
+└── 06_work_plan.md
+```


### PR DESCRIPTION
Closes #31

## Summary
- Expands the v0.2.0 Action Context Firewall plan into formal documentation.
- Documents the v0.1.0 delta, raw tool log non-admission policy, schema/API concepts, architecture, evaluation, and work plan.
- Adds issue-specific design, implementation, and verification reports.

## Verification
- See `dev-reports/issue-31/verification.md`.
- Worker verification reports all acceptance criteria as PASS.