### PR TITLE
#34 Implement ActionChunker

### DIFF
--- a/dev-reports/issue-34/design.md
+++ b/dev-reports/issue-34/design.md
@@ -1,0 +1,71 @@
+# Issue 34 Design: ActionChunker
+
+## Context
+
+Issue #34 is Milestone 2 of the v0.2.0 plan: implement `ActionChunker`, the component
+that groups sanitized `StoredEvent` records from the local SQLite store into `ActionChunk`
+units as defined in `photon_action_memory/api/schema_v2.py`.
+
+The architecture document (`workspace/v0.2.0/04_architecture.md`, section 2) specifies:
+
+> Recent events are grouped by intent / turn / time / tool type.
+> Sidecar creates ActionChunk. ActionChunk records `event_ids` and coarse outcome.
+
+## Inputs and Outputs
+
+**Input:** `Sequence[StoredEvent]` - already sanitized by `EventStore` before storage.
+No additional sanitization is needed in the chunker itself.
+
+**Output:** `list[ActionChunk]` from `schema_v2.ActionChunk`.
+
+## Grouping Strategy
+
+Default: one `ActionChunk` per `(session_id, turn_id)` pair, preserving first-seen
+order. Events within a turn represent a cohesive agent action (e.g., one tool call
+plus its result), so turn-level grouping is the natural boundary.
+
+`chunk_one()` is provided for callers that want all events collapsed into one chunk
+regardless of turn boundaries (e.g., summarizing a short session).
+
+## Determinism
+
+`chunk_id` is a 16-hex-character prefix of SHA-256 over newline-joined **sorted**
+event IDs. This ensures:
+
+- Same event set -> same `chunk_id` across runs.
+- List insertion order does not affect the ID.
+- Different event sets reliably produce different IDs (collision probability negligible).
+
+## Inference Heuristics
+
+### kind
+Majority vote over `_EVENT_KIND_MAP[event_type.lower()]`. Ties broken alphabetically
+for stability. Falls back to `"other"` for unrecognized types.
+
+### outcome
+Scan events in reverse order. Accept the first `payload["outcome"]` that is a valid
+`ChunkOutcome` literal, or map `payload["status"]` via a fixed lookup table
+(`success`/`ok`/`passed` -> `useful`, `error`/`failed`/`failure` -> `failed`).
+Default: `"unknown"`.
+
+### risk
+Scan events for an explicit `payload["risk"]` that is a valid `RiskLevel` literal.
+Fallback: if the inferred `kind` is `edit_attempt` or `failure_reproduction`, return
+`"medium"`. Otherwise `None`.
+
+### redaction_status
+`"redacted"` if any event payload has `redaction_status == "redacted"`.
+`"clean"` only if every event payload has `redaction_status == "clean"`.
+`"unknown"` otherwise (including missing values).
+
+## Module Location
+
+`photon_action_memory/memory/chunks.py` - alongside `store.py` and `sanitizer.py`
+in the memory sub-package, matching the planned package structure in architecture doc
+section 9.
+
+## Non-Goals
+
+- No model integration (model is optional per architecture doc section 8).
+- No persistence of chunks (storage is caller's responsibility).
+- No context admission or token budgeting (out of scope for this milestone).

--- a/dev-reports/issue-34/implementation-summary.md
+++ b/dev-reports/issue-34/implementation-summary.md
@@ -1,0 +1,51 @@
+# Issue 34 Implementation Summary: ActionChunker
+
+## Files Added
+
+| File | Purpose |
+|------|---------|
+| `photon_action_memory/memory/chunks.py` | `ActionChunker` class and helper functions |
+| `tests/test_chunks.py` | 66 tests covering all acceptance criteria |
+
+## Public API
+
+```python
+from photon_action_memory.memory.chunks import ActionChunker
+
+chunker = ActionChunker()
+
+# Group by (session_id, turn_id) - one ActionChunk per pair
+chunks: list[ActionChunk] = chunker.chunk(events)
+
+# Collapse all events into one ActionChunk (ignores turn boundaries)
+chunk: ActionChunk = chunker.chunk_one(events)
+```
+
+## Key Decisions
+
+**Grouping by turn_id:** The turn is the natural unit of agent action. All events
+within a turn share the same intent and context, making turn-level grouping the
+correct default without requiring semantic analysis.
+
+**Deterministic chunk_id:** SHA-256 of sorted event IDs ensures reproducibility.
+The same events always produce the same chunk regardless of call order or insertion
+sequence.
+
+**No sanitization in chunker:** `EventStore.append_event()` sanitizes before
+storage. The chunker consumes only `StoredEvent` objects, so sanitization is
+already guaranteed. Running it again in the chunker would be redundant and could
+corrupt already-normalized content.
+
+**Inference over configuration:** Kind, outcome, and risk are inferred from event
+metadata rather than requiring callers to pass them explicitly. This keeps the API
+minimal while still covering the schema fields.
+
+## Acceptance Criteria Mapping
+
+| Criterion | Implementation |
+|-----------|---------------|
+| Recent EventRecords grouped into ActionChunk | `ActionChunker.chunk()` groups by `(session_id, turn_id)` |
+| Chunk keeps source event IDs | `ActionChunk.event_ids` preserves insertion order |
+| Kind / outcome / risk representable | `_infer_kind`, `_infer_outcome`, `_infer_risk` helpers |
+| Only sanitized events used | Accepts `StoredEvent` only; EventStore guarantees sanitization |
+| Deterministic fallback | `_deterministic_chunk_id` hashes sorted event IDs via SHA-256 |

--- a/dev-reports/issue-34/verification.md
+++ b/dev-reports/issue-34/verification.md
@@ -1,0 +1,55 @@
+# Issue 34 Verification: ActionChunker
+
+## Commands Run
+
+```
+python -m ruff format --check .   # formatting
+python -m ruff check .            # lint
+python -m mypy photon_action_memory tests  # type checking
+python -m pytest tests/test_chunks.py -v   # focused tests
+python -m pytest -q                        # full suite
+```
+
+## Results
+
+### ruff format --check
+
+```
+45 files already formatted
+```
+
+### ruff check
+
+```
+All checks passed!
+```
+
+### mypy
+
+```
+Success: no issues found in 43 source files
+```
+
+### pytest tests/test_chunks.py (66 tests)
+
+```
+66 passed in 0.05s
+```
+
+### pytest full suite
+
+```
+212 passed, 1 skipped in 1.03s
+```
+
+The skipped test is the optional MLX smoke test, unrelated to this issue.
+
+## Test Coverage by Acceptance Criterion
+
+| Criterion | Test class |
+|-----------|-----------|
+| EventRecords grouped into ActionChunk | `TestActionChunkerBasic`, `TestActionChunkerGrouping` |
+| Chunk keeps source event IDs | `TestActionChunkerBasic::test_event_ids_preserved`, `test_all_event_ids_present_in_order` |
+| Kind / outcome / risk representable | `TestActionChunkerKindInference`, `TestActionChunkerOutcome`, `TestActionChunkerRisk` |
+| Only sanitized events used | All tests use `StoredEvent` (output of `EventStore`) |
+| Deterministic fallback | `TestActionChunkerDeterminism` |

--- a/photon_action_memory/memory/chunks.py
+++ b/photon_action_memory/memory/chunks.py
@@ -1,0 +1,179 @@
+"""ActionChunker - groups StoredEvents into ActionChunk units."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    ActionChunk,
+)
+from photon_action_memory.memory.store import StoredEvent
+
+# Maps event_type to ChunkKind literal.
+_EVENT_KIND_MAP: dict[str, str] = {
+    "answer": "answer_prep",
+    "bash": "other",
+    "edit": "edit_attempt",
+    "error": "failure_reproduction",
+    "failure": "failure_reproduction",
+    "file_create": "edit_attempt",
+    "file_delete": "edit_attempt",
+    "file_edit": "edit_attempt",
+    "file_read": "file_inspection",
+    "file_write": "edit_attempt",
+    "grep": "repo_search",
+    "repo_search": "repo_search",
+    "search": "repo_search",
+    "test_result": "test_verification",
+    "test_run": "test_verification",
+}
+
+_VALID_OUTCOMES: frozenset[str] = frozenset(
+    ["failed", "irrelevant", "partial", "unknown", "useful"]
+)
+
+_VALID_RISKS: frozenset[str] = frozenset(["high", "low", "medium"])
+
+_STATUS_TO_OUTCOME: dict[str, str] = {
+    "error": "failed",
+    "failed": "failed",
+    "failure": "failed",
+    "ok": "useful",
+    "passed": "useful",
+    "success": "useful",
+}
+
+_MEDIUM_RISK_KINDS: frozenset[str] = frozenset(["edit_attempt", "failure_reproduction"])
+
+
+def _infer_kind(events: list[StoredEvent]) -> str:
+    kind_counts: dict[str, int] = {}
+    for event in events:
+        kind = _EVENT_KIND_MAP.get(event.event_type.lower(), "other")
+        kind_counts[kind] = kind_counts.get(kind, 0) + 1
+    if not kind_counts:
+        return "other"
+    return max(kind_counts, key=lambda k: (kind_counts[k], k))
+
+
+def _infer_outcome(events: list[StoredEvent]) -> str:
+    for event in reversed(events):
+        payload = event.payload
+        outcome = payload.get("outcome")
+        if isinstance(outcome, str) and outcome in _VALID_OUTCOMES:
+            return outcome
+        status = payload.get("status")
+        if isinstance(status, str):
+            mapped = _STATUS_TO_OUTCOME.get(status.lower())
+            if mapped is not None:
+                return mapped
+    return "unknown"
+
+
+def _infer_risk(events: list[StoredEvent]) -> str | None:
+    for event in events:
+        risk = event.payload.get("risk")
+        if isinstance(risk, str) and risk in _VALID_RISKS:
+            return risk
+    kinds = {_EVENT_KIND_MAP.get(e.event_type.lower(), "other") for e in events}
+    if kinds & _MEDIUM_RISK_KINDS:
+        return "medium"
+    return None
+
+
+def _build_summary(kind: str, events: list[StoredEvent]) -> str:
+    n = len(events)
+    event_types = sorted({e.event_type for e in events})
+    type_str = ", ".join(event_types[:3])
+    if len(event_types) > 3:
+        type_str += f", +{len(event_types) - 3} more"
+    plural = "s" if n != 1 else ""
+    return f"{kind} ({n} event{plural}: {type_str})"
+
+
+def _deterministic_chunk_id(event_ids: list[str]) -> str:
+    """Produce a stable chunk_id from sorted event IDs via SHA-256."""
+    key = "\n".join(sorted(event_ids))
+    digest = hashlib.sha256(key.encode()).hexdigest()[:16]
+    return f"chunk-{digest}"
+
+
+def _infer_redaction_status(events: list[StoredEvent]) -> str:
+    statuses = [e.payload.get("redaction_status") for e in events]
+    if "redacted" in statuses:
+        return "redacted"
+    if all(s == "clean" for s in statuses):
+        return "clean"
+    return "unknown"
+
+
+class ActionChunker:
+    """Groups sanitized StoredEvents into ActionChunk units.
+
+    Default grouping: events sharing the same (session_id, turn_id) form one
+    chunk. All input events must already be sanitized (guaranteed by EventStore).
+    Chunk IDs are deterministic: the same set of event IDs always yields the
+    same chunk_id, regardless of list order.
+    """
+
+    def chunk(self, events: Sequence[StoredEvent]) -> list[ActionChunk]:
+        """Group events by (session_id, turn_id), one ActionChunk per group."""
+        if not events:
+            return []
+        groups = self._group_by_turn(list(events))
+        return [self._build_chunk(group) for group in groups]
+
+    def chunk_one(self, events: Sequence[StoredEvent]) -> ActionChunk:
+        """Collapse all given events into a single ActionChunk."""
+        if not events:
+            msg = "events must not be empty"
+            raise ValueError(msg)
+        return self._build_chunk(list(events))
+
+    def _group_by_turn(self, events: list[StoredEvent]) -> list[list[StoredEvent]]:
+        seen: dict[tuple[str, str], list[StoredEvent]] = {}
+        order: list[tuple[str, str]] = []
+        for event in events:
+            key = (event.session_id, event.turn_id)
+            if key not in seen:
+                seen[key] = []
+                order.append(key)
+            seen[key].append(event)
+        return [seen[k] for k in order]
+
+    def _build_chunk(self, events: list[StoredEvent]) -> ActionChunk:
+        event_ids = [e.event_id for e in events]
+        kind = _infer_kind(events)
+        outcome = _infer_outcome(events)
+        risk = _infer_risk(events)
+        summary = _build_summary(kind, events)
+        redaction_status = _infer_redaction_status(events)
+
+        commit: str | None = None
+        for e in reversed(events):
+            c = e.payload.get("commit")
+            if isinstance(c, str) and c:
+                commit = c
+                break
+
+        return ActionChunk(
+            schema_version=DEFAULT_SCHEMA_VERSION_V2,
+            chunk_id=_deterministic_chunk_id(event_ids),
+            session_id=events[0].session_id,
+            turn_id=events[0].turn_id,
+            repo_id=events[0].repo_id,
+            commit=commit,
+            kind=kind,
+            event_ids=event_ids,
+            started_at=events[0].timestamp,
+            ended_at=events[-1].timestamp,
+            summary=summary,
+            outcome=outcome,
+            risk=risk,
+            redaction_status=redaction_status,
+        )
+
+
+__all__ = ["ActionChunker"]

--- a/tests/test_chunks.py
+++ b/tests/test_chunks.py
@@ -1,0 +1,345 @@
+"""Tests for ActionChunker."""
+
+from __future__ import annotations
+
+import pytest
+
+from photon_action_memory.api.schema_v2 import ActionChunk
+from photon_action_memory.memory.chunks import ActionChunker
+from photon_action_memory.memory.sanitizer import SanitizedPayload
+from photon_action_memory.memory.store import StoredEvent
+
+
+def _make_event(
+    event_id: str = "evt-001",
+    session_id: str = "session-001",
+    turn_id: str = "turn-001",
+    repo_id: str = "repo-001",
+    timestamp: str = "2024-01-01T00:00:00+00:00",
+    event_type: str = "file_read",
+    payload: SanitizedPayload | None = None,
+) -> StoredEvent:
+    return StoredEvent(
+        schema_version="action-memory.v1",
+        event_id=event_id,
+        session_id=session_id,
+        turn_id=turn_id,
+        repo_id=repo_id,
+        timestamp=timestamp,
+        event_type=event_type,
+        payload=payload if payload is not None else {"redaction_status": "clean"},
+    )
+
+
+class TestActionChunkerBasic:
+    def test_empty_input_returns_empty_list(self) -> None:
+        assert ActionChunker().chunk([]) == []
+
+    def test_single_event_produces_one_chunk(self) -> None:
+        chunks = ActionChunker().chunk([_make_event()])
+        assert len(chunks) == 1
+        assert isinstance(chunks[0], ActionChunk)
+
+    def test_event_ids_preserved(self) -> None:
+        events = [_make_event(event_id="e1"), _make_event(event_id="e2")]
+        chunks = ActionChunker().chunk(events)
+        assert len(chunks) == 1
+        assert set(chunks[0].event_ids) == {"e1", "e2"}
+
+    def test_schema_version_is_v2(self) -> None:
+        chunks = ActionChunker().chunk([_make_event()])
+        assert chunks[0].schema_version == "action-memory.v0.2"
+
+    def test_all_event_ids_present_in_order(self) -> None:
+        events = [
+            _make_event(event_id="e1"),
+            _make_event(event_id="e2"),
+            _make_event(event_id="e3"),
+        ]
+        chunks = ActionChunker().chunk(events)
+        assert chunks[0].event_ids == ["e1", "e2", "e3"]
+
+
+class TestActionChunkerGrouping:
+    def test_same_turn_grouped_as_one_chunk(self) -> None:
+        events = [
+            _make_event(event_id="e1", turn_id="t1"),
+            _make_event(event_id="e2", turn_id="t1"),
+            _make_event(event_id="e3", turn_id="t1"),
+        ]
+        chunks = ActionChunker().chunk(events)
+        assert len(chunks) == 1
+        assert len(chunks[0].event_ids) == 3
+
+    def test_different_turns_produce_separate_chunks(self) -> None:
+        events = [
+            _make_event(event_id="e1", turn_id="t1"),
+            _make_event(event_id="e2", turn_id="t2"),
+        ]
+        chunks = ActionChunker().chunk(events)
+        assert len(chunks) == 2
+
+    def test_chunk_order_follows_first_seen_turn(self) -> None:
+        events = [
+            _make_event(event_id="e1", turn_id="t1"),
+            _make_event(event_id="e2", turn_id="t2"),
+            _make_event(event_id="e3", turn_id="t1"),
+        ]
+        chunks = ActionChunker().chunk(events)
+        assert chunks[0].turn_id == "t1"
+        assert chunks[1].turn_id == "t2"
+
+    def test_three_turns_produce_three_chunks(self) -> None:
+        events = [_make_event(event_id=f"e{i}", turn_id=f"t{i}") for i in range(3)]
+        chunks = ActionChunker().chunk(events)
+        assert len(chunks) == 3
+
+    def test_different_sessions_produce_separate_chunks(self) -> None:
+        events = [
+            _make_event(event_id="e1", session_id="s1", turn_id="t1"),
+            _make_event(event_id="e2", session_id="s2", turn_id="t1"),
+        ]
+        chunks = ActionChunker().chunk(events)
+        assert len(chunks) == 2
+
+
+class TestActionChunkerDeterminism:
+    def test_same_events_produce_same_chunk_id(self) -> None:
+        events = [_make_event(event_id="e1"), _make_event(event_id="e2")]
+        chunker = ActionChunker()
+        id_a = chunker.chunk(events)[0].chunk_id
+        id_b = chunker.chunk(events)[0].chunk_id
+        assert id_a == id_b
+
+    def test_chunk_id_is_order_independent(self) -> None:
+        events_ab = [_make_event(event_id="eA"), _make_event(event_id="eB")]
+        events_ba = [_make_event(event_id="eB"), _make_event(event_id="eA")]
+        chunker = ActionChunker()
+        assert chunker.chunk_one(events_ab).chunk_id == chunker.chunk_one(events_ba).chunk_id
+
+    def test_different_event_ids_produce_different_chunk_ids(self) -> None:
+        chunker = ActionChunker()
+        id_a = chunker.chunk_one([_make_event(event_id="eA")]).chunk_id
+        id_b = chunker.chunk_one([_make_event(event_id="eB")]).chunk_id
+        assert id_a != id_b
+
+    def test_chunk_id_starts_with_chunk_prefix(self) -> None:
+        chunk = ActionChunker().chunk_one([_make_event()])
+        assert chunk.chunk_id.startswith("chunk-")
+
+
+class TestActionChunkerKindInference:
+    @pytest.mark.parametrize(
+        ("event_type", "expected_kind"),
+        [
+            ("file_read", "file_inspection"),
+            ("file_write", "edit_attempt"),
+            ("file_edit", "edit_attempt"),
+            ("file_create", "edit_attempt"),
+            ("file_delete", "edit_attempt"),
+            ("search", "repo_search"),
+            ("grep", "repo_search"),
+            ("repo_search", "repo_search"),
+            ("test_run", "test_verification"),
+            ("test_result", "test_verification"),
+            ("edit", "edit_attempt"),
+            ("answer", "answer_prep"),
+            ("bash", "other"),
+            ("failure", "failure_reproduction"),
+            ("error", "failure_reproduction"),
+        ],
+    )
+    def test_event_type_mapped_to_kind(self, event_type: str, expected_kind: str) -> None:
+        chunk = ActionChunker().chunk_one([_make_event(event_type=event_type)])
+        assert chunk.kind == expected_kind
+
+    def test_unknown_event_type_maps_to_other(self) -> None:
+        chunk = ActionChunker().chunk_one([_make_event(event_type="unknown_xyz")])
+        assert chunk.kind == "other"
+
+    def test_majority_kind_wins(self) -> None:
+        events = [
+            _make_event(event_id="e1", event_type="file_read"),
+            _make_event(event_id="e2", event_type="file_read"),
+            _make_event(event_id="e3", event_type="search"),
+        ]
+        assert ActionChunker().chunk_one(events).kind == "file_inspection"
+
+    def test_case_insensitive_event_type(self) -> None:
+        chunk = ActionChunker().chunk_one([_make_event(event_type="FILE_READ")])
+        assert chunk.kind == "file_inspection"
+
+
+class TestActionChunkerOutcome:
+    def test_default_outcome_is_unknown(self) -> None:
+        assert ActionChunker().chunk_one([_make_event()]).outcome == "unknown"
+
+    def test_outcome_from_payload(self) -> None:
+        events = [_make_event(payload={"outcome": "useful", "redaction_status": "clean"})]
+        assert ActionChunker().chunk_one(events).outcome == "useful"
+
+    def test_outcome_partial_from_payload(self) -> None:
+        events = [_make_event(payload={"outcome": "partial", "redaction_status": "clean"})]
+        assert ActionChunker().chunk_one(events).outcome == "partial"
+
+    def test_status_success_maps_to_useful(self) -> None:
+        events = [_make_event(payload={"status": "success", "redaction_status": "clean"})]
+        assert ActionChunker().chunk_one(events).outcome == "useful"
+
+    def test_status_passed_maps_to_useful(self) -> None:
+        events = [_make_event(payload={"status": "passed", "redaction_status": "clean"})]
+        assert ActionChunker().chunk_one(events).outcome == "useful"
+
+    def test_status_failed_maps_to_failed(self) -> None:
+        events = [_make_event(payload={"status": "failed", "redaction_status": "clean"})]
+        assert ActionChunker().chunk_one(events).outcome == "failed"
+
+    def test_status_error_maps_to_failed(self) -> None:
+        events = [_make_event(payload={"status": "error", "redaction_status": "clean"})]
+        assert ActionChunker().chunk_one(events).outcome == "failed"
+
+    def test_last_event_outcome_takes_precedence(self) -> None:
+        events = [
+            _make_event(event_id="e1", payload={"outcome": "failed", "redaction_status": "clean"}),
+            _make_event(event_id="e2", payload={"outcome": "useful", "redaction_status": "clean"}),
+        ]
+        assert ActionChunker().chunk_one(events).outcome == "useful"
+
+    def test_invalid_outcome_in_payload_falls_back_to_unknown(self) -> None:
+        events = [_make_event(payload={"outcome": "bogus_value", "redaction_status": "clean"})]
+        assert ActionChunker().chunk_one(events).outcome == "unknown"
+
+
+class TestActionChunkerRisk:
+    def test_no_risk_info_returns_none_for_low_risk_kind(self) -> None:
+        events = [_make_event(event_type="search")]
+        assert ActionChunker().chunk_one(events).risk is None
+
+    def test_risk_from_payload(self) -> None:
+        events = [_make_event(payload={"risk": "high", "redaction_status": "clean"})]
+        assert ActionChunker().chunk_one(events).risk == "high"
+
+    def test_risk_low_from_payload(self) -> None:
+        events = [_make_event(payload={"risk": "low", "redaction_status": "clean"})]
+        assert ActionChunker().chunk_one(events).risk == "low"
+
+    def test_edit_kind_infers_medium_risk(self) -> None:
+        events = [_make_event(event_type="edit")]
+        assert ActionChunker().chunk_one(events).risk == "medium"
+
+    def test_failure_kind_infers_medium_risk(self) -> None:
+        events = [_make_event(event_type="failure")]
+        assert ActionChunker().chunk_one(events).risk == "medium"
+
+    def test_payload_risk_takes_precedence_over_inferred(self) -> None:
+        events = [
+            _make_event(event_type="edit", payload={"risk": "low", "redaction_status": "clean"})
+        ]
+        assert ActionChunker().chunk_one(events).risk == "low"
+
+    def test_invalid_risk_in_payload_falls_back_to_inferred(self) -> None:
+        events = [
+            _make_event(event_type="edit", payload={"risk": "extreme", "redaction_status": "clean"})
+        ]
+        assert ActionChunker().chunk_one(events).risk == "medium"
+
+
+class TestActionChunkerFields:
+    def test_session_id_propagated(self) -> None:
+        chunk = ActionChunker().chunk_one([_make_event(session_id="sess-XYZ")])
+        assert chunk.session_id == "sess-XYZ"
+
+    def test_turn_id_propagated(self) -> None:
+        chunk = ActionChunker().chunk_one([_make_event(turn_id="turn-42")])
+        assert chunk.turn_id == "turn-42"
+
+    def test_repo_id_propagated(self) -> None:
+        chunk = ActionChunker().chunk_one([_make_event(repo_id="repo-ABC")])
+        assert chunk.repo_id == "repo-ABC"
+
+    def test_timestamps_propagated(self) -> None:
+        events = [
+            _make_event(event_id="e1", timestamp="2024-01-01T10:00:00+00:00"),
+            _make_event(event_id="e2", timestamp="2024-01-01T11:00:00+00:00"),
+        ]
+        chunk = ActionChunker().chunk_one(events)
+        assert chunk.started_at == "2024-01-01T10:00:00+00:00"
+        assert chunk.ended_at == "2024-01-01T11:00:00+00:00"
+
+    def test_single_event_started_equals_ended(self) -> None:
+        chunk = ActionChunker().chunk_one([_make_event(timestamp="2024-01-01T00:00:00+00:00")])
+        assert chunk.started_at == chunk.ended_at
+
+    def test_commit_from_payload(self) -> None:
+        events = [_make_event(payload={"commit": "abc123def", "redaction_status": "clean"})]
+        assert ActionChunker().chunk_one(events).commit == "abc123def"
+
+    def test_last_event_commit_wins(self) -> None:
+        events = [
+            _make_event(event_id="e1", payload={"commit": "old-sha", "redaction_status": "clean"}),
+            _make_event(event_id="e2", payload={"commit": "new-sha", "redaction_status": "clean"}),
+        ]
+        assert ActionChunker().chunk_one(events).commit == "new-sha"
+
+    def test_no_commit_in_payload_is_none(self) -> None:
+        assert ActionChunker().chunk_one([_make_event()]).commit is None
+
+    def test_summary_contains_kind(self) -> None:
+        chunk = ActionChunker().chunk_one([_make_event(event_type="file_read")])
+        assert "file_inspection" in chunk.summary
+
+    def test_summary_contains_event_count(self) -> None:
+        events = [_make_event(event_id=f"e{i}") for i in range(3)]
+        chunk = ActionChunker().chunk_one(events)
+        assert "3 events" in chunk.summary
+
+
+class TestActionChunkerRedactionStatus:
+    def test_redacted_if_any_event_redacted(self) -> None:
+        events = [
+            _make_event(event_id="e1", payload={"redaction_status": "clean"}),
+            _make_event(event_id="e2", payload={"redaction_status": "redacted"}),
+        ]
+        assert ActionChunker().chunk_one(events).redaction_status == "redacted"
+
+    def test_clean_if_all_events_clean(self) -> None:
+        events = [
+            _make_event(event_id="e1", payload={"redaction_status": "clean"}),
+            _make_event(event_id="e2", payload={"redaction_status": "clean"}),
+        ]
+        assert ActionChunker().chunk_one(events).redaction_status == "clean"
+
+    def test_unknown_if_status_missing(self) -> None:
+        events = [_make_event(payload={})]
+        assert ActionChunker().chunk_one(events).redaction_status == "unknown"
+
+    def test_unknown_if_mixed_statuses(self) -> None:
+        events = [
+            _make_event(event_id="e1", payload={"redaction_status": "clean"}),
+            _make_event(event_id="e2", payload={}),
+        ]
+        assert ActionChunker().chunk_one(events).redaction_status == "unknown"
+
+
+class TestActionChunkerChunkOne:
+    def test_chunk_one_raises_on_empty(self) -> None:
+        with pytest.raises(ValueError, match="events must not be empty"):
+            ActionChunker().chunk_one([])
+
+    def test_chunk_one_ignores_turn_boundaries(self) -> None:
+        events = [
+            _make_event(event_id="e1", turn_id="t1"),
+            _make_event(event_id="e2", turn_id="t2"),
+        ]
+        chunk = ActionChunker().chunk_one(events)
+        assert set(chunk.event_ids) == {"e1", "e2"}
+
+    def test_chunk_one_returns_actionchunk_instance(self) -> None:
+        assert isinstance(ActionChunker().chunk_one([_make_event()]), ActionChunk)
+
+    def test_chunk_one_session_from_first_event(self) -> None:
+        events = [
+            _make_event(event_id="e1", session_id="sess-A"),
+            _make_event(event_id="e2", session_id="sess-B"),
+        ]
+        assert ActionChunker().chunk_one(events).session_id == "sess-A"


### PR DESCRIPTION
Closes #34

## Summary
- Adds `ActionChunker` for deterministic grouping of sanitized `StoredEvent` records into v0.2 `ActionChunk` models.
- Infers chunk kind, outcome, risk, redaction status, timestamps, commit linkage, and source event IDs.
- Adds issue-specific design, implementation, and verification reports.

## Verification
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m mypy photon_action_memory tests`
- `python -m pytest -q`
- See `dev-reports/issue-34/verification.md`.