### PR TITLE
#35 Implement ActionSummaryBuilder

### DIFF
--- a/dev-reports/issue-35/design.md
+++ b/dev-reports/issue-35/design.md
@@ -1,0 +1,60 @@
+# Design: ActionSummaryBuilder (Issue #35)
+
+## Goal
+
+Implement `ActionSummaryBuilder`, `SummaryCanonicalizer`, and `SummaryStateUpdater` in
+`photon_action_memory/memory/summaries.py`.  All three operate on the v0.2 schema models
+from `photon_action_memory.api.schema_v2`.
+
+## Key Design Decisions
+
+### 1. Deterministic-only fallback
+
+No LLM call is made.  All claims are derived directly from `ActionChunk` fields using
+the heuristics specified in `04_architecture.md` section 8.
+
+### 2. Outcome -> category mapping
+
+| chunk.outcome | Produces           | Does NOT produce |
+|---------------|--------------------|-----------------|
+| `useful`      | Fact (with evidence_ids) | Hypothesis, FailedAttempt |
+| `partial`     | Hypothesis (open)  | Fact, FailedAttempt |
+| `failed`      | FailedAttempt      | Fact, Hypothesis |
+| `irrelevant`  | AvoidGuidance      | Fact, Hypothesis, FailedAttempt |
+| `unknown`     | (nothing extra)    | Fact, Hypothesis, FailedAttempt |
+
+`actions_done` is always populated regardless of outcome.
+
+### 3. Evidence grounding invariant
+
+Facts are emitted only when `chunk.event_ids` is non-empty.  The `SummaryCanonicalizer`
+enforces this post-hoc by stripping any `Fact` without `evidence_ids` and downgrading
+`validity` to `"partial"`.
+
+### 4. Hypotheses stay separate from facts
+
+`Hypothesis` objects are never added to `facts` and vice versa.  Both carry a `status`
+field (`"open"` for newly created hypotheses).
+
+### 5. Incremental update: `S_t = update(S_{t-1}, ActionChunk_t)`
+
+`SummaryStateUpdater.update()` calls `ActionSummaryBuilder` to produce a chunk-level
+summary, canonicalizes it, then merges fields into the previous state:
+
+- `source_chunk_ids` - append new chunk_id
+- `actions_done` - concatenate all (no deduplication; each action is distinct)
+- `facts`, `hypotheses` - deduplicated by `.text` (same observation seen twice -> kept once)
+- `failed_attempts` - deduplicated by `.action` key
+- `avoid` - deduplicated by `.action` key
+- `next_hints` - replaced by the new chunk's hints (more recent is more relevant)
+- `token_cost` - summed
+
+### 6. Token cost estimation
+
+A heuristic of 200 raw tokens per event is used when actual event storage is unavailable.
+`max(summary_tokens, events * 200)` ensures `tokens_saved_vs_raw >= 0`.
+
+### 7. Type-safe merge helper
+
+`_merge_by_text` uses a `TypeVar` bound to a `_HasText` Protocol to work for both
+`list[Fact]` and `list[Hypothesis]` without `type: ignore` or dynamic casting.

--- a/dev-reports/issue-35/implementation-summary.md
+++ b/dev-reports/issue-35/implementation-summary.md
@@ -1,0 +1,55 @@
+# Implementation Summary: Issue #35
+
+## Files added / modified
+
+| File | Change |
+|------|--------|
+| `photon_action_memory/memory/summaries.py` | New: ActionSummaryBuilder, SummaryCanonicalizer, SummaryStateUpdater |
+| `tests/test_summaries.py` | New: 59 tests covering all three classes |
+| `dev-reports/issue-35/design.md` | New: design rationale |
+| `dev-reports/issue-35/implementation-summary.md` | This file |
+| `dev-reports/issue-35/verification.md` | Verification results |
+
+## Public API
+
+### `ActionSummaryBuilder`
+
+```python
+builder = ActionSummaryBuilder()
+summary: ActionSummary = builder.build(chunk, summary_id=None)
+```
+
+Converts one `ActionChunk` into an `ActionSummary` using deterministic heuristics.
+All claims are grounded in `chunk.event_ids`.
+
+### `SummaryCanonicalizer`
+
+```python
+canonicalizer = SummaryCanonicalizer()
+result: CanonicalizeResult = canonicalizer.canonicalize(summary)
+# result.summary - cleaned ActionSummary
+# result.removed_ungrounded_facts - int
+# result.warnings - list[str]
+```
+
+Removes `Fact` objects that have no `evidence_ids` and updates `validity` accordingly.
+
+### `SummaryStateUpdater`
+
+```python
+updater = SummaryStateUpdater()
+s_t: ActionSummary = updater.update(s_prev, chunk, summary_id=None)
+```
+
+Incremental state update: `S_t = update(S_{t-1}, ActionChunk_t)`.
+
+## Acceptance criteria mapping
+
+| Criterion | Implementation |
+|-----------|---------------|
+| ActionSummary from ActionChunk | `ActionSummaryBuilder.build()` |
+| Facts require evidence_ids | Builder skips facts when `event_ids=[]`; Canonicalizer strips any that slip through |
+| Hypotheses separated, with status/confidence | `outcome="partial"` -> `Hypothesis(status="open", confidence=0.5)` |
+| Failed actions not in facts | `outcome="failed"` -> `FailedAttempt` only |
+| Avoid/next_hints representable | `outcome="irrelevant"` -> `AvoidGuidance`; chunk-kind heuristics -> `NextHint` |
+| Incremental update | `SummaryStateUpdater.update(prev, chunk)` |

--- a/dev-reports/issue-35/verification.md
+++ b/dev-reports/issue-35/verification.md
@@ -1,0 +1,56 @@
+# Verification: Issue #35
+
+## Commands run
+
+```
+python -m ruff format --check .
+python -m ruff check .
+python -m mypy photon_action_memory tests
+python -m pytest -q tests/test_summaries.py
+python -m pytest -q
+```
+
+## Results
+
+### `ruff format --check .`
+
+```
+45 files already formatted
+```
+Exit 0 - PASS
+
+### `ruff check .`
+
+```
+All checks passed!
+```
+Exit 0 - PASS
+
+### `mypy photon_action_memory tests`
+
+```
+Success: no issues found in 43 source files
+```
+Exit 0 - PASS (strict mode, Python 3.12)
+
+### `pytest -q tests/test_summaries.py`
+
+```
+59 passed in 0.08s
+```
+Exit 0 - PASS
+
+### `pytest -q` (full suite)
+
+```
+205 passed, 1 skipped in 1.07s
+```
+Exit 0 - PASS (1 skipped is MLX smoke test, unrelated to this issue)
+
+## Coverage summary (tests/test_summaries.py)
+
+| Class | Tests |
+|-------|-------|
+| `ActionSummaryBuilder` | 30 tests covering all outcomes, evidence grounding, fact/hypothesis/failed separation, next hints, token cost |
+| `SummaryCanonicalizer` | 9 tests covering grounded/ungrounded facts, validity downgrade, hypotheses untouched |
+| `SummaryStateUpdater` | 20 tests covering merge/dedup for all list fields, incremental multi-turn simulation, token cost accumulation |

--- a/photon_action_memory/memory/summaries.py
+++ b/photon_action_memory/memory/summaries.py
@@ -1,0 +1,330 @@
+"""Action Summary Builder, Canonicalizer, and State Updater for v0.2."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    ActionChunk,
+    ActionDone,
+    ActionSummary,
+    AvoidGuidance,
+    Fact,
+    FailedAttempt,
+    Hypothesis,
+    NextHint,
+    TokenCost,
+    Validity,
+)
+
+_CHARS_PER_TOKEN: int = 4
+_HEURISTIC_RAW_TOKENS_PER_EVENT: int = 200
+
+
+def _estimate_tokens(text: str) -> int:
+    return max(1, len(text) // _CHARS_PER_TOKEN)
+
+
+def _deterministic_summary_id(*parts: str) -> str:
+    key = "\n".join(parts)
+    digest = hashlib.sha256(key.encode()).hexdigest()[:16]
+    return f"sum-{digest}"
+
+
+class _HasText(Protocol):
+    """Structural type for items that can be deduplicated by `.text`."""
+
+    @property
+    def text(self) -> str: ...
+
+
+class ActionSummaryBuilder:
+    """Convert a single ActionChunk into an ActionSummary using deterministic heuristics.
+
+    No external model is required; all claims are grounded in chunk.event_ids.
+    Rules (deterministic fallback from 04_architecture.md section 8):
+    - outcome=useful + event_ids present -> Fact
+    - outcome=partial                    -> Hypothesis (open, confidence 0.5)
+    - outcome=failed                     -> FailedAttempt (never Fact)
+    - outcome=irrelevant                 -> AvoidGuidance
+    """
+
+    def build(
+        self,
+        chunk: ActionChunk,
+        *,
+        summary_id: str | None = None,
+    ) -> ActionSummary:
+        """Return an ActionSummary derived from *chunk*."""
+        sid = summary_id or _deterministic_summary_id(chunk.chunk_id)
+        evidence_ids = list(chunk.event_ids)
+        outcome = str(chunk.outcome)
+
+        return ActionSummary(
+            schema_version=DEFAULT_SCHEMA_VERSION_V2,
+            summary_id=sid,
+            session_id=chunk.session_id,
+            repo_id=chunk.repo_id,
+            commit=chunk.commit,
+            summary_level="chunk",
+            source_chunk_ids=[chunk.chunk_id],
+            actions_done=self._actions_done(chunk, evidence_ids, outcome),
+            facts=self._facts(chunk, evidence_ids, outcome),
+            hypotheses=self._hypotheses(chunk, evidence_ids, outcome),
+            failed_attempts=self._failed_attempts(chunk, evidence_ids, outcome),
+            avoid=self._avoid(chunk, evidence_ids, outcome),
+            next_hints=self._next_hints(chunk, outcome),
+            token_cost=self._token_cost(chunk),
+            validity=Validity(status="valid"),
+        )
+
+    # ------------------------------------------------------------------
+    # Internal builders - each returns a typed list.
+    # ------------------------------------------------------------------
+
+    def _actions_done(
+        self,
+        chunk: ActionChunk,
+        evidence_ids: list[str],
+        outcome: str,
+    ) -> list[ActionDone]:
+        return [
+            ActionDone(
+                kind=str(chunk.kind),
+                outcome=chunk.summary,
+                status=outcome,
+                evidence_ids=evidence_ids,
+            )
+        ]
+
+    def _facts(
+        self,
+        chunk: ActionChunk,
+        evidence_ids: list[str],
+        outcome: str,
+    ) -> list[Fact]:
+        # Facts require evidence_ids and a definitively successful outcome.
+        if outcome != "useful" or not evidence_ids:
+            return []
+        return [Fact(text=chunk.summary, evidence_ids=evidence_ids, confidence=0.9)]
+
+    def _hypotheses(
+        self,
+        chunk: ActionChunk,
+        evidence_ids: list[str],
+        outcome: str,
+    ) -> list[Hypothesis]:
+        # Partial outcomes produce open hypotheses, separated from facts.
+        if outcome != "partial":
+            return []
+        return [
+            Hypothesis(
+                text=chunk.summary,
+                evidence_ids=evidence_ids,
+                confidence=0.5,
+                status="open",
+            )
+        ]
+
+    def _failed_attempts(
+        self,
+        chunk: ActionChunk,
+        evidence_ids: list[str],
+        outcome: str,
+    ) -> list[FailedAttempt]:
+        # Failed actions tracked separately to prevent pointless retries.
+        if outcome != "failed":
+            return []
+        return [
+            FailedAttempt(
+                action=f"{chunk.kind}: {chunk.summary}",
+                outcome=chunk.summary,
+                evidence_ids=evidence_ids,
+                retry_policy="avoid_until_files_changed",
+            )
+        ]
+
+    def _avoid(
+        self,
+        chunk: ActionChunk,
+        evidence_ids: list[str],
+        outcome: str,
+    ) -> list[AvoidGuidance]:
+        if outcome != "irrelevant":
+            return []
+        return [
+            AvoidGuidance(
+                action=f"{chunk.kind}: {chunk.summary}",
+                reason="action produced no useful result",
+                evidence_ids=evidence_ids,
+            )
+        ]
+
+    def _next_hints(self, chunk: ActionChunk, outcome: str) -> list[NextHint]:
+        if outcome == "failed":
+            return [
+                NextHint(
+                    kind="inspect",
+                    reason="investigate failure before retrying",
+                    confidence=0.6,
+                )
+            ]
+        if outcome in ("useful", "partial") and chunk.kind == "repo_search":
+            return [NextHint(kind="read", reason="inspect files found by search", confidence=0.7)]
+        return []
+
+    def _token_cost(self, chunk: ActionChunk) -> TokenCost:
+        summary_tokens = _estimate_tokens(chunk.summary)
+        raw_tokens = max(
+            summary_tokens,
+            len(chunk.event_ids) * _HEURISTIC_RAW_TOKENS_PER_EVENT,
+        )
+        return TokenCost(
+            estimated_summary_tokens=summary_tokens,
+            estimated_raw_tokens=raw_tokens,
+            tokens_saved_vs_raw=raw_tokens - summary_tokens,
+        )
+
+
+@dataclass
+class CanonicalizeResult:
+    """Outcome of a canonicalize pass."""
+
+    summary: ActionSummary
+    removed_ungrounded_facts: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+
+class SummaryCanonicalizer:
+    """Validate and normalize an ActionSummary to enforce evidence-grounding rules.
+
+    Key invariant: every prompt-visible fact must carry at least one evidence_id.
+    Facts without evidence_ids are removed and the validity is downgraded to
+    ``partial`` so callers can detect the degradation.
+    """
+
+    def canonicalize(self, summary: ActionSummary) -> CanonicalizeResult:
+        """Return a normalized summary and a report of any items removed."""
+        grounded: list[Fact] = []
+        removed = 0
+        warnings: list[str] = []
+
+        for fact in summary.facts:
+            if fact.evidence_ids:
+                grounded.append(fact)
+            else:
+                removed += 1
+                warnings.append(f"removed ungrounded fact: {fact.text[:60]!r}")
+
+        validity = summary.validity
+        if removed > 0 and validity.status == "valid":
+            validity = Validity(
+                status="partial",
+                reason=f"removed {removed} ungrounded fact(s)",
+            )
+
+        updated = summary.model_copy(update={"facts": grounded, "validity": validity})
+        return CanonicalizeResult(
+            summary=updated,
+            removed_ungrounded_facts=removed,
+            warnings=warnings,
+        )
+
+
+class SummaryStateUpdater:
+    """Incrementally update an existing ActionSummary with a new ActionChunk.
+
+    Implements the recursive state update from 04_architecture.md section 4:
+        S_t = update(S_{t-1}, ActionChunk_t)
+
+    The updater builds a chunk-level summary, canonicalizes it, then merges it
+    into the previous state.  Deduplication is by text/action identity so that
+    repeated observations do not inflate the summary.
+    """
+
+    def __init__(self) -> None:
+        self._builder = ActionSummaryBuilder()
+        self._canonicalizer = SummaryCanonicalizer()
+
+    def update(
+        self,
+        previous: ActionSummary,
+        chunk: ActionChunk,
+        *,
+        summary_id: str | None = None,
+    ) -> ActionSummary:
+        """Merge *chunk* into *previous* and return the updated state."""
+        chunk_summary = self._builder.build(chunk)
+        result = self._canonicalizer.canonicalize(chunk_summary)
+        new = result.summary
+
+        sid = summary_id or _deterministic_summary_id(previous.summary_id, chunk.chunk_id)
+
+        return ActionSummary(
+            schema_version=DEFAULT_SCHEMA_VERSION_V2,
+            summary_id=sid,
+            session_id=previous.session_id or chunk.session_id,
+            repo_id=previous.repo_id or chunk.repo_id,
+            commit=chunk.commit or previous.commit,
+            summary_level=previous.summary_level,
+            source_chunk_ids=[*previous.source_chunk_ids, chunk.chunk_id],
+            actions_done=[*previous.actions_done, *new.actions_done],
+            facts=_merge_by_text(previous.facts, new.facts),
+            hypotheses=_merge_by_text(previous.hypotheses, new.hypotheses),
+            failed_attempts=_merge_failed(previous.failed_attempts, new.failed_attempts),
+            avoid=_merge_avoid(previous.avoid, new.avoid),
+            next_hints=new.next_hints,  # newer chunk's hints are more relevant
+            token_cost=_add_token_costs(previous.token_cost, new.token_cost),
+            validity=Validity(status="valid"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Merge helpers - module-private
+# ---------------------------------------------------------------------------
+
+
+def _merge_by_text[T: _HasText](prev: list[T], new: list[T]) -> list[T]:
+    seen: set[str] = {item.text for item in prev}
+    return [*prev, *(item for item in new if item.text not in seen)]
+
+
+def _merge_failed(
+    prev: list[FailedAttempt],
+    new: list[FailedAttempt],
+) -> list[FailedAttempt]:
+    seen: set[str] = {f.action for f in prev}
+    return [*prev, *(f for f in new if f.action not in seen)]
+
+
+def _merge_avoid(
+    prev: list[AvoidGuidance],
+    new: list[AvoidGuidance],
+) -> list[AvoidGuidance]:
+    seen: set[str] = {a.action for a in prev}
+    return [*prev, *(a for a in new if a.action not in seen)]
+
+
+def _add_token_costs(prev: TokenCost | None, new: TokenCost | None) -> TokenCost | None:
+    if prev is None:
+        return new
+    if new is None:
+        return prev
+    summary = prev.estimated_summary_tokens + new.estimated_summary_tokens
+    raw = prev.estimated_raw_tokens + new.estimated_raw_tokens
+    return TokenCost(
+        estimated_summary_tokens=summary,
+        estimated_raw_tokens=raw,
+        tokens_saved_vs_raw=raw - summary,
+    )
+
+
+__all__ = [
+    "ActionSummaryBuilder",
+    "CanonicalizeResult",
+    "SummaryCanonicalizer",
+    "SummaryStateUpdater",
+]

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -1,0 +1,614 @@
+"""Tests for ActionSummaryBuilder, SummaryCanonicalizer, and SummaryStateUpdater."""
+
+from __future__ import annotations
+
+import pytest
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    ActionChunk,
+    ActionSummary,
+)
+from photon_action_memory.memory.summaries import (
+    ActionSummaryBuilder,
+    CanonicalizeResult,
+    SummaryCanonicalizer,
+    SummaryStateUpdater,
+)
+
+SCHEMA_V2 = DEFAULT_SCHEMA_VERSION_V2
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _chunk(
+    *,
+    chunk_id: str = "chunk_001",
+    session_id: str = "sess_001",
+    kind: str = "repo_search",
+    summary: str = "Searched SessionStore.",
+    outcome: str = "useful",
+    event_ids: list[str] | None = None,
+    repo_id: str | None = "repo_001",
+    commit: str | None = "abc123",
+) -> ActionChunk:
+    return ActionChunk.model_validate(
+        {
+            "schema_version": SCHEMA_V2,
+            "chunk_id": chunk_id,
+            "session_id": session_id,
+            "kind": kind,
+            "summary": summary,
+            "outcome": outcome,
+            "event_ids": ["evt_001"] if event_ids is None else event_ids,
+            "repo_id": repo_id,
+            "commit": commit,
+        }
+    )
+
+
+def _minimal_summary(
+    *,
+    summary_id: str = "sum_000",
+    session_id: str = "sess_001",
+    repo_id: str = "repo_001",
+) -> ActionSummary:
+    return ActionSummary.model_validate(
+        {
+            "schema_version": SCHEMA_V2,
+            "summary_id": summary_id,
+            "session_id": session_id,
+            "repo_id": repo_id,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# ActionSummaryBuilder
+# ---------------------------------------------------------------------------
+
+
+class TestActionSummaryBuilder:
+    def setup_method(self) -> None:
+        self.builder = ActionSummaryBuilder()
+
+    def test_build_returns_action_summary(self) -> None:
+        summary = self.builder.build(_chunk())
+        assert isinstance(summary, ActionSummary)
+        assert summary.schema_version == SCHEMA_V2
+
+    def test_build_propagates_session_and_repo(self) -> None:
+        summary = self.builder.build(_chunk(session_id="sess_x", repo_id="repo_x"))
+        assert summary.session_id == "sess_x"
+        assert summary.repo_id == "repo_x"
+
+    def test_build_source_chunk_ids(self) -> None:
+        summary = self.builder.build(_chunk(chunk_id="chunk_017"))
+        assert summary.source_chunk_ids == ["chunk_017"]
+
+    def test_build_summary_level_is_chunk(self) -> None:
+        summary = self.builder.build(_chunk())
+        assert summary.summary_level == "chunk"
+
+    def test_build_custom_summary_id(self) -> None:
+        summary = self.builder.build(_chunk(), summary_id="sum_custom")
+        assert summary.summary_id == "sum_custom"
+
+    def test_build_auto_generates_deterministic_summary_id(self) -> None:
+        s1 = self.builder.build(_chunk())
+        s2 = self.builder.build(_chunk())
+        assert s1.summary_id.startswith("sum-")
+        assert s1.summary_id == s2.summary_id
+
+    def test_build_auto_summary_id_changes_by_chunk_id(self) -> None:
+        s1 = self.builder.build(_chunk(chunk_id="chunk_001"))
+        s2 = self.builder.build(_chunk(chunk_id="chunk_002"))
+        assert s1.summary_id != s2.summary_id
+
+    # --- actions_done ---
+
+    def test_actions_done_always_populated(self) -> None:
+        for outcome in ("useful", "failed", "partial", "irrelevant", "unknown"):
+            summary = self.builder.build(_chunk(outcome=outcome))
+            assert len(summary.actions_done) == 1
+            assert summary.actions_done[0].status == outcome
+
+    def test_actions_done_carries_evidence_ids(self) -> None:
+        summary = self.builder.build(_chunk(event_ids=["evt_041", "evt_042"]))
+        assert summary.actions_done[0].evidence_ids == ["evt_041", "evt_042"]
+
+    # --- facts ---
+
+    def test_useful_chunk_produces_fact(self) -> None:
+        summary = self.builder.build(_chunk(outcome="useful", event_ids=["evt_041"]))
+        assert len(summary.facts) == 1
+        assert summary.facts[0].evidence_ids == ["evt_041"]
+        assert summary.facts[0].confidence == pytest.approx(0.9)
+
+    def test_facts_require_evidence_ids(self) -> None:
+        summary = self.builder.build(_chunk(outcome="useful", event_ids=[]))
+        assert summary.facts == []
+
+    def test_failed_chunk_produces_no_facts(self) -> None:
+        summary = self.builder.build(_chunk(outcome="failed", event_ids=["evt_001"]))
+        assert summary.facts == []
+
+    def test_partial_chunk_produces_no_facts(self) -> None:
+        summary = self.builder.build(_chunk(outcome="partial", event_ids=["evt_001"]))
+        assert summary.facts == []
+
+    def test_irrelevant_chunk_produces_no_facts(self) -> None:
+        summary = self.builder.build(_chunk(outcome="irrelevant", event_ids=["evt_001"]))
+        assert summary.facts == []
+
+    def test_unknown_outcome_produces_no_facts(self) -> None:
+        summary = self.builder.build(_chunk(outcome="unknown"))
+        assert summary.facts == []
+
+    # --- hypotheses ---
+
+    def test_partial_chunk_produces_hypothesis(self) -> None:
+        summary = self.builder.build(_chunk(outcome="partial", event_ids=["evt_001"]))
+        assert len(summary.hypotheses) == 1
+        assert summary.hypotheses[0].status == "open"
+        assert summary.hypotheses[0].confidence == pytest.approx(0.5)
+        assert summary.hypotheses[0].evidence_ids == ["evt_001"]
+
+    def test_useful_chunk_produces_no_hypotheses(self) -> None:
+        summary = self.builder.build(_chunk(outcome="useful"))
+        assert summary.hypotheses == []
+
+    def test_failed_chunk_produces_no_hypotheses(self) -> None:
+        summary = self.builder.build(_chunk(outcome="failed"))
+        assert summary.hypotheses == []
+
+    # --- failed_attempts ---
+
+    def test_failed_chunk_produces_failed_attempt(self) -> None:
+        summary = self.builder.build(
+            _chunk(outcome="failed", kind="test_verification", summary="cargo test failed.")
+        )
+        assert len(summary.failed_attempts) == 1
+        fa = summary.failed_attempts[0]
+        assert "test_verification" in fa.action
+        assert fa.retry_policy == "avoid_until_files_changed"
+
+    def test_failed_attempt_carries_evidence_ids(self) -> None:
+        summary = self.builder.build(_chunk(outcome="failed", event_ids=["evt_052"]))
+        assert summary.failed_attempts[0].evidence_ids == ["evt_052"]
+
+    def test_useful_chunk_produces_no_failed_attempts(self) -> None:
+        summary = self.builder.build(_chunk(outcome="useful"))
+        assert summary.failed_attempts == []
+
+    # --- avoid ---
+
+    def test_irrelevant_chunk_produces_avoid_guidance(self) -> None:
+        summary = self.builder.build(_chunk(outcome="irrelevant", event_ids=["evt_099"]))
+        assert len(summary.avoid) == 1
+        assert summary.avoid[0].reason == "action produced no useful result"
+        assert summary.avoid[0].evidence_ids == ["evt_099"]
+
+    def test_useful_chunk_produces_no_avoid(self) -> None:
+        summary = self.builder.build(_chunk(outcome="useful"))
+        assert summary.avoid == []
+
+    def test_failed_chunk_produces_no_avoid(self) -> None:
+        summary = self.builder.build(_chunk(outcome="failed"))
+        assert summary.avoid == []
+
+    # --- next_hints ---
+
+    def test_failed_chunk_produces_inspect_hint(self) -> None:
+        summary = self.builder.build(_chunk(outcome="failed"))
+        assert len(summary.next_hints) == 1
+        assert summary.next_hints[0].kind == "inspect"
+
+    def test_useful_repo_search_produces_read_hint(self) -> None:
+        summary = self.builder.build(_chunk(outcome="useful", kind="repo_search"))
+        assert len(summary.next_hints) == 1
+        assert summary.next_hints[0].kind == "read"
+
+    def test_partial_repo_search_produces_read_hint(self) -> None:
+        summary = self.builder.build(_chunk(outcome="partial", kind="repo_search"))
+        assert len(summary.next_hints) == 1
+        assert summary.next_hints[0].kind == "read"
+
+    def test_useful_non_search_chunk_produces_no_hints(self) -> None:
+        summary = self.builder.build(_chunk(outcome="useful", kind="file_inspection"))
+        assert summary.next_hints == []
+
+    # --- token_cost ---
+
+    def test_token_cost_summary_tokens_ge_one(self) -> None:
+        summary = self.builder.build(_chunk(summary="X"))
+        assert summary.token_cost is not None
+        assert summary.token_cost.estimated_summary_tokens >= 1
+
+    def test_token_cost_raw_ge_summary(self) -> None:
+        summary = self.builder.build(_chunk(event_ids=["evt_001", "evt_002"]))
+        assert summary.token_cost is not None
+        assert (
+            summary.token_cost.estimated_raw_tokens >= summary.token_cost.estimated_summary_tokens
+        )
+
+    def test_token_cost_savings(self) -> None:
+        summary = self.builder.build(_chunk(event_ids=["evt_001", "evt_002"]))
+        tc = summary.token_cost
+        assert tc is not None
+        assert tc.tokens_saved_vs_raw == tc.estimated_raw_tokens - tc.estimated_summary_tokens
+
+    def test_token_cost_with_no_events(self) -> None:
+        summary = self.builder.build(_chunk(event_ids=[]))
+        assert summary.token_cost is not None
+        assert summary.token_cost.tokens_saved_vs_raw == 0
+
+    # --- validity ---
+
+    def test_built_summary_validity_is_valid(self) -> None:
+        summary = self.builder.build(_chunk())
+        assert summary.validity.status == "valid"
+
+    # --- fact/hypothesis/failed separation invariant ---
+
+    def test_failed_chunk_not_in_facts_not_in_hypotheses(self) -> None:
+        summary = self.builder.build(_chunk(outcome="failed"))
+        assert summary.facts == []
+        assert summary.hypotheses == []
+        assert len(summary.failed_attempts) == 1
+
+    def test_useful_chunk_not_in_failed_not_in_hypotheses(self) -> None:
+        summary = self.builder.build(_chunk(outcome="useful"))
+        assert summary.failed_attempts == []
+        assert summary.hypotheses == []
+        assert len(summary.facts) == 1
+
+
+# ---------------------------------------------------------------------------
+# SummaryCanonicalizer
+# ---------------------------------------------------------------------------
+
+
+class TestSummaryCanonicalizer:
+    def setup_method(self) -> None:
+        self.canonicalizer = SummaryCanonicalizer()
+
+    def _summary_with_facts(self, facts: list[dict[str, object]]) -> ActionSummary:
+        return ActionSummary.model_validate(
+            {
+                "schema_version": SCHEMA_V2,
+                "summary_id": "sum_test",
+                "facts": facts,
+            }
+        )
+
+    def test_grounded_fact_kept(self) -> None:
+        summary = self._summary_with_facts(
+            [{"text": "Store is in store.rs.", "evidence_ids": ["evt_001"]}]
+        )
+        result = self.canonicalizer.canonicalize(summary)
+        assert isinstance(result, CanonicalizeResult)
+        assert result.removed_ungrounded_facts == 0
+        assert len(result.summary.facts) == 1
+
+    def test_ungrounded_fact_removed(self) -> None:
+        summary = self._summary_with_facts([{"text": "Ungrounded claim.", "evidence_ids": []}])
+        result = self.canonicalizer.canonicalize(summary)
+        assert result.removed_ungrounded_facts == 1
+        assert result.summary.facts == []
+        assert len(result.warnings) == 1
+
+    def test_mixed_facts_only_grounded_kept(self) -> None:
+        summary = self._summary_with_facts(
+            [
+                {"text": "Grounded.", "evidence_ids": ["evt_001"]},
+                {"text": "Ungrounded.", "evidence_ids": []},
+            ]
+        )
+        result = self.canonicalizer.canonicalize(summary)
+        assert result.removed_ungrounded_facts == 1
+        assert len(result.summary.facts) == 1
+        assert result.summary.facts[0].text == "Grounded."
+
+    def test_validity_downgraded_when_facts_removed(self) -> None:
+        summary = self._summary_with_facts([{"text": "Bad fact.", "evidence_ids": []}])
+        result = self.canonicalizer.canonicalize(summary)
+        assert result.summary.validity.status == "partial"
+        assert result.summary.validity.reason is not None
+
+    def test_validity_not_changed_for_already_non_valid(self) -> None:
+        raw = ActionSummary.model_validate(
+            {
+                "schema_version": SCHEMA_V2,
+                "summary_id": "sum_test",
+                "facts": [{"text": "Bad.", "evidence_ids": []}],
+                "validity": {"status": "stale"},
+            }
+        )
+        result = self.canonicalizer.canonicalize(raw)
+        # validity was already non-valid; should not overwrite it
+        assert result.summary.validity.status == "stale"
+
+    def test_empty_summary_unchanged(self) -> None:
+        summary = _minimal_summary()
+        result = self.canonicalizer.canonicalize(summary)
+        assert result.removed_ungrounded_facts == 0
+        assert result.warnings == []
+        assert result.summary.facts == []
+
+    def test_warning_message_contains_fact_text_snippet(self) -> None:
+        summary = self._summary_with_facts(
+            [{"text": "This is a specific fact.", "evidence_ids": []}]
+        )
+        result = self.canonicalizer.canonicalize(summary)
+        assert any("This is a specific fact." in w for w in result.warnings)
+
+    def test_hypotheses_untouched(self) -> None:
+        summary = ActionSummary.model_validate(
+            {
+                "schema_version": SCHEMA_V2,
+                "summary_id": "sum_test",
+                "hypotheses": [
+                    {
+                        "text": "Maybe serde path.",
+                        "evidence_ids": ["evt_052"],
+                        "status": "open",
+                    }
+                ],
+            }
+        )
+        result = self.canonicalizer.canonicalize(summary)
+        assert len(result.summary.hypotheses) == 1
+        assert result.summary.hypotheses[0].status == "open"
+
+
+# ---------------------------------------------------------------------------
+# SummaryStateUpdater
+# ---------------------------------------------------------------------------
+
+
+class TestSummaryStateUpdater:
+    def setup_method(self) -> None:
+        self.updater = SummaryStateUpdater()
+
+    def test_update_returns_action_summary(self) -> None:
+        prev = _minimal_summary()
+        updated = self.updater.update(prev, _chunk())
+        assert isinstance(updated, ActionSummary)
+        assert updated.schema_version == SCHEMA_V2
+
+    def test_update_appends_source_chunk_ids(self) -> None:
+        prev = ActionSummary.model_validate(
+            {
+                "schema_version": SCHEMA_V2,
+                "summary_id": "sum_000",
+                "source_chunk_ids": ["chunk_000"],
+            }
+        )
+        updated = self.updater.update(prev, _chunk(chunk_id="chunk_001"))
+        assert updated.source_chunk_ids == ["chunk_000", "chunk_001"]
+
+    def test_update_appends_actions_done(self) -> None:
+        prev = _minimal_summary()
+        updated = self.updater.update(prev, _chunk())
+        assert len(updated.actions_done) == 1
+
+        updated2 = self.updater.update(updated, _chunk(chunk_id="chunk_002", outcome="failed"))
+        assert len(updated2.actions_done) == 2
+
+    def test_update_merges_facts_without_duplicates(self) -> None:
+        prev = ActionSummary.model_validate(
+            {
+                "schema_version": SCHEMA_V2,
+                "summary_id": "sum_000",
+                "facts": [{"text": "Store is in store.rs.", "evidence_ids": ["evt_000"]}],
+            }
+        )
+        # chunk produces a different fact
+        updated = self.updater.update(
+            prev,
+            _chunk(outcome="useful", summary="Test found in tests/.", event_ids=["evt_001"]),
+        )
+        assert len(updated.facts) == 2
+
+    def test_update_deduplicates_facts_by_text(self) -> None:
+        prev = ActionSummary.model_validate(
+            {
+                "schema_version": SCHEMA_V2,
+                "summary_id": "sum_000",
+                "facts": [{"text": "Searched SessionStore.", "evidence_ids": ["evt_000"]}],
+            }
+        )
+        # chunk produces the exact same fact text
+        updated = self.updater.update(
+            prev,
+            _chunk(outcome="useful", summary="Searched SessionStore.", event_ids=["evt_001"]),
+        )
+        assert len(updated.facts) == 1
+
+    def test_update_merges_hypotheses(self) -> None:
+        prev = ActionSummary.model_validate(
+            {
+                "schema_version": SCHEMA_V2,
+                "summary_id": "sum_000",
+                "hypotheses": [
+                    {"text": "Maybe serde issue.", "evidence_ids": ["evt_010"], "status": "open"}
+                ],
+            }
+        )
+        updated = self.updater.update(
+            prev,
+            _chunk(outcome="partial", summary="Possible config mismatch.", event_ids=["evt_011"]),
+        )
+        assert len(updated.hypotheses) == 2
+
+    def test_update_merges_failed_attempts(self) -> None:
+        builder = ActionSummaryBuilder()
+        prev_chunk = _chunk(outcome="failed", chunk_id="chunk_001", summary="cargo test failed.")
+        prev = builder.build(prev_chunk)
+
+        updated = self.updater.update(
+            prev,
+            _chunk(outcome="failed", chunk_id="chunk_002", summary="make build failed."),
+        )
+        assert len(updated.failed_attempts) == 2
+
+    def test_update_deduplicates_failed_attempts(self) -> None:
+        builder = ActionSummaryBuilder()
+        prev_chunk = _chunk(
+            outcome="failed",
+            chunk_id="chunk_001",
+            kind="test_verification",
+            summary="cargo test failed.",
+        )
+        prev = builder.build(prev_chunk)
+
+        updated = self.updater.update(
+            prev,
+            _chunk(
+                outcome="failed",
+                chunk_id="chunk_002",
+                kind="test_verification",
+                summary="cargo test failed.",  # same text -> same action key
+            ),
+        )
+        assert len(updated.failed_attempts) == 1
+
+    def test_update_merges_avoid_guidance(self) -> None:
+        prev = ActionSummary.model_validate(
+            {
+                "schema_version": SCHEMA_V2,
+                "summary_id": "sum_000",
+                "avoid": [
+                    {
+                        "action": "repo_search: grep for X",
+                        "reason": "already done",
+                        "evidence_ids": ["evt_000"],
+                    }
+                ],
+            }
+        )
+        updated = self.updater.update(
+            prev,
+            _chunk(outcome="irrelevant", kind="file_inspection", summary="read irrelevant file"),
+        )
+        assert len(updated.avoid) == 2
+
+    def test_update_uses_newer_next_hints(self) -> None:
+        builder = ActionSummaryBuilder()
+        prev = builder.build(_chunk(outcome="useful", kind="repo_search"))
+        assert prev.next_hints  # has hints from first chunk
+
+        updated = self.updater.update(
+            prev,
+            _chunk(outcome="useful", kind="file_inspection", chunk_id="chunk_002"),
+        )
+        # file_inspection with useful outcome produces no hints in our heuristic
+        assert updated.next_hints == []
+
+    def test_update_adds_token_costs(self) -> None:
+        builder = ActionSummaryBuilder()
+        prev = builder.build(_chunk(event_ids=["evt_001"]))
+        assert prev.token_cost is not None
+        prev_raw = prev.token_cost.estimated_raw_tokens
+        prev_sum = prev.token_cost.estimated_summary_tokens
+
+        updated = self.updater.update(
+            prev,
+            _chunk(chunk_id="chunk_002", event_ids=["evt_002", "evt_003"]),
+        )
+        assert updated.token_cost is not None
+        assert updated.token_cost.estimated_raw_tokens > prev_raw
+        assert updated.token_cost.estimated_summary_tokens > prev_sum
+
+    def test_update_failed_chunk_not_in_facts(self) -> None:
+        prev = _minimal_summary()
+        updated = self.updater.update(
+            prev,
+            _chunk(outcome="failed", event_ids=["evt_052"]),
+        )
+        assert updated.facts == []
+        assert len(updated.failed_attempts) == 1
+
+    def test_update_custom_summary_id(self) -> None:
+        prev = _minimal_summary()
+        updated = self.updater.update(prev, _chunk(), summary_id="sum_custom")
+        assert updated.summary_id == "sum_custom"
+
+    def test_incremental_multi_step_session(self) -> None:
+        """Simulates a multi-turn session with mixed outcomes."""
+        builder = ActionSummaryBuilder()
+
+        # Turn 1: search -> useful
+        s1 = builder.build(
+            _chunk(
+                chunk_id="chunk_001",
+                kind="repo_search",
+                summary="Found SessionStore in store.rs.",
+                outcome="useful",
+                event_ids=["evt_001"],
+            )
+        )
+        assert len(s1.facts) == 1
+        assert s1.failed_attempts == []
+
+        # Turn 2: test -> failed
+        s2 = self.updater.update(
+            s1,
+            _chunk(
+                chunk_id="chunk_002",
+                kind="test_verification",
+                summary="cargo test session_persistence failed.",
+                outcome="failed",
+                event_ids=["evt_002"],
+            ),
+            summary_id="sum_002",
+        )
+        assert len(s2.facts) == 1
+        assert len(s2.failed_attempts) == 1
+        assert len(s2.source_chunk_ids) == 2
+        assert len(s2.actions_done) == 2
+
+        # Turn 3: file inspection -> partial
+        s3 = self.updater.update(
+            s2,
+            _chunk(
+                chunk_id="chunk_003",
+                kind="file_inspection",
+                summary="serde path may be related.",
+                outcome="partial",
+                event_ids=["evt_003"],
+            ),
+            summary_id="sum_003",
+        )
+        assert len(s3.facts) == 1
+        assert len(s3.hypotheses) == 1
+        assert len(s3.failed_attempts) == 1
+        assert len(s3.source_chunk_ids) == 3
+        assert s3.summary_id == "sum_003"
+
+    def test_update_inherits_session_id_from_previous(self) -> None:
+        prev = _minimal_summary(session_id="sess_inherited")
+        updated = self.updater.update(prev, _chunk(session_id="sess_new"))
+        assert updated.session_id == "sess_inherited"
+
+    def test_update_default_summary_id_is_deterministic(self) -> None:
+        prev = _minimal_summary(summary_id="sum_prev")
+        chunk = _chunk(chunk_id="chunk_next")
+        s1 = self.updater.update(prev, chunk)
+        s2 = self.updater.update(prev, chunk)
+        assert s1.summary_id.startswith("sum-")
+        assert s1.summary_id == s2.summary_id
+
+    def test_update_uses_chunk_commit(self) -> None:
+        prev = _minimal_summary()
+        updated = self.updater.update(prev, _chunk(commit="newcommit"))
+        assert updated.commit == "newcommit"
+
+    def test_update_validity_is_valid(self) -> None:
+        prev = _minimal_summary()
+        updated = self.updater.update(prev, _chunk())
+        assert updated.validity.status == "valid"


### PR DESCRIPTION
Closes #35

## Summary
- Adds deterministic `ActionSummaryBuilder` for v0.2 `ActionChunk` to `ActionSummary` conversion.
- Adds `SummaryCanonicalizer` and `SummaryStateUpdater` for grounded facts and incremental `S_t = update(S_{t-1}, ActionChunk_t)` updates.
- Adds issue-specific design, implementation, and verification reports.

## Verification
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m mypy photon_action_memory tests`
- `python -m pytest -q`
- See `dev-reports/issue-35/verification.md`.