### PR TITLE
#38 Implement EvidenceExpander and evidence expand API

### DIFF
--- a/dev-reports/issue-38/implementation-summary.md
+++ b/dev-reports/issue-38/implementation-summary.md
@@ -1,0 +1,41 @@
+# Issue #38 - EvidenceExpander Implementation Summary
+
+## What was added
+
+### `photon_action_memory/memory/evidence.py` (new)
+Core implementation of the `EvidenceExpander` class.
+
+**Internal model: `_Candidate`**
+Each candidate record is normalised into a structured view:
+- `evidence_id` - resolved from `evidence_id` field, falling back to `event_id`
+- `kind` - event kind string
+- `summary` - brief description
+- `concise_text` - selected concise content (`snippet`, plus `text`/`content` for non-raw kinds)
+- `raw_text` - raw full output (`stdout` / `stderr` / `text` / `content` for raw kinds)
+- `locator` - `Locator` assembled from flat fields or a nested `locator` dict
+
+**Snippet selection priority**
+1. `snippet` field - always preferred as selected concise content
+2. `text` field - selected concise content only when `kind` is not in `RAW_DENIED_KINDS`
+3. `content` field - concise only when `kind` is not in `RAW_DENIED_KINDS`
+4. `stdout` / `stderr` / `text` / `content` for raw kinds - raw full output, denied by default
+
+**Default-deny for raw full output**
+When `policy.allow_raw_full_output=False` (the default) and only raw output is available, the evidence is omitted with a descriptive reason. This mirrors the `raw_tool_log_default_deny` policy already applied in `build_context_pack`.
+
+**Budget enforcement**
+- `max_chars_per_evidence` (default 1200): snippet is truncated and `truncated=True` is set.
+- `max_total_chars` (optional): once the running total reaches the cap, remaining evidence IDs are omitted with reason `"max_total_chars budget exhausted"`.
+
+**Sanitizer re-run**
+When `policy.redact_again=True` (default), `sanitize_text_with_report` is called on the final snippet before it is placed in `ExpandedEvidence`. `redaction_status` is set to `"redacted"` or `"clean"` accordingly.
+
+### `photon_action_memory/api/server.py` (updated)
+Added `POST /v1/evidence/expand` route:
+- Fetches all store events via `event_store.list_events()` and adds their payloads to the record pool.
+- Merges any `evidence_records` list from `request.model_extra` (extra Pydantic fields).
+- Builds an `EvidenceExpander` and calls `expand()`.
+- Fails open: any exception returns a valid `EvidenceExpandResponse` with all requested IDs in `omitted` with the error message.
+
+### `tests/test_evidence_expander.py` (new)
+38 focused deterministic tests covering all acceptance criteria.

--- a/dev-reports/issue-38/verification.md
+++ b/dev-reports/issue-38/verification.md
@@ -1,0 +1,75 @@
+# Issue #38 - Verification Results
+
+## Commands run
+
+```
+python -m ruff format --check .
+python -m ruff check .
+python -m mypy photon_action_memory tests
+python -m pytest -q
+```
+
+## Results
+
+### ruff format
+```
+57 files already formatted
+```
+Exit code: 0 - PASS
+
+### ruff check
+```
+All checks passed!
+```
+Exit code: 0 - PASS
+
+### mypy
+```
+Success: no issues found in 55 source files
+```
+Exit code: 0 - PASS
+
+### pytest
+```
+362 passed, 1 skipped in 1.06s
+```
+The 1 skipped test is `tests/integration/test_mlx_smoke.py` (opt-in MLX test, not related to this issue).
+
+Exit code: 0 - PASS
+
+## New tests added (`tests/test_evidence_expander.py`)
+
+| Test | Criterion |
+|---|---|
+| `test_snippet_field_returned_by_evidence_id` | selected snippet returned |
+| `test_text_field_used_as_concise_snippet` | text field as concise content |
+| `test_content_field_used_for_non_raw_kind` | content field for non-raw kinds |
+| `test_snippet_preferred_over_text` | snippet > text priority |
+| `test_event_id_fallback_for_evidence_id` | event_id fallback lookup |
+| `test_stdout_default_denied` | raw stdout denied by default |
+| `test_stderr_default_denied` | raw stderr denied by default |
+| `test_content_on_raw_kind_default_denied` | raw kind content denied |
+| `test_text_on_raw_kind_default_denied` | raw kind text denied |
+| `test_raw_output_allowed_when_policy_permits` | allow_raw_full_output=True |
+| `test_max_chars_per_evidence_truncates` | per-evidence char limit |
+| `test_snippet_not_truncated_when_under_limit` | no spurious truncation |
+| `test_max_total_chars_limits_and_omits_remaining` | total char budget, omit remaining |
+| `test_max_total_chars_exhausted_before_second_item` | budget exhaustion ordering |
+| `test_sanitizer_strips_secret_from_snippet` | sanitizer re-run, secret redaction |
+| `test_sanitizer_strips_absolute_home_path` | sanitizer re-run, path redaction |
+| `test_redaction_status_is_set_after_sanitization` | redaction_status field set |
+| `test_redaction_status_is_none_when_redact_again_false` | redact_again=False |
+| `test_omitted_reason_for_missing_evidence_id` | missing ID omitted with reason |
+| `test_omitted_reason_for_denied_raw_output` | raw denied with reason |
+| `test_omitted_reason_when_no_expandable_content` | no content omitted with reason |
+| `test_locator_line_range_from_flat_fields` | locator line range |
+| `test_locator_command_from_flat_field` | locator command |
+| `test_locator_from_nested_locator_dict` | nested locator dict |
+| `test_locator_is_none_when_no_location_fields` | locator absent when no fields |
+| `test_kind_and_summary_included_in_expanded` | kind/summary in response |
+| `test_api_expand_with_evidence_records_extra` | API route, extra records |
+| `test_api_expand_with_store_backed_events` | API route, store events |
+| `test_api_expand_raw_denied_by_default` | API route, raw deny |
+| `test_api_expand_missing_id_returns_omitted` | API route, missing ID |
+| `test_api_expand_fail_open_on_error` | API route, fail-open |
+| `test_api_expand_schema_version_in_response` | schema_version in response |

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import tempfile
 from pathlib import Path
+from typing import Any
 
 from fastapi import FastAPI, HTTPException
 
@@ -25,14 +27,20 @@ from photon_action_memory.api.schema_v2 import (
     ContextPackRequest,
     ContextPackResponse,
     ContextPackWarning,
+    EvidenceExpandRequest,
+    EvidenceExpandResponse,
+    OmittedEvidence,
     TokenBudget,
 )
 from photon_action_memory.context.pack import build_context_pack
 from photon_action_memory.context.raw_policy import RawEvidenceItem
+from photon_action_memory.memory.evidence import EvidenceExpander
 from photon_action_memory.memory.store import SQLiteEventStore
 from photon_action_memory.models.photon_adapter import score_suggestions_with_optional_adapter
 from photon_action_memory.ranking.fallback import build_ranked_suggestions
 from photon_action_memory.ranking.guards import fallback_warnings
+
+logger = logging.getLogger(__name__)
 
 
 def health_payload() -> dict[str, str]:
@@ -129,6 +137,28 @@ def create_app(store: SQLiteEventStore | None = None) -> FastAPI:
             context_pack=pack,
             admission_decisions=decisions,
         )
+
+    @app.post("/v1/evidence/expand", response_model=EvidenceExpandResponse)
+    def expand_evidence(request: EvidenceExpandRequest) -> EvidenceExpandResponse:
+        try:
+            records: list[dict[str, Any]] = [ev.payload for ev in event_store.list_events()]
+            extras = request.model_extra or {}
+            extra_records = extras.get("evidence_records")
+            if isinstance(extra_records, list):
+                records.extend(r for r in extra_records if isinstance(r, dict))
+            expander = EvidenceExpander(records=records)
+            return expander.expand(request)
+        except Exception as exc:
+            logger.warning("evidence expand error: %s", exc)
+            return EvidenceExpandResponse(
+                schema_version=DEFAULT_SCHEMA_VERSION_V2,
+                request_id=request.request_id,
+                expanded=[],
+                omitted=[
+                    OmittedEvidence(evidence_id=eid, reason=f"expansion error: {exc}")
+                    for eid in request.evidence_ids
+                ],
+            )
 
     @app.post("/v1/summarize")
     def summarize_stub() -> None:

--- a/photon_action_memory/memory/evidence.py
+++ b/photon_action_memory/memory/evidence.py
@@ -1,0 +1,218 @@
+"""Evidence expander: resolve evidence_id values into sanitized snippets."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    EvidenceExpandRequest,
+    EvidenceExpandResponse,
+    ExpandedEvidence,
+    Locator,
+    OmittedEvidence,
+)
+from photon_action_memory.context.raw_policy import RAW_DENIED_KINDS
+from photon_action_memory.memory.sanitizer import sanitize_text_with_report
+
+logger = logging.getLogger(__name__)
+
+# Fields that represent selected concise content (preferred).
+_CONCISE_FIELDS: tuple[str, ...] = ("snippet",)
+# Fields that carry raw full output, subject to default-deny.
+_RAW_FIELDS: tuple[str, ...] = ("stdout", "stderr")
+
+
+@dataclass
+class _Candidate:
+    """Internal structured view of a candidate evidence record."""
+
+    evidence_id: str
+    kind: str
+    summary: str
+    concise_text: str | None
+    raw_text: str | None
+    locator: Locator | None
+
+
+def _to_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_locator(record: dict[str, Any]) -> Locator | None:
+    raw_loc = record.get("locator")
+    if isinstance(raw_loc, dict):
+        file_val = raw_loc.get("file")
+        ls = raw_loc.get("line_start")
+        le = raw_loc.get("line_end")
+        cmd = raw_loc.get("command")
+    else:
+        file_val = record.get("file")
+        ls = record.get("line_start")
+        le = record.get("line_end")
+        cmd = record.get("command")
+
+    if all(v is None for v in (file_val, ls, le, cmd)):
+        return None
+
+    return Locator(
+        file=str(file_val) if file_val is not None else None,
+        line_start=_to_int(ls),
+        line_end=_to_int(le),
+        command=str(cmd) if cmd is not None else None,
+    )
+
+
+def _build_candidate(record: dict[str, Any]) -> _Candidate | None:
+    eid = record.get("evidence_id")
+    if eid is None:
+        eid = record.get("event_id")
+    if not isinstance(eid, str) or not eid:
+        return None
+
+    kind_raw = record.get("kind")
+    kind = str(kind_raw) if kind_raw is not None else "unknown"
+    summary_raw = record.get("summary")
+    summary = str(summary_raw) if summary_raw is not None else ""
+
+    is_raw_kind = kind in RAW_DENIED_KINDS
+
+    # Selected concise content: snippet is always concise. For raw-output
+    # kinds, text/content fields are treated as raw unless an explicit snippet
+    # is supplied.
+    concise_text: str | None = None
+    for fname in _CONCISE_FIELDS:
+        val = record.get(fname)
+        if isinstance(val, str) and val.strip():
+            concise_text = val
+            break
+    if concise_text is None and not is_raw_kind:
+        for fname in ("text", "content"):
+            val = record.get(fname)
+            if isinstance(val, str) and val.strip():
+                concise_text = val
+                break
+
+    # Raw full output: stdout/stderr and text/content for raw-output kinds.
+    raw_text: str | None = None
+    raw_field_list = _RAW_FIELDS + (("text", "content") if is_raw_kind else ())
+    for fname in raw_field_list:
+        val = record.get(fname)
+        if isinstance(val, str) and val.strip():
+            raw_text = val
+            break
+
+    return _Candidate(
+        evidence_id=eid,
+        kind=kind,
+        summary=summary,
+        concise_text=concise_text,
+        raw_text=raw_text,
+        locator=_extract_locator(record),
+    )
+
+
+class EvidenceExpander:
+    """Expands evidence_id values into the smallest useful sanitized snippets."""
+
+    def __init__(self, records: list[dict[str, Any]] | None = None) -> None:
+        self._index: dict[str, _Candidate] = {}
+        for record in records or []:
+            candidate = _build_candidate(record)
+            if candidate is not None and candidate.evidence_id not in self._index:
+                self._index[candidate.evidence_id] = candidate
+
+    def expand(self, request: EvidenceExpandRequest) -> EvidenceExpandResponse:
+        budget = request.budget
+        policy = request.policy
+        max_per = budget.max_chars_per_evidence
+        max_total = budget.max_total_chars
+
+        expanded: list[ExpandedEvidence] = []
+        omitted: list[OmittedEvidence] = []
+        total_chars = 0
+
+        for evidence_id in request.evidence_ids:
+            if max_total is not None and total_chars >= max_total:
+                omitted.append(
+                    OmittedEvidence(
+                        evidence_id=evidence_id,
+                        reason="max_total_chars budget exhausted",
+                    )
+                )
+                continue
+
+            candidate = self._index.get(evidence_id)
+            if candidate is None:
+                omitted.append(
+                    OmittedEvidence(evidence_id=evidence_id, reason="evidence_id not found")
+                )
+                continue
+
+            if candidate.concise_text is not None:
+                raw_snippet = candidate.concise_text
+            elif candidate.raw_text is not None:
+                if not policy.allow_raw_full_output:
+                    omitted.append(
+                        OmittedEvidence(
+                            evidence_id=evidence_id,
+                            reason="raw full output denied by policy (allow_raw_full_output=False)",
+                        )
+                    )
+                    logger.warning("evidence %r omitted: raw output denied by policy", evidence_id)
+                    continue
+                raw_snippet = candidate.raw_text
+            else:
+                omitted.append(
+                    OmittedEvidence(
+                        evidence_id=evidence_id,
+                        reason="no expandable content available",
+                    )
+                )
+                continue
+
+            # Enforce per-evidence char limit, capped by remaining total budget.
+            char_limit = max_per
+            if max_total is not None:
+                remaining = max_total - total_chars
+                char_limit = min(char_limit, remaining)
+
+            truncated = len(raw_snippet) > char_limit
+            snippet = raw_snippet[:char_limit] if truncated else raw_snippet
+
+            redaction_status: str | None = None
+            if policy.redact_again:
+                result = sanitize_text_with_report(snippet)
+                snippet = result.text
+                redaction_status = "redacted" if result.report.counts else "clean"
+
+            total_chars += len(snippet)
+
+            expanded.append(
+                ExpandedEvidence(
+                    evidence_id=evidence_id,
+                    kind=candidate.kind,
+                    summary=candidate.summary,
+                    snippet=snippet,
+                    locator=candidate.locator,
+                    redaction_status=redaction_status,
+                    truncated=truncated,
+                )
+            )
+
+        return EvidenceExpandResponse(
+            schema_version=DEFAULT_SCHEMA_VERSION_V2,
+            request_id=request.request_id,
+            expanded=expanded,
+            omitted=omitted,
+        )
+
+
+__all__ = ["EvidenceExpander"]

--- a/tests/test_evidence_expander.py
+++ b/tests/test_evidence_expander.py
@@ -1,0 +1,450 @@
+"""Tests for EvidenceExpander and POST /v1/evidence/expand.
+
+Acceptance criteria covered:
+- selected sanitized snippet returned by evidence_id
+- full raw output is default-denied
+- max_chars_per_evidence truncates snippets
+- max_total_chars limits total output and omits remaining IDs with reasons
+- sanitizer re-runs before response; secrets and home paths not visible
+- omitted reason for missing evidence IDs and denied raw output
+- locator line range / command returned when present
+- API route works with evidence_records extras and store-backed events
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    EvidenceExpandBudget,
+    EvidenceExpandPolicy,
+    EvidenceExpandRequest,
+)
+from photon_action_memory.api.server import create_app
+from photon_action_memory.memory.evidence import EvidenceExpander
+from photon_action_memory.memory.store import SQLiteEventStore
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _req(
+    evidence_ids: list[str],
+    *,
+    budget: EvidenceExpandBudget | None = None,
+    policy: EvidenceExpandPolicy | None = None,
+) -> EvidenceExpandRequest:
+    return EvidenceExpandRequest(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        request_id="req-test",
+        evidence_ids=evidence_ids,
+        budget=budget or EvidenceExpandBudget(),
+        policy=policy or EvidenceExpandPolicy(),
+    )
+
+
+def _rec(evidence_id: str, **kwargs: Any) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "evidence_id": evidence_id,
+        "kind": kwargs.pop("kind", "file_inspection"),
+        "summary": kwargs.pop("summary", "test summary"),
+    }
+    record.update(kwargs)
+    return record
+
+
+# ---------------------------------------------------------------------------
+# Snippet selection
+# ---------------------------------------------------------------------------
+
+
+def test_snippet_field_returned_by_evidence_id() -> None:
+    expander = EvidenceExpander(records=[_rec("ev-1", snippet="auth.py line 42")])
+    resp = expander.expand(_req(["ev-1"]))
+    assert len(resp.expanded) == 1
+    assert resp.expanded[0].evidence_id == "ev-1"
+    assert resp.expanded[0].snippet == "auth.py line 42"
+    assert resp.omitted == []
+
+
+def test_text_field_used_as_concise_snippet() -> None:
+    expander = EvidenceExpander(records=[_rec("ev-2", text="concise finding")])
+    resp = expander.expand(_req(["ev-2"]))
+    assert len(resp.expanded) == 1
+    assert resp.expanded[0].snippet == "concise finding"
+
+
+def test_content_field_used_for_non_raw_kind() -> None:
+    expander = EvidenceExpander(
+        records=[_rec("ev-3", kind="file_inspection", content="def foo(): pass")]
+    )
+    resp = expander.expand(_req(["ev-3"]))
+    assert len(resp.expanded) == 1
+    assert "def foo" in (resp.expanded[0].snippet or "")
+
+
+def test_snippet_preferred_over_text() -> None:
+    expander = EvidenceExpander(records=[_rec("ev-pri", snippet="snippet wins", text="text loses")])
+    resp = expander.expand(_req(["ev-pri"]))
+    assert resp.expanded[0].snippet == "snippet wins"
+
+
+def test_event_id_fallback_for_evidence_id() -> None:
+    records: list[dict[str, Any]] = [
+        {"event_id": "ev-evt", "kind": "file_inspection", "summary": "s", "snippet": "code"}
+    ]
+    expander = EvidenceExpander(records=records)
+    resp = expander.expand(_req(["ev-evt"]))
+    assert len(resp.expanded) == 1
+    assert resp.expanded[0].evidence_id == "ev-evt"
+
+
+# ---------------------------------------------------------------------------
+# Default deny for raw full output
+# ---------------------------------------------------------------------------
+
+
+def test_stdout_default_denied() -> None:
+    expander = EvidenceExpander(records=[_rec("ev-raw", kind="stdout", stdout="Build output")])
+    resp = expander.expand(_req(["ev-raw"]))
+    assert resp.expanded == []
+    assert len(resp.omitted) == 1
+    assert "denied" in resp.omitted[0].reason
+
+
+def test_stderr_default_denied() -> None:
+    expander = EvidenceExpander(records=[_rec("ev-err", kind="stderr", stderr="Error trace")])
+    resp = expander.expand(_req(["ev-err"]))
+    assert resp.expanded == []
+    assert "denied" in resp.omitted[0].reason
+
+
+def test_content_on_raw_kind_default_denied() -> None:
+    expander = EvidenceExpander(
+        records=[_rec("ev-fc", kind="file_content", content="raw file body")]
+    )
+    resp = expander.expand(_req(["ev-fc"]))
+    assert resp.expanded == []
+    assert "denied" in resp.omitted[0].reason
+
+
+def test_text_on_raw_kind_default_denied() -> None:
+    expander = EvidenceExpander(records=[_rec("ev-text-raw", kind="stdout", text="raw log")])
+    resp = expander.expand(_req(["ev-text-raw"]))
+    assert resp.expanded == []
+    assert "denied" in resp.omitted[0].reason
+
+
+def test_raw_output_allowed_when_policy_permits() -> None:
+    expander = EvidenceExpander(records=[_rec("ev-allow", kind="stdout", stdout="output")])
+    policy = EvidenceExpandPolicy(allow_raw_full_output=True)
+    resp = expander.expand(_req(["ev-allow"], policy=policy))
+    assert len(resp.expanded) == 1
+    assert resp.expanded[0].snippet == "output"
+
+
+# ---------------------------------------------------------------------------
+# Budget enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_max_chars_per_evidence_truncates() -> None:
+    # Use safe text (short words, no patterns that trigger sanitizer redaction).
+    snippet = "Hello World! " * 200  # ~2600 chars, no long-secret match
+    expander = EvidenceExpander(records=[_rec("ev-big", snippet=snippet)])
+    budget = EvidenceExpandBudget(max_chars_per_evidence=100)
+    resp = expander.expand(_req(["ev-big"], budget=budget))
+    assert len(resp.expanded) == 1
+    assert resp.expanded[0].truncated is True
+    assert len(resp.expanded[0].snippet or "") == 100
+
+
+def test_snippet_not_truncated_when_under_limit() -> None:
+    expander = EvidenceExpander(records=[_rec("ev-small", snippet="short")])
+    budget = EvidenceExpandBudget(max_chars_per_evidence=100)
+    resp = expander.expand(_req(["ev-small"], budget=budget))
+    assert resp.expanded[0].truncated is False
+    assert resp.expanded[0].snippet == "short"
+
+
+def test_max_total_chars_limits_and_omits_remaining() -> None:
+    # Use safe text so sanitizer does not change the snippet length.
+    base = "the quick brown fox. " * 30  # ~630 chars per record, no redaction
+    records = [
+        _rec("ev-a", snippet=base),
+        _rec("ev-b", snippet=base),
+        _rec("ev-c", snippet=base),
+    ]
+    expander = EvidenceExpander(records=records)
+    budget = EvidenceExpandBudget(max_chars_per_evidence=1200, max_total_chars=600)
+    resp = expander.expand(_req(["ev-a", "ev-b", "ev-c"], budget=budget))
+
+    total = sum(len(e.snippet or "") for e in resp.expanded)
+    assert total <= 600
+    assert len(resp.omitted) >= 1
+    assert any("budget" in o.reason for o in resp.omitted)
+
+
+def test_max_total_chars_exhausted_before_second_item() -> None:
+    records = [_rec("ev-x", snippet="a" * 100), _rec("ev-y", snippet="b" * 100)]
+    expander = EvidenceExpander(records=records)
+    budget = EvidenceExpandBudget(max_chars_per_evidence=200, max_total_chars=50)
+    resp = expander.expand(_req(["ev-x", "ev-y"], budget=budget))
+    assert len(resp.expanded) == 1
+    assert resp.expanded[0].truncated is True
+    assert len(resp.omitted) == 1
+    assert resp.omitted[0].evidence_id == "ev-y"
+    assert "budget" in resp.omitted[0].reason
+
+
+# ---------------------------------------------------------------------------
+# Sanitizer re-run
+# ---------------------------------------------------------------------------
+
+
+def test_sanitizer_strips_secret_from_snippet() -> None:
+    secret = "token=sk-abc123def456ghi789jkl012"
+    expander = EvidenceExpander(records=[_rec("ev-sec", snippet=secret)])
+    resp = expander.expand(_req(["ev-sec"]))
+    assert len(resp.expanded) == 1
+    snippet = resp.expanded[0].snippet or ""
+    assert "sk-abc123" not in snippet
+    assert "[REDACTED" in snippet
+
+
+def test_sanitizer_strips_absolute_home_path() -> None:
+    expander = EvidenceExpander(
+        records=[_rec("ev-path", snippet="file at /Users/alice/secret/config.py")]
+    )
+    resp = expander.expand(_req(["ev-path"]))
+    assert len(resp.expanded) == 1
+    snippet = resp.expanded[0].snippet or ""
+    assert "/Users/alice" not in snippet
+
+
+def test_redaction_status_is_set_after_sanitization() -> None:
+    expander = EvidenceExpander(records=[_rec("ev-clean", snippet="clean text")])
+    resp = expander.expand(_req(["ev-clean"]))
+    assert resp.expanded[0].redaction_status in ("clean", "redacted")
+
+
+def test_redaction_status_is_none_when_redact_again_false() -> None:
+    expander = EvidenceExpander(records=[_rec("ev-noredact", snippet="text")])
+    policy = EvidenceExpandPolicy(redact_again=False)
+    resp = expander.expand(_req(["ev-noredact"], policy=policy))
+    assert resp.expanded[0].redaction_status is None
+
+
+# ---------------------------------------------------------------------------
+# Omitted reasons
+# ---------------------------------------------------------------------------
+
+
+def test_omitted_reason_for_missing_evidence_id() -> None:
+    expander = EvidenceExpander(records=[])
+    resp = expander.expand(_req(["nonexistent"]))
+    assert resp.expanded == []
+    assert len(resp.omitted) == 1
+    assert "not found" in resp.omitted[0].reason
+
+
+def test_omitted_reason_for_denied_raw_output() -> None:
+    expander = EvidenceExpander(records=[_rec("ev-deny", kind="stderr", stderr="trace")])
+    resp = expander.expand(_req(["ev-deny"]))
+    assert len(resp.omitted) == 1
+    assert "denied" in resp.omitted[0].reason
+
+
+def test_omitted_reason_when_no_expandable_content() -> None:
+    expander = EvidenceExpander(records=[_rec("ev-empty")])
+    resp = expander.expand(_req(["ev-empty"]))
+    assert len(resp.omitted) == 1
+    assert "no expandable content" in resp.omitted[0].reason
+
+
+# ---------------------------------------------------------------------------
+# Locator
+# ---------------------------------------------------------------------------
+
+
+def test_locator_line_range_from_flat_fields() -> None:
+    expander = EvidenceExpander(
+        records=[_rec("ev-loc", snippet="def auth", file="auth.py", line_start=10, line_end=20)]
+    )
+    resp = expander.expand(_req(["ev-loc"]))
+    loc = resp.expanded[0].locator
+    assert loc is not None
+    assert loc.file == "auth.py"
+    assert loc.line_start == 10
+    assert loc.line_end == 20
+
+
+def test_locator_command_from_flat_field() -> None:
+    expander = EvidenceExpander(records=[_rec("ev-cmd", snippet="output", command="ls -la")])
+    resp = expander.expand(_req(["ev-cmd"]))
+    loc = resp.expanded[0].locator
+    assert loc is not None
+    assert loc.command == "ls -la"
+
+
+def test_locator_from_nested_locator_dict() -> None:
+    expander = EvidenceExpander(
+        records=[
+            _rec(
+                "ev-nested",
+                snippet="code",
+                locator={"file": "api.py", "line_start": 5, "line_end": 15},
+            )
+        ]
+    )
+    resp = expander.expand(_req(["ev-nested"]))
+    loc = resp.expanded[0].locator
+    assert loc is not None
+    assert loc.file == "api.py"
+    assert loc.line_start == 5
+    assert loc.line_end == 15
+
+
+def test_locator_is_none_when_no_location_fields() -> None:
+    expander = EvidenceExpander(records=[_rec("ev-noloc", snippet="just text")])
+    resp = expander.expand(_req(["ev-noloc"]))
+    assert resp.expanded[0].locator is None
+
+
+# ---------------------------------------------------------------------------
+# Summary / kind fields
+# ---------------------------------------------------------------------------
+
+
+def test_kind_and_summary_included_in_expanded() -> None:
+    expander = EvidenceExpander(
+        records=[_rec("ev-meta", kind="edit_attempt", summary="Tried to edit auth.py", snippet="x")]
+    )
+    resp = expander.expand(_req(["ev-meta"]))
+    item = resp.expanded[0]
+    assert item.kind == "edit_attempt"
+    assert item.summary == "Tried to edit auth.py"
+
+
+# ---------------------------------------------------------------------------
+# API integration - POST /v1/evidence/expand
+# ---------------------------------------------------------------------------
+
+
+def _api_body(
+    evidence_ids: list[str],
+    *,
+    extra_records: list[dict[str, Any]] | None = None,
+    policy: dict[str, Any] | None = None,
+    budget: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "req-api",
+        "evidence_ids": evidence_ids,
+        "budget": budget or {"max_chars_per_evidence": 1200},
+        "policy": policy or {"allow_raw_full_output": False, "redact_again": True},
+    }
+    if extra_records is not None:
+        body["evidence_records"] = extra_records
+    return body
+
+
+def test_api_expand_with_evidence_records_extra(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    records = [
+        {
+            "evidence_id": "ev-api-1",
+            "kind": "file_inspection",
+            "summary": "s",
+            "snippet": "found it",
+        }
+    ]
+    with TestClient(app) as client:
+        resp = client.post(
+            "/v1/evidence/expand", json=_api_body(["ev-api-1"], extra_records=records)
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["expanded"]) == 1
+    assert data["expanded"][0]["snippet"] == "found it"
+    assert data["omitted"] == []
+
+
+def test_api_expand_with_store_backed_events(tmp_path: Path) -> None:
+    store = SQLiteEventStore(tmp_path / "events.sqlite")
+    store.append(
+        {
+            "session_id": "sess-1",
+            "turn_id": "turn-1",
+            "repo_id": "repo-1",
+            "event_type": "file_inspection",
+            "evidence_id": "ev-store-1",
+            "kind": "file_inspection",
+            "summary": "store evidence",
+            "snippet": "def main(): pass",
+        }
+    )
+    app = create_app(store)
+    with TestClient(app) as client:
+        resp = client.post("/v1/evidence/expand", json=_api_body(["ev-store-1"]))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["expanded"]) == 1
+    assert data["expanded"][0]["snippet"] == "def main(): pass"
+
+
+def test_api_expand_raw_denied_by_default(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    records = [
+        {"evidence_id": "ev-raw-api", "kind": "stdout", "summary": "s", "stdout": "build log"}
+    ]
+    with TestClient(app) as client:
+        resp = client.post(
+            "/v1/evidence/expand", json=_api_body(["ev-raw-api"], extra_records=records)
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["expanded"] == []
+    assert len(data["omitted"]) == 1
+    assert "denied" in data["omitted"][0]["reason"]
+
+
+def test_api_expand_missing_id_returns_omitted(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    with TestClient(app) as client:
+        resp = client.post("/v1/evidence/expand", json=_api_body(["no-such-id"]))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["expanded"] == []
+    assert len(data["omitted"]) == 1
+    assert "not found" in data["omitted"][0]["reason"]
+
+
+def test_api_expand_fail_open_on_error(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    with patch(
+        "photon_action_memory.api.server.EvidenceExpander",
+        side_effect=RuntimeError("simulated"),
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/v1/evidence/expand", json=_api_body(["ev-fail"]))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["expanded"] == []
+    assert len(data["omitted"]) == 1
+    assert "expansion error" in data["omitted"][0]["reason"]
+
+
+def test_api_expand_schema_version_in_response(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    with TestClient(app) as client:
+        resp = client.post("/v1/evidence/expand", json=_api_body([]))
+    assert resp.status_code == 200
+    assert resp.json()["schema_version"] == DEFAULT_SCHEMA_VERSION_V2


### PR DESCRIPTION
## Summary
- Add `EvidenceExpander` for selected sanitized evidence snippets with raw full-output default deny.
- Add `POST /v1/evidence/expand` using store-backed events plus request `evidence_records` extras.
- Enforce per-evidence and total character budgets, re-run sanitizer before response, return omitted reasons, and preserve locator metadata.
- Add focused tests and issue 38 dev reports.

## Verification
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m mypy photon_action_memory tests`
- `python -m pytest -q` (`362 passed, 1 skipped`)

Closes #38