### PR TITLE
#37 Enforce raw tool log default deny policy

### DIFF
--- a/dev-reports/issue-37/implementation-summary.md
+++ b/dev-reports/issue-37/implementation-summary.md
@@ -1,0 +1,74 @@
+# Issue #37 Implementation Summary
+
+## [P0][v0.2][M3] Enforce raw tool log default deny policy
+
+### Problem
+
+Raw tool output (stdout, stderr, grep output, build logs, full file content) could
+potentially reach the prompt-visible `ContextPack.items[*].text` through extra fields
+on `ContextPackRequest` or direct calls to `build_context_pack`.  Secret-like strings,
+absolute home paths, and token-like values must never be emitted in prompt-visible context.
+
+---
+
+### Changes
+
+#### New file: `photon_action_memory/context/raw_policy.py`
+
+Core default-deny policy module.
+
+- `RAW_DENIED_KINDS` - frozenset of kinds unconditionally denied:
+  `stdout`, `stderr`, `grep_output`, `build_log`, `file_content`, `raw_output`,
+  `tool_output`, `raw_tool_log`, `shell_output`, `command_output`
+- `RawEvidenceItem` - dataclass for candidate raw items (`item_id`, `kind`, `content`, `source`)
+- `has_sensitive_content(text)` - detects secret KV pairs, Bearer tokens, prefixed
+  API-key tokens (`sk-`, `ghp_`, `ghs_`, `xox*`), and absolute home paths
+  (`/home/`, `/Users/`, `/root/`)
+- `evaluate_raw_item(item)` - always returns `("deny", reason)`; reason encodes whether
+  denial is kind-based, sensitive-content-based, or default-policy-based
+
+#### Updated: `photon_action_memory/context/pack.py`
+
+- Added optional `raw_items: list[RawEvidenceItem] | None` parameter to `build_context_pack()`
+- Each raw item is evaluated via `evaluate_raw_item()` and:
+  - Added to `pack.omitted` with the deny reason
+  - Produces a `ContextAdmissionDecision(decision="deny", item_kind="raw_tool_log", policy=AdmissionPolicy(raw_evidence_policy="raw_tool_log_default_deny"))`
+- Raw items are **never** added to `pack.items`
+
+#### Updated: `photon_action_memory/api/server.py`
+
+- Added `_extract_raw_items(request)` helper that reads `request.model_extra["raw_evidence"]`
+  (a list of dicts) and converts to `RawEvidenceItem` instances
+- Passes extracted raw items to `build_context_pack()`
+- Since `SidecarModel` uses `extra="allow"`, agents can attach `raw_evidence` as an extra
+  field on the standard `ContextPackRequest` without breaking schema validation
+
+#### New test file: `tests/test_raw_tool_log_policy.py`
+
+28 tests covering all acceptance criteria:
+
+| Category | Tests |
+|---|---|
+| Kind-based denial (stdout, stderr, grep, build_log, file_content, all kinds) | 7 |
+| Sensitive content detection (secrets, bearer, tokens, home paths, safe content) | 6 |
+| Sensitive content -> deny in evaluate_raw_item | 2 |
+| build_context_pack - raw items stay out of items | 6 |
+| raw_tool_tokens_in_prompt is approximately 0 | 2 |
+| API integration (extras denied, policy in decisions, no-extras, secret denied) | 4 |
+| Unknown kind -> default deny | 1 |
+
+---
+
+### Policy Design
+
+The policy is unconditional default-deny: there is no code path through which a
+`RawEvidenceItem` can be admitted.  `evaluate_raw_item` always returns `"deny"`.
+
+The denial reason is specific enough to diagnose the cause:
+- `"raw tool log default deny policy: kind 'stdout' is always denied"` - kind match
+- `"raw tool log default deny policy: sensitive content detected"` - pattern match
+- `"raw tool log default deny policy: raw evidence denied by default"` - catch-all
+
+The `ContextAdmissionDecision.policy.raw_evidence_policy` field is set to
+`"raw_tool_log_default_deny"` for all denied raw items, enabling downstream tooling
+to filter decisions by policy type.

--- a/dev-reports/issue-37/verification.md
+++ b/dev-reports/issue-37/verification.md
@@ -1,0 +1,50 @@
+# Issue #37 Verification
+
+## Commands run and results
+
+### `python -m ruff format --check .`
+```
+55 files already formatted
+```
+Exit code: 0 - PASS
+
+### `python -m ruff check .`
+```
+All checks passed!
+```
+Exit code: 0 - PASS
+
+### `python -m mypy photon_action_memory tests`
+```
+Success: no issues found in 53 source files
+```
+Exit code: 0 - PASS
+
+### `python -m pytest -q`
+```
+s.......................................................................
+.......................................................................
+.......................................................................
+.......................................................................
+...........................................
+1 skipped (MLX smoke is opt-in), 330 passed in 1.20s
+```
+Exit code: 0 - PASS
+
+---
+
+## Acceptance criteria checklist
+
+| Criterion | Test(s) | Result |
+|---|---|---|
+| raw tool stdout/stderr not in ContextPack items | `test_stdout_is_denied`, `test_stderr_is_denied`, `test_raw_items_not_in_pack_items` | PASS |
+| full grep output denied | `test_grep_output_is_denied` | PASS |
+| full build log denied | `test_build_log_is_denied` | PASS |
+| full file content denied | `test_file_content_is_denied` | PASS |
+| secret-like string not prompt-visible | `test_secret_kv_pair_detected`, `test_secret_in_raw_item_does_not_reach_items`, `test_api_secret_in_raw_evidence_is_denied` | PASS |
+| absolute home path not prompt-visible | `test_absolute_home_path_detected`, `test_home_path_in_unknown_kind_is_denied` | PASS |
+| token-like value not prompt-visible | `test_openai_style_token_detected`, `test_github_pat_detected`, `test_bearer_token_detected` | PASS |
+| denied items in omitted with reasons | `test_raw_items_appear_in_omitted`, `test_raw_items_omitted_with_reasons` | PASS |
+| policy tests verify raw_tool_tokens_in_prompt is approximately 0 | `test_raw_tool_tokens_in_prompt_is_zero_with_only_raw_items`, `test_raw_tool_tokens_in_prompt_zero_mixed_with_summaries` | PASS |
+| admission decisions record deny with policy | `test_raw_items_produce_deny_decisions`, `test_raw_decision_has_policy_field`, `test_api_raw_evidence_deny_decisions_have_policy` | PASS |
+| existing tests still pass (no regression) | all 302 pre-existing tests | PASS |

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -28,6 +28,7 @@ from photon_action_memory.api.schema_v2 import (
     TokenBudget,
 )
 from photon_action_memory.context.pack import build_context_pack
+from photon_action_memory.context.raw_policy import RawEvidenceItem
 from photon_action_memory.memory.store import SQLiteEventStore
 from photon_action_memory.models.photon_adapter import score_suggestions_with_optional_adapter
 from photon_action_memory.ranking.fallback import build_ranked_suggestions
@@ -84,6 +85,7 @@ def create_app(store: SQLiteEventStore | None = None) -> FastAPI:
                         ),
                     )
                 )
+            raw_items = _extract_raw_items(request)
             pack, decisions = build_context_pack(
                 request_id=request.request_id,
                 session_id=None,
@@ -91,6 +93,7 @@ def create_app(store: SQLiteEventStore | None = None) -> FastAPI:
                 summaries=[],
                 budget=request.budget,
                 warnings=route_warnings,
+                raw_items=raw_items,
             )
             sidecar_status = "degraded" if route_warnings else "ok"
         except Exception as exc:
@@ -136,6 +139,27 @@ def create_app(store: SQLiteEventStore | None = None) -> FastAPI:
         raise HTTPException(status_code=501, detail="evaluate is not implemented in M2")
 
     return app
+
+
+def _extract_raw_items(request: ContextPackRequest) -> list[RawEvidenceItem]:
+    """Extract raw evidence items from request extra fields."""
+    extras = request.model_extra or {}
+    raw_evidence = extras.get("raw_evidence")
+    if not isinstance(raw_evidence, list):
+        return []
+    items: list[RawEvidenceItem] = []
+    for i, entry in enumerate(raw_evidence):
+        if not isinstance(entry, dict):
+            continue
+        items.append(
+            RawEvidenceItem(
+                item_id=str(entry.get("item_id", f"raw-{i}")),
+                kind=str(entry.get("kind", "raw_output")),
+                content=str(entry.get("content", "")),
+                source=str(entry["source"]) if entry.get("source") else None,
+            )
+        )
+    return items
 
 
 def build_fallback_suggestions(request: SuggestRequest) -> SuggestResponse:

--- a/photon_action_memory/context/pack.py
+++ b/photon_action_memory/context/pack.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
+
 from photon_action_memory.api.schema_v2 import (
     DEFAULT_SCHEMA_VERSION_V2,
     ActionSummary,
+    AdmissionPolicy,
     ContextAdmissionDecision,
     ContextPack,
     ContextPackBudget,
@@ -14,7 +17,15 @@ from photon_action_memory.api.schema_v2 import (
 )
 from photon_action_memory.context.admission import ContextAdmissionController
 from photon_action_memory.context.budget import TokenBudgetTracker
+from photon_action_memory.context.raw_policy import RawEvidenceItem, evaluate_raw_item
 from photon_action_memory.context.render import estimate_tokens, render_summary
+
+_RAW_ADMISSION_POLICY = AdmissionPolicy(raw_evidence_policy="raw_tool_log_default_deny")
+
+
+def _raw_decision_id(item_id: str) -> str:
+    digest = hashlib.sha256(item_id.encode()).hexdigest()[:12]
+    return f"dec-raw-{digest}"
 
 
 def build_context_pack(
@@ -25,12 +36,16 @@ def build_context_pack(
     summaries: list[ActionSummary],
     budget: ContextPackBudget,
     warnings: list[ContextPackWarning] | None = None,
+    raw_items: list[RawEvidenceItem] | None = None,
 ) -> tuple[ContextPack, list[ContextAdmissionDecision]]:
     """Run the admission pipeline and return a ContextPack with decisions.
 
     Pure helper; can be tested without HTTP. Never raises for recoverable
     failures; callers should wrap in a try/except and set sidecar_status
     accordingly.
+
+    Raw items are always denied under the default-deny policy and recorded
+    in ``omitted``; they never appear in ``items[*].text``.
     """
     tracker = TokenBudgetTracker(max_tokens=budget.max_memory_tokens)
     controller = ContextAdmissionController(tracker)
@@ -69,6 +84,28 @@ def build_context_pack(
                     reason=reason or "omitted",
                 )
             )
+
+    # Raw tool-log items are denied unconditionally; they must not appear in items.
+    for raw_item in raw_items or []:
+        _, reason = evaluate_raw_item(raw_item)
+        decisions.append(
+            ContextAdmissionDecision(
+                schema_version=DEFAULT_SCHEMA_VERSION_V2,
+                decision_id=_raw_decision_id(raw_item.item_id),
+                item_id=raw_item.item_id,
+                item_kind="raw_tool_log",
+                decision="deny",
+                reason=reason,
+                policy=_RAW_ADMISSION_POLICY,
+            )
+        )
+        omitted.append(
+            OmittedItem(
+                kind=raw_item.kind,
+                id=raw_item.item_id,
+                reason=reason,
+            )
+        )
 
     pack = ContextPack(
         schema_version=DEFAULT_SCHEMA_VERSION_V2,

--- a/photon_action_memory/context/raw_policy.py
+++ b/photon_action_memory/context/raw_policy.py
@@ -1,0 +1,90 @@
+"""Raw evidence / tool-log default-deny policy.
+
+Raw tool output (stdout, stderr, grep output, build logs, full file content)
+must not become prompt-visible ContextPack text.  This module provides the
+evaluation logic; ``build_context_pack`` applies it to every raw item.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+# ---------------------------------------------------------------------------
+# Denied kinds: every item whose kind matches is unconditionally denied.
+# ---------------------------------------------------------------------------
+
+RAW_DENIED_KINDS: frozenset[str] = frozenset(
+    {
+        "stdout",
+        "stderr",
+        "grep_output",
+        "build_log",
+        "file_content",
+        "raw_output",
+        "tool_output",
+        "raw_tool_log",
+        "shell_output",
+        "command_output",
+    }
+)
+
+_DENY_POLICY = "raw_tool_log_default_deny"
+
+# ---------------------------------------------------------------------------
+# Sensitive-content patterns
+# ---------------------------------------------------------------------------
+
+_SECRET_KV = re.compile(
+    r"(?i)(?:password|passwd|secret|api[_\-]?key|access[_\-]?token"
+    r"|auth[_\-]?token|private[_\-]?key)[\s]*[=:]\s*\S+"
+)
+_BEARER = re.compile(r"(?i)bearer\s+[A-Za-z0-9\-._~+/]{20,}=*")
+_TOKEN_PREFIX = re.compile(
+    r"(?:sk-[A-Za-z0-9]{20,}|ghp_[A-Za-z0-9]{10,}|ghs_[A-Za-z0-9]{10,}"
+    r"|xox[baprs]-[A-Za-z0-9\-]{10,})"
+)
+_HOME_PATH = re.compile(r"/(?:home|Users|root)/[^\s,;\"']+")
+
+
+@dataclass
+class RawEvidenceItem:
+    """A candidate raw evidence / tool-log item."""
+
+    item_id: str
+    kind: str
+    content: str
+    source: str | None = field(default=None)
+
+
+def has_sensitive_content(text: str) -> bool:
+    """Return True if *text* contains secret-like strings, home paths, or token-like values."""
+    return bool(
+        _SECRET_KV.search(text)
+        or _BEARER.search(text)
+        or _TOKEN_PREFIX.search(text)
+        or _HOME_PATH.search(text)
+    )
+
+
+def evaluate_raw_item(item: RawEvidenceItem) -> tuple[str, str]:
+    """Evaluate *item* under the raw evidence default-deny policy.
+
+    Always returns ``("deny", reason)``.  Raw tool output is never admitted.
+    """
+    if item.kind in RAW_DENIED_KINDS:
+        return (
+            "deny",
+            f"raw tool log default deny policy: kind '{item.kind}' is always denied",
+        )
+    if has_sensitive_content(item.content):
+        return "deny", "raw tool log default deny policy: sensitive content detected"
+    return "deny", "raw tool log default deny policy: raw evidence denied by default"
+
+
+__all__ = [
+    "RAW_DENIED_KINDS",
+    "RawEvidenceItem",
+    "evaluate_raw_item",
+    "has_sensitive_content",
+]

--- a/tests/test_raw_tool_log_policy.py
+++ b/tests/test_raw_tool_log_policy.py
@@ -1,0 +1,396 @@
+"""Tests for the raw tool-log default-deny policy (issue #37).
+
+Acceptance criteria verified:
+- raw tool stdout/stderr are not included in ContextPack items
+- full grep output / build log / file content are denied by default
+- secret-like strings / absolute home paths / token-like values are not prompt-visible
+- denied items appear in omitted with reasons
+- raw_tool_tokens_in_prompt is approximately zero
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    ActionSummary,
+    ContextPackBudget,
+    Fact,
+    Validity,
+)
+from photon_action_memory.api.server import create_app
+from photon_action_memory.context.pack import build_context_pack
+from photon_action_memory.context.raw_policy import (
+    RAW_DENIED_KINDS,
+    RawEvidenceItem,
+    evaluate_raw_item,
+    has_sensitive_content,
+)
+from photon_action_memory.context.render import estimate_tokens
+from photon_action_memory.memory.store import SQLiteEventStore
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _raw(item_id: str, kind: str, content: str = "some output") -> RawEvidenceItem:
+    return RawEvidenceItem(item_id=item_id, kind=kind, content=content)
+
+
+def _pack_with_raw(
+    raw_items: list[RawEvidenceItem],
+    max_tokens: int = 800,
+) -> tuple:  # type: ignore[type-arg]
+    return build_context_pack(
+        request_id="req-raw-test",
+        session_id=None,
+        repo_id=None,
+        summaries=[],
+        budget=ContextPackBudget(max_memory_tokens=max_tokens),
+        raw_items=raw_items,
+    )
+
+
+# ---------------------------------------------------------------------------
+# evaluate_raw_item - kind-based denial
+# ---------------------------------------------------------------------------
+
+
+def test_stdout_is_denied() -> None:
+    item = _raw("r-1", "stdout", "$ cargo build\nCompiling photon v0.1.0\n")
+    decision, reason = evaluate_raw_item(item)
+    assert decision == "deny"
+    assert "stdout" in reason
+
+
+def test_stderr_is_denied() -> None:
+    item = _raw("r-2", "stderr", "error[E0308]: mismatched types\n")
+    decision, reason = evaluate_raw_item(item)
+    assert decision == "deny"
+    assert "stderr" in reason
+
+
+def test_grep_output_is_denied() -> None:
+    item = _raw("r-3", "grep_output", "src/main.rs:10: fn main() {")
+    decision, reason = evaluate_raw_item(item)
+    assert decision == "deny"
+    assert "grep_output" in reason
+
+
+def test_build_log_is_denied() -> None:
+    item = _raw("r-4", "build_log", "BUILD SUCCESSFUL in 3s")
+    decision, reason = evaluate_raw_item(item)
+    assert decision == "deny"
+    assert "build_log" in reason
+
+
+def test_file_content_is_denied() -> None:
+    item = _raw("r-5", "file_content", 'fn main() { println!("hello"); }')
+    decision, reason = evaluate_raw_item(item)
+    assert decision == "deny"
+    assert "file_content" in reason
+
+
+def test_all_raw_denied_kinds_are_denied() -> None:
+    for kind in RAW_DENIED_KINDS:
+        item = _raw(f"r-{kind}", kind, "some content")
+        decision, reason = evaluate_raw_item(item)
+        assert decision == "deny", f"expected deny for kind={kind}"
+        assert reason, f"expected non-empty reason for kind={kind}"
+
+
+def test_unknown_raw_kind_is_still_denied_by_default() -> None:
+    item = _raw("r-unknown", "custom_raw_kind", "some raw output")
+    decision, reason = evaluate_raw_item(item)
+    assert decision == "deny"
+    assert "default" in reason
+
+
+# ---------------------------------------------------------------------------
+# has_sensitive_content - secret / path / token detection
+# ---------------------------------------------------------------------------
+
+
+def test_secret_kv_pair_detected() -> None:
+    assert has_sensitive_content("api_key=sk-abc123secret456789")
+    assert has_sensitive_content("password: hunter2")
+    assert has_sensitive_content("API_KEY=abcdefghijklmnop")
+
+
+def test_bearer_token_detected() -> None:
+    assert has_sensitive_content("Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.xxx")
+
+
+def test_openai_style_token_detected() -> None:
+    assert has_sensitive_content("using key sk-abcdefghijklmnopqrstuvwxyz1234567890")
+
+
+def test_github_pat_detected() -> None:
+    assert has_sensitive_content("export GITHUB_TOKEN=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabc")
+
+
+def test_absolute_home_path_detected() -> None:
+    assert has_sensitive_content("/home/alice/.ssh/id_rsa")
+    assert has_sensitive_content("/Users/bob/Documents/secret.txt")
+    assert has_sensitive_content("/root/.bashrc")
+
+
+def test_safe_content_not_flagged() -> None:
+    assert not has_sensitive_content("FACT: server lives in api/server.py")
+    assert not has_sensitive_content("build succeeded in 3s")
+    assert not has_sensitive_content("relative/path/to/file.py")
+
+
+# ---------------------------------------------------------------------------
+# evaluate_raw_item - sensitive content denial
+# ---------------------------------------------------------------------------
+
+
+def test_sensitive_content_in_unknown_kind_is_denied() -> None:
+    item = _raw("r-s1", "custom_output", "password=hunter2")
+    decision, reason = evaluate_raw_item(item)
+    assert decision == "deny"
+    assert "sensitive" in reason
+
+
+def test_home_path_in_unknown_kind_is_denied() -> None:
+    item = _raw("r-s2", "note", "/home/alice/workspace/project/main.py")
+    decision, reason = evaluate_raw_item(item)
+    assert decision == "deny"
+    assert "sensitive" in reason
+
+
+# ---------------------------------------------------------------------------
+# build_context_pack - raw items stay out of items[*].text
+# ---------------------------------------------------------------------------
+
+
+def test_raw_items_not_in_pack_items() -> None:
+    raw = [_raw("r-1", "stdout", "lots of build output")]
+    pack, _ = _pack_with_raw(raw)
+    assert pack.items == []
+
+
+def test_raw_items_appear_in_omitted() -> None:
+    raw = [
+        _raw("r-1", "stdout", "build output line 1"),
+        _raw("r-2", "stderr", "error: missing semicolon"),
+    ]
+    pack, _ = _pack_with_raw(raw)
+    assert len(pack.omitted) == 2
+    omitted_ids = {o.id for o in pack.omitted}
+    assert "r-1" in omitted_ids
+    assert "r-2" in omitted_ids
+
+
+def test_raw_items_omitted_with_reasons() -> None:
+    raw = [_raw("r-1", "grep_output", "src/main.rs:5: use std::io")]
+    pack, _ = _pack_with_raw(raw)
+    assert len(pack.omitted) == 1
+    assert pack.omitted[0].reason
+    assert "deny" in pack.omitted[0].reason or "raw" in pack.omitted[0].reason.lower()
+
+
+def test_raw_items_produce_deny_decisions() -> None:
+    raw = [_raw("r-1", "build_log", "BUILD SUCCESSFUL")]
+    _, decisions = _pack_with_raw(raw)
+    assert len(decisions) == 1
+    dec = decisions[0]
+    assert dec.decision == "deny"
+    assert dec.item_kind == "raw_tool_log"
+    assert dec.reason is not None
+
+
+def test_raw_decision_has_policy_field() -> None:
+    raw = [_raw("r-1", "stdout", "output")]
+    _, decisions = _pack_with_raw(raw)
+    dec = decisions[0]
+    assert dec.policy is not None
+    assert dec.policy.raw_evidence_policy == "raw_tool_log_default_deny"
+
+
+def test_secret_in_raw_item_does_not_reach_items() -> None:
+    raw = [_raw("r-secret", "custom_output", "API_KEY=mysecretapikey123456")]
+    pack, decisions = _pack_with_raw(raw)
+    assert pack.items == []
+    assert len(pack.omitted) == 1
+    assert decisions[0].decision == "deny"
+
+
+def test_home_path_in_raw_item_does_not_reach_items() -> None:
+    raw = [_raw("r-path", "note", "config at /home/alice/.config/app.toml")]
+    pack, _ = _pack_with_raw(raw)
+    assert pack.items == []
+    assert len(pack.omitted) == 1
+
+
+# ---------------------------------------------------------------------------
+# raw_tool_tokens_in_prompt is approximately 0
+#
+# Verify that even if raw items contain many tokens, none end up in the
+# prompt-visible items list.
+# ---------------------------------------------------------------------------
+
+
+def _raw_tool_tokens_in_prompt(pack_items: list) -> int:  # type: ignore[type-arg]
+    """Sum estimated tokens for any item whose text contains raw tool output markers."""
+    total = 0
+    for item in pack_items:
+        total += estimate_tokens(item.text)
+    return total
+
+
+def test_raw_tool_tokens_in_prompt_is_zero_with_only_raw_items() -> None:
+    large_raw = [
+        _raw(f"r-{i}", kind, "x" * 2000)
+        for i, kind in enumerate(["stdout", "stderr", "grep_output", "build_log", "file_content"])
+    ]
+    pack, _ = _pack_with_raw(large_raw)
+    assert _raw_tool_tokens_in_prompt(pack.items) == 0
+
+
+def _fact(text: str, evidence_id: str = "ev-1") -> Fact:
+    return Fact(text=text, evidence_ids=[evidence_id], confidence=0.9)
+
+
+def _make_summary_simple(summary_id: str, facts: list[Fact]) -> ActionSummary:
+    return ActionSummary(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        summary_id=summary_id,
+        session_id="sess-1",
+        facts=facts,
+        hypotheses=[],
+        failed_attempts=[],
+        avoid=[],
+        validity=Validity(status="valid"),
+        token_cost=None,
+    )
+
+
+def test_raw_tool_tokens_in_prompt_zero_mixed_with_summaries() -> None:
+    """Raw items must not add tokens to items even when summaries are also present."""
+    summaries: list[ActionSummary] = [
+        _make_summary_simple("sum-1", facts=[_fact("server is in api/")])
+    ]
+    raw = [_raw("r-1", "stdout", "build output " * 100)]
+    pack, decisions = build_context_pack(
+        request_id="req-mixed",
+        session_id=None,
+        repo_id=None,
+        summaries=summaries,
+        budget=ContextPackBudget(max_memory_tokens=800),
+        raw_items=raw,
+    )
+    # Summary items are admitted, raw items are denied
+    assert len(pack.items) == 1
+    assert "stdout" not in pack.items[0].text
+    assert "build output" not in pack.items[0].text
+    # Omitted list contains the raw item
+    assert any(o.id == "r-1" for o in pack.omitted)
+    # Raw tokens don't add to prompt
+    raw_tokens_in_prompt = sum(
+        estimate_tokens(item.text)
+        for item in pack.items
+        if any(word in item.text for word in ["build output", "stdout"])
+    )
+    assert raw_tokens_in_prompt == 0
+
+
+# ---------------------------------------------------------------------------
+# API integration - raw_evidence in ContextPackRequest extras is denied
+# ---------------------------------------------------------------------------
+
+
+def _pack_api_request(
+    *,
+    raw_evidence: list[dict] | None = None,  # type: ignore[type-arg]
+    max_tokens: int = 800,
+) -> dict:  # type: ignore[type-arg]
+    req: dict = {  # type: ignore[type-arg]
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "req-raw-api",
+        "agent": {"name": "codex"},
+        "repo": {"root": "/tmp", "name": "photon-test"},
+        "task": {
+            "user_request": "fix bug",
+            "mode": "act",
+            "summary": "fixing a bug",
+        },
+        "working_memory": {"touched_files": []},
+        "recent_event_ids": [],
+        "candidate_summary_ids": [],
+        "budget": {"max_memory_tokens": max_tokens, "max_evidence_chars": 1200},
+    }
+    if raw_evidence is not None:
+        req["raw_evidence"] = raw_evidence
+    return req
+
+
+def test_api_raw_evidence_extras_are_denied(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    raw_evidence = [
+        {"item_id": "raw-stdout-1", "kind": "stdout", "content": "cargo build output..."},
+        {"item_id": "raw-stderr-1", "kind": "stderr", "content": "warning: unused var"},
+    ]
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/context/pack", json=_pack_api_request(raw_evidence=raw_evidence)
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["context_pack"]["items"] == []
+    omitted_ids = {o["id"] for o in payload["context_pack"]["omitted"]}
+    assert "raw-stdout-1" in omitted_ids
+    assert "raw-stderr-1" in omitted_ids
+
+
+def test_api_raw_evidence_deny_decisions_have_policy(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    raw_evidence = [{"item_id": "raw-1", "kind": "build_log", "content": "BUILD SUCCESSFUL"}]
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/context/pack", json=_pack_api_request(raw_evidence=raw_evidence)
+        )
+
+    payload = response.json()
+    decisions = payload["admission_decisions"]
+    assert len(decisions) == 1
+    dec = decisions[0]
+    assert dec["decision"] == "deny"
+    assert dec["item_kind"] == "raw_tool_log"
+    assert dec["policy"]["raw_evidence_policy"] == "raw_tool_log_default_deny"
+
+
+def test_api_no_raw_evidence_field_is_fine(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    with TestClient(app) as client:
+        response = client.post("/v1/context/pack", json=_pack_api_request())
+
+    assert response.status_code == 200
+    assert response.json()["sidecar_status"] == "ok"
+
+
+def test_api_secret_in_raw_evidence_is_denied(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    raw_evidence = [
+        {
+            "item_id": "raw-secret",
+            "kind": "custom_output",
+            "content": "API_KEY=supersecretvalue123456789",
+        }
+    ]
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/context/pack", json=_pack_api_request(raw_evidence=raw_evidence)
+        )
+
+    payload = response.json()
+    assert payload["context_pack"]["items"] == []
+    assert len(payload["context_pack"]["omitted"]) == 1
+    for item_text in [i["text"] for i in payload["context_pack"]["items"]]:
+        assert "supersecretvalue" not in item_text


### PR DESCRIPTION
## Summary
- Add raw tool/evidence default-deny policy for stdout, stderr, grep output, build logs, full file content, and other raw output kinds.
- Wire raw evidence extras from `POST /v1/context/pack` into the ContextPack admission pipeline as denied omitted items with policy-tagged decisions.
- Add privacy regression tests for secret-like strings, home paths, token-like values, and zero raw tokens in prompt-visible items.

## Verification
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m mypy photon_action_memory tests`
- `python -m pytest -q`

Closes #37