### PR TITLE
#36 Implement ContextPack API and admission controller

### DIFF
--- a/dev-reports/issue-36/implementation-summary.md
+++ b/dev-reports/issue-36/implementation-summary.md
@@ -1,0 +1,13 @@
+# Issue 36 Implementation Summary
+
+## Scope
+
+Implemented the v0.2 ContextPack admission path:
+
+- Added `photon_action_memory.context` helpers for rendering, token budget tracking, admission decisions, and pack construction.
+- Added `POST /v1/context/pack` with summary-only output, admission decision response wiring, and fail-open behavior.
+- Added focused tests for budget enforcement, stale/ungrounded/duplicate omission, token savings, and API fail-open behavior.
+
+## Current Limitation
+
+The API route accepts `candidate_summary_ids`, but a persistent ActionSummary lookup store is not available yet. When IDs are supplied, the route returns a valid empty summary-only pack with a `summary_store_unavailable` warning and `sidecar_status = "degraded"`.

--- a/dev-reports/issue-36/verification.md
+++ b/dev-reports/issue-36/verification.md
@@ -1,0 +1,17 @@
+# Issue 36 Verification
+
+## Commands
+
+- `python -m ruff format --check .`
+- `python -m ruff check .`
+- `python -m mypy photon_action_memory tests`
+- `python -m pytest -q`
+
+## Acceptance Coverage
+
+- Summary-only ContextPack response: covered by `test_context_pack_api_returns_summary_only_pack`.
+- ContextAdmissionDecision response: covered by `test_build_context_pack_returns_admission_decisions`.
+- `max_memory_tokens` enforcement: covered by `test_build_context_pack_enforces_max_memory_tokens`.
+- `tokens_saved_vs_raw` calculation: covered by `test_build_context_pack_calculates_tokens_saved_vs_raw`.
+- Stale, ungrounded, and duplicate omissions: covered by admission and pack tests.
+- Fail-open sidecar behavior: covered by `test_context_pack_api_fail_open_on_internal_error`.

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -19,6 +19,15 @@ from photon_action_memory.api.schema import (
     SuggestRequest,
     SuggestResponse,
 )
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    ContextPack,
+    ContextPackRequest,
+    ContextPackResponse,
+    ContextPackWarning,
+    TokenBudget,
+)
+from photon_action_memory.context.pack import build_context_pack
 from photon_action_memory.memory.store import SQLiteEventStore
 from photon_action_memory.models.photon_adapter import score_suggestions_with_optional_adapter
 from photon_action_memory.ranking.fallback import build_ranked_suggestions
@@ -60,6 +69,63 @@ def create_app(store: SQLiteEventStore | None = None) -> FastAPI:
     @app.post("/v1/suggest", response_model=SuggestResponse)
     def suggest(request: SuggestRequest) -> SuggestResponse:
         return build_fallback_suggestions(request)
+
+    @app.post("/v1/context/pack", response_model=ContextPackResponse)
+    def context_pack(request: ContextPackRequest) -> ContextPackResponse:
+        try:
+            route_warnings: list[ContextPackWarning] = []
+            if request.candidate_summary_ids:
+                route_warnings.append(
+                    ContextPackWarning(
+                        kind="summary_store_unavailable",
+                        message=(
+                            f"{len(request.candidate_summary_ids)} candidate summary ID(s) "
+                            "could not be resolved (no summary store)"
+                        ),
+                    )
+                )
+            pack, decisions = build_context_pack(
+                request_id=request.request_id,
+                session_id=None,
+                repo_id=request.repo.name,
+                summaries=[],
+                budget=request.budget,
+                warnings=route_warnings,
+            )
+            sidecar_status = "degraded" if route_warnings else "ok"
+        except Exception as exc:
+            empty_pack = ContextPack(
+                schema_version=DEFAULT_SCHEMA_VERSION_V2,
+                request_id=request.request_id,
+                session_id=None,
+                repo_id=None,
+                mode="summary_only",
+                items=[],
+                omitted=[],
+                warnings=[ContextPackWarning(kind="pack_error", message=str(exc))],
+                token_budget=TokenBudget(
+                    max_tokens=request.budget.max_memory_tokens,
+                    estimated_tokens=0,
+                    tokens_saved_vs_raw=0,
+                ),
+            )
+            return ContextPackResponse(
+                schema_version=DEFAULT_SCHEMA_VERSION_V2,
+                request_id=request.request_id,
+                model_version=FALLBACK_MODEL_VERSION,
+                sidecar_status="fail-open",
+                context_pack=empty_pack,
+                admission_decisions=[],
+            )
+
+        return ContextPackResponse(
+            schema_version=DEFAULT_SCHEMA_VERSION_V2,
+            request_id=request.request_id,
+            model_version=FALLBACK_MODEL_VERSION,
+            sidecar_status=sidecar_status,
+            context_pack=pack,
+            admission_decisions=decisions,
+        )
 
     @app.post("/v1/summarize")
     def summarize_stub() -> None:

--- a/photon_action_memory/context/__init__.py
+++ b/photon_action_memory/context/__init__.py
@@ -1,0 +1,1 @@
+"""Context packing and admission control for v0.2."""

--- a/photon_action_memory/context/admission.py
+++ b/photon_action_memory/context/admission.py
@@ -1,0 +1,81 @@
+"""Context Admission Controller for ContextPack generation."""
+
+from __future__ import annotations
+
+import hashlib
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    ActionSummary,
+    ContextAdmissionDecision,
+)
+from photon_action_memory.context.budget import TokenBudgetTracker
+from photon_action_memory.context.render import estimate_tokens, render_summary
+
+_STALE_STATUSES: frozenset[str] = frozenset({"stale", "contradicted"})
+
+
+def _decision_id(item_id: str) -> str:
+    digest = hashlib.sha256(item_id.encode()).hexdigest()[:12]
+    return f"dec-{digest}"
+
+
+class ContextAdmissionController:
+    """Evaluate ActionSummary candidates for admission into a ContextPack.
+
+    Admission rules (in order):
+    1. Staleness: omit if validity.status is stale or contradicted.
+    2. Empty content: omit if no facts, hypotheses, failed_attempts, or avoid.
+    3. Deduplication: omit if rendered text already seen.
+    4. Token budget: omit if adding would exceed max_memory_tokens.
+    """
+
+    def __init__(self, tracker: TokenBudgetTracker) -> None:
+        self._tracker = tracker
+        self._seen: set[str] = set()
+
+    def evaluate(self, summary: ActionSummary) -> tuple[str, str | None]:
+        """Return (decision, reason) for *summary*."""
+        if summary.validity.status in _STALE_STATUSES:
+            return "omit", f"summary is {summary.validity.status}"
+
+        has_content = bool(
+            summary.facts or summary.hypotheses or summary.failed_attempts or summary.avoid
+        )
+        if not has_content:
+            return "omit", "no admissible content"
+
+        text = render_summary(summary)
+        normalized = text.strip().lower()
+        if normalized in self._seen:
+            return "omit", "duplicate content"
+
+        tokens = estimate_tokens(text)
+        if not self._tracker.fits(tokens):
+            return "omit", "token budget exceeded"
+
+        self._seen.add(normalized)
+        self._tracker.consume(tokens)
+        return "admit", None
+
+    def make_decision(
+        self,
+        summary: ActionSummary,
+        decision: str,
+        reason: str | None,
+    ) -> ContextAdmissionDecision:
+        est_tokens: int | None = None
+        if decision == "admit":
+            est_tokens = estimate_tokens(render_summary(summary))
+        return ContextAdmissionDecision(
+            schema_version=DEFAULT_SCHEMA_VERSION_V2,
+            decision_id=_decision_id(summary.summary_id),
+            item_id=summary.summary_id,
+            item_kind="action_summary",
+            decision=decision,
+            reason=reason,
+            estimated_tokens=est_tokens,
+        )
+
+
+__all__ = ["ContextAdmissionController"]

--- a/photon_action_memory/context/budget.py
+++ b/photon_action_memory/context/budget.py
@@ -1,0 +1,39 @@
+"""Token budget management for ContextPack generation."""
+
+from __future__ import annotations
+
+from photon_action_memory.api.schema_v2 import TokenBudget
+
+
+class TokenBudgetTracker:
+    """Track token usage against a fixed budget."""
+
+    def __init__(self, max_tokens: int) -> None:
+        self._max = max(0, max_tokens)
+        self._used: int = 0
+        self._raw: int = 0
+
+    @property
+    def max_tokens(self) -> int:
+        return self._max
+
+    def fits(self, tokens: int) -> bool:
+        """Return True if consuming *tokens* stays within budget."""
+        return self._used + tokens <= self._max
+
+    def consume(self, tokens: int) -> None:
+        self._used += tokens
+
+    def add_raw(self, tokens: int) -> None:
+        """Record the raw-equivalent cost for tokens_saved_vs_raw accounting."""
+        self._raw += tokens
+
+    def to_token_budget(self) -> TokenBudget:
+        return TokenBudget(
+            max_tokens=self._max,
+            estimated_tokens=self._used,
+            tokens_saved_vs_raw=max(0, self._raw - self._used),
+        )
+
+
+__all__ = ["TokenBudgetTracker"]

--- a/photon_action_memory/context/pack.py
+++ b/photon_action_memory/context/pack.py
@@ -1,0 +1,87 @@
+"""ContextPack builder for admission and packing."""
+
+from __future__ import annotations
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    ActionSummary,
+    ContextAdmissionDecision,
+    ContextPack,
+    ContextPackBudget,
+    ContextPackItem,
+    ContextPackWarning,
+    OmittedItem,
+)
+from photon_action_memory.context.admission import ContextAdmissionController
+from photon_action_memory.context.budget import TokenBudgetTracker
+from photon_action_memory.context.render import estimate_tokens, render_summary
+
+
+def build_context_pack(
+    *,
+    request_id: str,
+    session_id: str | None,
+    repo_id: str | None,
+    summaries: list[ActionSummary],
+    budget: ContextPackBudget,
+    warnings: list[ContextPackWarning] | None = None,
+) -> tuple[ContextPack, list[ContextAdmissionDecision]]:
+    """Run the admission pipeline and return a ContextPack with decisions.
+
+    Pure helper; can be tested without HTTP. Never raises for recoverable
+    failures; callers should wrap in a try/except and set sidecar_status
+    accordingly.
+    """
+    tracker = TokenBudgetTracker(max_tokens=budget.max_memory_tokens)
+    controller = ContextAdmissionController(tracker)
+
+    items: list[ContextPackItem] = []
+    omitted: list[OmittedItem] = []
+    decisions: list[ContextAdmissionDecision] = []
+
+    for summary in summaries:
+        decision, reason = controller.evaluate(summary)
+        decisions.append(controller.make_decision(summary, decision, reason))
+
+        if decision == "admit":
+            text = render_summary(summary)
+            raw_tokens = (
+                summary.token_cost.estimated_raw_tokens
+                if summary.token_cost
+                else estimate_tokens(text) * 10
+            )
+            tracker.add_raw(raw_tokens)
+            evidence_ids = [eid for f in summary.facts for eid in f.evidence_ids]
+            items.append(
+                ContextPackItem(
+                    kind="action_summary",
+                    id=summary.summary_id,
+                    text=text,
+                    evidence_ids=evidence_ids,
+                    admission_reason="grounded and within budget",
+                )
+            )
+        else:
+            omitted.append(
+                OmittedItem(
+                    kind="action_summary",
+                    id=summary.summary_id,
+                    reason=reason or "omitted",
+                )
+            )
+
+    pack = ContextPack(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        request_id=request_id,
+        session_id=session_id,
+        repo_id=repo_id,
+        mode="summary_only",
+        items=items,
+        omitted=omitted,
+        warnings=warnings or [],
+        token_budget=tracker.to_token_budget(),
+    )
+    return pack, decisions
+
+
+__all__ = ["build_context_pack"]

--- a/photon_action_memory/context/render.py
+++ b/photon_action_memory/context/render.py
@@ -1,0 +1,30 @@
+"""Render ActionSummary items to prompt-visible text."""
+
+from __future__ import annotations
+
+from photon_action_memory.api.schema_v2 import ActionSummary
+
+_CHARS_PER_TOKEN: int = 4
+
+
+def estimate_tokens(text: str) -> int:
+    return max(1, len(text) // _CHARS_PER_TOKEN)
+
+
+def render_summary(summary: ActionSummary) -> str:
+    """Render an ActionSummary to compact prompt-visible text."""
+    parts: list[str] = []
+    for fact in summary.facts:
+        parts.append(f"FACT: {fact.text}")
+    for hyp in summary.hypotheses:
+        parts.append(f"HYPOTHESIS: {hyp.text}")
+    for fa in summary.failed_attempts:
+        parts.append(f"FAILED: {fa.action}")
+    for av in summary.avoid:
+        parts.append(f"AVOID: {av.action} - {av.reason}")
+    for nh in summary.next_hints:
+        parts.append(f"HINT: {nh.kind} - {nh.reason}")
+    return "\n".join(parts)
+
+
+__all__ = ["estimate_tokens", "render_summary"]

--- a/tests/test_context_pack.py
+++ b/tests/test_context_pack.py
@@ -1,0 +1,446 @@
+"""Tests for context pack admission pipeline and POST /v1/context/pack.
+
+Acceptance criteria covered:
+- summary-only ContextPack can be returned
+- ContextAdmissionDecision can be returned
+- max_memory_tokens is enforced
+- tokens_saved_vs_raw can be calculated
+- stale / ungrounded / duplicated items can be omitted
+- sidecar failure allows the agent path to fail open
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    ActionSummary,
+    AvoidGuidance,
+    ContextPackBudget,
+    Fact,
+    FailedAttempt,
+    Hypothesis,
+    TokenCost,
+    Validity,
+)
+from photon_action_memory.api.server import create_app
+from photon_action_memory.context.admission import ContextAdmissionController
+from photon_action_memory.context.budget import TokenBudgetTracker
+from photon_action_memory.context.pack import build_context_pack
+from photon_action_memory.context.render import estimate_tokens, render_summary
+from photon_action_memory.memory.store import SQLiteEventStore
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_summary(
+    summary_id: str = "sum-aaa",
+    *,
+    facts: list[Fact] | None = None,
+    hypotheses: list[Hypothesis] | None = None,
+    failed_attempts: list[FailedAttempt] | None = None,
+    avoid: list[AvoidGuidance] | None = None,
+    validity_status: str = "valid",
+    token_cost: TokenCost | None = None,
+) -> ActionSummary:
+    return ActionSummary(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        summary_id=summary_id,
+        session_id="sess-1",
+        facts=facts or [],
+        hypotheses=hypotheses or [],
+        failed_attempts=failed_attempts or [],
+        avoid=avoid or [],
+        validity=Validity(status=validity_status),
+        token_cost=token_cost,
+    )
+
+
+def _fact(text: str, evidence_id: str = "ev-1") -> Fact:
+    return Fact(text=text, evidence_ids=[evidence_id], confidence=0.9)
+
+
+def _hypothesis(text: str) -> Hypothesis:
+    return Hypothesis(text=text, confidence=0.5, status="open")
+
+
+def _failed(action: str) -> FailedAttempt:
+    return FailedAttempt(action=action, outcome="error", evidence_ids=[])
+
+
+# ---------------------------------------------------------------------------
+# render helpers
+# ---------------------------------------------------------------------------
+
+
+def test_render_summary_includes_facts_and_hypotheses() -> None:
+    summary = _make_summary(
+        facts=[_fact("auth module exists")],
+        hypotheses=[_hypothesis("performance bottleneck in parser")],
+    )
+    text = render_summary(summary)
+    assert "FACT: auth module exists" in text
+    assert "HYPOTHESIS: performance bottleneck in parser" in text
+
+
+def test_render_summary_empty_returns_empty_string() -> None:
+    summary = _make_summary()
+    assert render_summary(summary) == ""
+
+
+def test_estimate_tokens_minimum_is_one() -> None:
+    assert estimate_tokens("") == 1
+    assert estimate_tokens("x") == 1
+
+
+def test_estimate_tokens_scales_with_length() -> None:
+    assert estimate_tokens("a" * 400) == 100
+
+
+# ---------------------------------------------------------------------------
+# budget
+# ---------------------------------------------------------------------------
+
+
+def test_token_budget_tracker_fits_within_limit() -> None:
+    tracker = TokenBudgetTracker(max_tokens=100)
+    assert tracker.fits(100)
+    assert not tracker.fits(101)
+
+
+def test_token_budget_tracker_enforces_max_memory_tokens() -> None:
+    tracker = TokenBudgetTracker(max_tokens=50)
+    tracker.consume(40)
+    assert tracker.fits(10)
+    assert not tracker.fits(11)
+
+
+def test_token_budget_tokens_saved_vs_raw() -> None:
+    tracker = TokenBudgetTracker(max_tokens=1000)
+    tracker.consume(20)
+    tracker.add_raw(200)
+    budget = tracker.to_token_budget()
+    assert budget.tokens_saved_vs_raw == 180
+    assert budget.estimated_tokens == 20
+    assert budget.max_tokens == 1000
+
+
+def test_token_budget_never_negative_savings() -> None:
+    tracker = TokenBudgetTracker(max_tokens=1000)
+    tracker.consume(100)
+    tracker.add_raw(10)
+    budget = tracker.to_token_budget()
+    assert budget.tokens_saved_vs_raw == 0
+
+
+# ---------------------------------------------------------------------------
+# admission controller
+# ---------------------------------------------------------------------------
+
+
+def test_admission_admits_grounded_valid_summary() -> None:
+    tracker = TokenBudgetTracker(max_tokens=500)
+    ctrl = ContextAdmissionController(tracker)
+    summary = _make_summary(facts=[_fact("file exists")])
+    decision, reason = ctrl.evaluate(summary)
+    assert decision == "admit"
+    assert reason is None
+
+
+def test_admission_omits_stale_summary() -> None:
+    tracker = TokenBudgetTracker(max_tokens=500)
+    ctrl = ContextAdmissionController(tracker)
+    summary = _make_summary(facts=[_fact("old fact")], validity_status="stale")
+    decision, reason = ctrl.evaluate(summary)
+    assert decision == "omit"
+    assert reason is not None and "stale" in reason
+
+
+def test_admission_omits_contradicted_summary() -> None:
+    tracker = TokenBudgetTracker(max_tokens=500)
+    ctrl = ContextAdmissionController(tracker)
+    summary = _make_summary(facts=[_fact("x")], validity_status="contradicted")
+    decision, reason = ctrl.evaluate(summary)
+    assert decision == "omit"
+    assert reason is not None and "contradicted" in reason
+
+
+def test_admission_omits_empty_summary() -> None:
+    tracker = TokenBudgetTracker(max_tokens=500)
+    ctrl = ContextAdmissionController(tracker)
+    summary = _make_summary()
+    decision, reason = ctrl.evaluate(summary)
+    assert decision == "omit"
+    assert reason == "no admissible content"
+
+
+def test_admission_omits_duplicate_content() -> None:
+    tracker = TokenBudgetTracker(max_tokens=500)
+    ctrl = ContextAdmissionController(tracker)
+    summary_a = _make_summary("sum-a", facts=[_fact("duplicate text")])
+    summary_b = _make_summary("sum-b", facts=[_fact("duplicate text")])
+    ctrl.evaluate(summary_a)
+    decision, reason = ctrl.evaluate(summary_b)
+    assert decision == "omit"
+    assert reason == "duplicate content"
+
+
+def test_admission_omits_when_budget_exceeded() -> None:
+    tracker = TokenBudgetTracker(max_tokens=1)  # tiny budget
+    ctrl = ContextAdmissionController(tracker)
+    summary = _make_summary(facts=[_fact("a" * 100)])
+    decision, reason = ctrl.evaluate(summary)
+    assert decision == "omit"
+    assert reason == "token budget exceeded"
+
+
+def test_admission_decision_record_has_tokens_for_admitted() -> None:
+    tracker = TokenBudgetTracker(max_tokens=500)
+    ctrl = ContextAdmissionController(tracker)
+    summary = _make_summary(facts=[_fact("present")])
+    decision, reason = ctrl.evaluate(summary)
+    dec = ctrl.make_decision(summary, decision, reason)
+    assert dec.decision == "admit"
+    assert dec.estimated_tokens is not None and dec.estimated_tokens > 0
+
+
+def test_admission_decision_record_no_tokens_for_omitted() -> None:
+    tracker = TokenBudgetTracker(max_tokens=500)
+    ctrl = ContextAdmissionController(tracker)
+    summary = _make_summary()
+    decision, reason = ctrl.evaluate(summary)
+    dec = ctrl.make_decision(summary, decision, reason)
+    assert dec.decision == "omit"
+    assert dec.estimated_tokens is None
+
+
+# ---------------------------------------------------------------------------
+# build_context_pack - acceptance criteria
+# ---------------------------------------------------------------------------
+
+
+def test_build_context_pack_summary_only_mode() -> None:
+    summary = _make_summary(facts=[_fact("server lives in api/server.py")])
+    pack, _ = build_context_pack(
+        request_id="req-1",
+        session_id="sess-1",
+        repo_id="photon",
+        summaries=[summary],
+        budget=ContextPackBudget(),
+    )
+    assert pack.mode == "summary_only"
+    assert len(pack.items) == 1
+    assert "FACT:" in pack.items[0].text
+
+
+def test_build_context_pack_returns_admission_decisions() -> None:
+    summaries = [
+        _make_summary("sum-a", facts=[_fact("fact a")]),
+        _make_summary("sum-b"),  # empty; will be omitted
+    ]
+    pack, decisions = build_context_pack(
+        request_id="req-2",
+        session_id=None,
+        repo_id=None,
+        summaries=summaries,
+        budget=ContextPackBudget(),
+    )
+    assert len(decisions) == 2
+    assert decisions[0].decision == "admit"
+    assert decisions[1].decision == "omit"
+
+
+def test_build_context_pack_enforces_max_memory_tokens() -> None:
+    big_text = "a" * 400  # ~100 tokens
+    summaries = [
+        _make_summary("sum-a", facts=[_fact(big_text, "ev-1")]),
+        _make_summary("sum-b", facts=[_fact("small fact", "ev-2")]),
+    ]
+    pack, decisions = build_context_pack(
+        request_id="req-3",
+        session_id=None,
+        repo_id=None,
+        summaries=summaries,
+        budget=ContextPackBudget(max_memory_tokens=101),  # room for ~first only
+    )
+    assert len(pack.items) == 1
+    assert len(pack.omitted) == 1
+    assert pack.omitted[0].reason == "token budget exceeded"
+
+
+def test_build_context_pack_calculates_tokens_saved_vs_raw() -> None:
+    tc = TokenCost(estimated_summary_tokens=10, estimated_raw_tokens=200, tokens_saved_vs_raw=190)
+    summary = _make_summary(facts=[_fact("grounded")], token_cost=tc)
+    pack, _ = build_context_pack(
+        request_id="req-4",
+        session_id=None,
+        repo_id=None,
+        summaries=[summary],
+        budget=ContextPackBudget(),
+    )
+    assert pack.token_budget.tokens_saved_vs_raw is not None
+    assert pack.token_budget.tokens_saved_vs_raw > 0
+
+
+def test_build_context_pack_omits_stale_items() -> None:
+    summaries = [
+        _make_summary("sum-stale", facts=[_fact("stale info")], validity_status="stale"),
+        _make_summary("sum-ok", facts=[_fact("fresh info")]),
+    ]
+    pack, _ = build_context_pack(
+        request_id="req-5",
+        session_id=None,
+        repo_id=None,
+        summaries=summaries,
+        budget=ContextPackBudget(),
+    )
+    assert len(pack.items) == 1
+    assert pack.items[0].id == "sum-ok"
+    assert len(pack.omitted) == 1
+    assert pack.omitted[0].id == "sum-stale"
+
+
+def test_build_context_pack_omits_ungrounded_empty_summary() -> None:
+    summary = _make_summary("sum-empty")
+    pack, decisions = build_context_pack(
+        request_id="req-6",
+        session_id=None,
+        repo_id=None,
+        summaries=[summary],
+        budget=ContextPackBudget(),
+    )
+    assert len(pack.items) == 0
+    assert len(pack.omitted) == 1
+    assert decisions[0].decision == "omit"
+
+
+def test_build_context_pack_omits_duplicates() -> None:
+    text = "exact same fact"
+    summaries = [
+        _make_summary("sum-a", facts=[_fact(text)]),
+        _make_summary("sum-b", facts=[_fact(text)]),
+    ]
+    pack, _ = build_context_pack(
+        request_id="req-7",
+        session_id=None,
+        repo_id=None,
+        summaries=summaries,
+        budget=ContextPackBudget(),
+    )
+    assert len(pack.items) == 1
+    assert len(pack.omitted) == 1
+
+
+def test_build_context_pack_empty_summaries_returns_valid_pack() -> None:
+    pack, decisions = build_context_pack(
+        request_id="req-8",
+        session_id=None,
+        repo_id=None,
+        summaries=[],
+        budget=ContextPackBudget(),
+    )
+    assert pack.mode == "summary_only"
+    assert pack.items == []
+    assert decisions == []
+    assert pack.token_budget.estimated_tokens == 0
+
+
+def test_build_context_pack_failed_attempt_and_avoid_admitted() -> None:
+    summary = _make_summary(
+        "sum-mixed",
+        failed_attempts=[_failed("run tests")],
+        avoid=[AvoidGuidance(action="grep everything", reason="too noisy", evidence_ids=[])],
+    )
+    pack, decisions = build_context_pack(
+        request_id="req-9",
+        session_id=None,
+        repo_id=None,
+        summaries=[summary],
+        budget=ContextPackBudget(),
+    )
+    assert len(pack.items) == 1
+    assert "FAILED:" in pack.items[0].text
+    assert "AVOID:" in pack.items[0].text
+
+
+# ---------------------------------------------------------------------------
+# API integration - POST /v1/context/pack
+# ---------------------------------------------------------------------------
+
+
+def _pack_request(*, candidate_ids: list[str] | None = None, max_tokens: int = 800) -> dict:  # type: ignore[type-arg]
+    return {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "req-api-1",
+        "agent": {"name": "codex"},
+        "repo": {"root": "/tmp", "name": "photon-test"},
+        "task": {
+            "user_request": "implement feature X",
+            "mode": "act",
+            "summary": "working on feature X",
+        },
+        "working_memory": {"touched_files": ["photon_action_memory/api/server.py"]},
+        "recent_event_ids": [],
+        "candidate_summary_ids": candidate_ids or [],
+        "budget": {"max_memory_tokens": max_tokens, "max_evidence_chars": 1200},
+    }
+
+
+def test_context_pack_api_returns_summary_only_pack(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    with TestClient(app) as client:
+        response = client.post("/v1/context/pack", json=_pack_request())
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["request_id"] == "req-api-1"
+    assert payload["sidecar_status"] == "ok"
+    assert payload["context_pack"]["mode"] == "summary_only"
+    assert payload["admission_decisions"] == []
+
+
+def test_context_pack_api_degraded_when_summary_ids_given(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    with TestClient(app) as client:
+        response = client.post("/v1/context/pack", json=_pack_request(candidate_ids=["sum-xyz"]))
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["sidecar_status"] == "degraded"
+    warnings = payload["context_pack"]["warnings"]
+    assert len(warnings) == 1
+    assert warnings[0]["kind"] == "summary_store_unavailable"
+
+
+def test_context_pack_api_fail_open_on_internal_error(tmp_path: Path) -> None:
+    """The route must return a valid response even when the pack builder raises."""
+    from unittest.mock import patch
+
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    with patch(
+        "photon_action_memory.api.server.build_context_pack",
+        side_effect=RuntimeError("simulated failure"),
+    ):
+        with TestClient(app) as client:
+            response = client.post("/v1/context/pack", json=_pack_request())
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["sidecar_status"] == "fail-open"
+    assert payload["context_pack"]["warnings"][0]["kind"] == "pack_error"
+
+
+def test_context_pack_api_token_budget_in_response(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    with TestClient(app) as client:
+        response = client.post("/v1/context/pack", json=_pack_request(max_tokens=500))
+
+    assert response.status_code == 200
+    budget = response.json()["context_pack"]["token_budget"]
+    assert budget["max_tokens"] == 500
+    assert budget["estimated_tokens"] == 0


### PR DESCRIPTION
## Summary
- Add ContextPack rendering, token budget tracking, admission control, and pack building helpers.
- Add `POST /v1/context/pack` with summary-only output, admission decisions, degraded warning for unresolved summary IDs, and fail-open behavior.
- Add focused tests and issue 36 dev reports.

## Verification
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m mypy photon_action_memory tests`
- `python -m pytest -q`

Closes #36