### PR TITLE
#39 Implement SummaryValidation and fidelity checks

### DIFF
--- a/dev-reports/issue-39/implementation-summary.md
+++ b/dev-reports/issue-39/implementation-summary.md
@@ -1,0 +1,80 @@
+# Issue #39 - SummaryValidation and Fidelity Checks Implementation Summary
+
+## What was added
+
+### `photon_action_memory/eval/summary_fidelity.py` (new)
+
+Core implementation of the `SummaryFidelityChecker` class.
+
+**Module-level constants**
+
+- `_UNCERTAINTY_KEYWORDS` - tuple of words that indicate hypothesis-level uncertainty
+  (`appears`, `could`, `likely`, `maybe`, `might`, `perhaps`, `possibly`, `presumably`,
+  `seems`, `suspect`, `unclear`, `uncertain`, `probably`)
+- `_UNCERTAINTY_PATTERN` - pre-compiled `re.Pattern` with word-boundary anchors matching
+  those keywords case-insensitively; word boundaries prevent false matches inside longer words
+- `_FAILURE_OUTCOMES` - frozenset of outcome/status strings treated as failure indicators
+  (`failed`, `failure`, `error`, `fail`)
+- `_BLOCKING_KINDS` - frozenset of issue `kind` values that cause `"invalid"` status
+  (`missing_evidence_id`, `ungrounded_fact`, `failed_action_misclassified`)
+
+**`SummaryFidelityChecker`**
+
+Constructor accepts an optional `records` list (evidence dicts). Evidence IDs are extracted
+from `evidence_id` or `event_id` fields and stored in an internal set for O(1) grounding
+lookups. Without records, only structural checks run.
+
+`check(summary) -> SummaryValidationResult` - runs all checks, computes score and status:
+
+- **`_check_facts`** - for each `Fact`:
+  - `missing_evidence_id` (blocking): `evidence_ids` list is empty
+  - `ungrounded_fact` (blocking): `evidence_ids` present but none found in evidence records
+    (only when records were provided); message contains only the missing IDs (up to 3) and a count
+  - `hypothesis_as_fact` (non-blocking): fact text matches `_UNCERTAINTY_PATTERN`; message
+    names the matched word - no evidence content is embedded
+- **`_check_actions_done`** - for each `ActionDone`:
+  - If outcome/status indicates failure and the command/target is not found in any
+    `failed_attempts.action` -> `failed_action_misclassified` (blocking)
+  - If outcome/status indicates success and the command/target matches a `failed_attempts.action`
+    -> `failed_action_misclassified` (blocking): contradiction between actions_done and
+    failed_attempts for the same action
+
+`_compute_score` - deduction formula, clamped to `[0.0, 1.0]`, rounded to 4 decimal places:
+```
+n_total = max(1, len(facts) + len(failed_attempts) + len(actions_done))
+deduction = min(1.0, (n_blocking + n_non_blocking * 0.5) / n_total)
+score = max(0.0, 1.0 - deduction)
+```
+
+`_compute_status`:
+- `"valid"` - no issues
+- `"invalid"` - at least one issue with `kind` in `_BLOCKING_KINDS`
+- `"partial"` - issues present, none blocking
+
+`check_all(summaries) -> list[SummaryValidationResult]` - delegates to `check()` per summary.
+
+**Prompt-safety guarantee**: issue `message` fields contain only evidence IDs (up to 3 at a time),
+counts, field indices, and the matched uncertainty keyword. Raw evidence content, secrets, or
+full evidence bodies are never embedded.
+
+### `photon_action_memory/eval/__init__.py` (updated)
+
+Added `SummaryFidelityChecker` import and `__all__` export.
+
+### `photon_action_memory/api/server.py` (updated)
+
+Added `POST /v1/summary/validate` route inside `create_app()`:
+
+- Imports `ActionSummary`, `SummaryValidateRequest`, `SummaryValidateResponse` from `schema_v2`.
+- Imports `SummaryFidelityChecker` from `eval.summary_fidelity`.
+- Reads `summaries` extra field (list of `ActionSummary` dicts) from `request.model_extra`.
+  Malformed items are skipped with a warning log - they do not abort the request.
+- Reads `evidence_records` extra field (list of dicts) and merges with store-backed event
+  payloads to form the record pool passed to the checker.
+- Calls `checker.check_all(summaries)` and returns a `SummaryValidateResponse`.
+- **Fail-open**: any unhandled exception is logged at WARNING level; the response is returned
+  with an empty `results` list - no HTTP 5xx is raised.
+
+### `tests/test_summary_fidelity.py` (new)
+
+45 focused deterministic tests covering all acceptance criteria.

--- a/dev-reports/issue-39/verification.md
+++ b/dev-reports/issue-39/verification.md
@@ -1,0 +1,89 @@
+# Issue #39 - Verification Results
+
+## Commands run
+
+```
+python -m ruff format --check .
+python -m ruff check .
+python -m mypy photon_action_memory tests
+python -m pytest -q
+```
+
+## Results
+
+### ruff format
+```
+59 files already formatted
+```
+Exit code: 0 - PASS
+
+### ruff check
+```
+All checks passed!
+```
+Exit code: 0 - PASS
+
+### mypy
+```
+Success: no issues found in 57 source files
+```
+Exit code: 0 - PASS
+
+### pytest
+```
+407 passed, 1 skipped in 1.15s
+```
+The 1 skipped test is `tests/integration/test_mlx_smoke.py` (opt-in MLX test, not related to this issue).
+New tests added: 45 (in `tests/test_summary_fidelity.py`).
+
+Exit code: 0 - PASS
+
+## New tests added (`tests/test_summary_fidelity.py`)
+
+| Test | Criterion |
+|---|---|
+| `test_missing_evidence_ids_reported` | missing evidence IDs reported, status=invalid |
+| `test_facts_without_evidence_flagged` | facts without evidence flagged |
+| `test_multiple_facts_missing_evidence_all_reported` | all missing-evidence facts reported |
+| `test_facts_with_evidence_pass` | facts with valid evidence_ids pass |
+| `test_facts_with_evidence_and_no_records_not_flagged_as_ungrounded` | no records -> no ungrounded check |
+| `test_fact_text_unsupported_by_evidence_flagged` | evidence_id not in records -> ungrounded_fact |
+| `test_fact_text_contradicts_evidence_content_flagged` | evidence content contradicts fact text |
+| `test_fact_text_supported_by_evidence_content_passes` | evidence content supports fact text |
+| `test_fact_grounding_uses_nested_payload_content` | nested payload evidence content |
+| `test_ungrounded_fact_message_contains_evidence_id_not_full_content` | prompt-safe message |
+| `test_partial_evidence_ids_some_missing_flagged` | partial mismatch flagged |
+| `test_all_evidence_ids_found_no_ungrounded_issue` | all IDs found -> clean |
+| `test_uncertainty_language_in_fact_flagged` | "might" -> hypothesis_as_fact |
+| `test_maybe_keyword_triggers_hypothesis_as_fact` | "maybe" keyword |
+| `test_probably_keyword_triggers_hypothesis_as_fact` | "probably" keyword |
+| `test_uncertain_keyword_triggers_hypothesis_as_fact` | "unclear" keyword |
+| `test_hypotheses_with_uncertainty_allowed` | hypotheses are exempt from check |
+| `test_clear_language_fact_not_flagged` | clear facts not flagged |
+| `test_hypothesis_as_fact_message_is_prompt_safe` | no raw evidence in message |
+| `test_failed_action_recorded_as_successful_flagged` | contradiction detected, status=invalid |
+| `test_action_done_with_failed_status_not_in_failed_attempts_flagged` | failed status not tracked |
+| `test_action_done_with_error_status_flagged` | "error" outcome flagged |
+| `test_action_done_with_failed_status_in_failed_attempts_not_flagged` | properly tracked -> clean |
+| `test_successful_action_not_in_failed_attempts_clean` | success with no failed_attempts -> clean |
+| `test_failed_action_misclassified_message_prompt_safe` | message is concise |
+| `test_score_is_one_for_valid_summary` | score=1.0 for clean summary |
+| `test_score_bounded_between_zero_and_one` | score stays in [0.0, 1.0] |
+| `test_score_lower_for_invalid_summary` | score < 1.0 for invalid |
+| `test_valid_status_when_no_issues` | valid status |
+| `test_partial_status_for_non_blocking_issue_only` | partial status |
+| `test_invalid_status_for_blocking_issue` | invalid status |
+| `test_empty_summary_is_valid_with_score_one` | empty summary -> valid, score=1.0 |
+| `test_checked_at_is_set` | checked_at field populated |
+| `test_result_does_not_leak_raw_evidence_content` | no secrets in messages |
+| `test_issue_messages_contain_only_ids_and_counts` | prompt-safe aggregate |
+| `test_check_all_returns_one_result_per_summary` | one result per summary |
+| `test_check_all_empty_list_returns_empty` | empty input -> empty output |
+| `test_api_validate_empty_summaries_returns_empty_results` | API route, empty summaries |
+| `test_api_validate_with_summaries_extra` | API route, summaries extra |
+| `test_api_validate_flags_missing_evidence` | API route, missing evidence detected |
+| `test_api_validate_with_evidence_records_extra` | API route, evidence_records extra |
+| `test_api_validate_flags_ungrounded_fact_via_evidence_records` | API route, grounding check |
+| `test_api_validate_schema_version_in_response` | schema_version in response |
+| `test_api_validate_fail_open_on_checker_error` | fail-open on RuntimeError |
+| `test_api_validate_multiple_summaries` | API route, multiple summaries |

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -23,6 +23,7 @@ from photon_action_memory.api.schema import (
 )
 from photon_action_memory.api.schema_v2 import (
     DEFAULT_SCHEMA_VERSION_V2,
+    ActionSummary,
     ContextPack,
     ContextPackRequest,
     ContextPackResponse,
@@ -30,10 +31,13 @@ from photon_action_memory.api.schema_v2 import (
     EvidenceExpandRequest,
     EvidenceExpandResponse,
     OmittedEvidence,
+    SummaryValidateRequest,
+    SummaryValidateResponse,
     TokenBudget,
 )
 from photon_action_memory.context.pack import build_context_pack
 from photon_action_memory.context.raw_policy import RawEvidenceItem
+from photon_action_memory.eval.summary_fidelity import SummaryFidelityChecker
 from photon_action_memory.memory.evidence import EvidenceExpander
 from photon_action_memory.memory.store import SQLiteEventStore
 from photon_action_memory.models.photon_adapter import score_suggestions_with_optional_adapter
@@ -159,6 +163,38 @@ def create_app(store: SQLiteEventStore | None = None) -> FastAPI:
                     for eid in request.evidence_ids
                 ],
             )
+
+    @app.post("/v1/summary/validate", response_model=SummaryValidateResponse)
+    def validate_summary(request: SummaryValidateRequest) -> SummaryValidateResponse:
+        try:
+            extras = request.model_extra or {}
+            raw_summaries = extras.get("summaries", [])
+            summaries: list[ActionSummary] = []
+            if isinstance(raw_summaries, list):
+                for item in raw_summaries:
+                    if isinstance(item, dict):
+                        try:
+                            summaries.append(ActionSummary.model_validate(item))
+                        except Exception as parse_exc:
+                            logger.warning("summary parse error: %s", parse_exc)
+
+            evidence_records: list[dict[str, Any]] = []
+            raw_evidence = extras.get("evidence_records")
+            if isinstance(raw_evidence, list):
+                evidence_records.extend(r for r in raw_evidence if isinstance(r, dict))
+            evidence_records.extend(ev.payload for ev in event_store.list_events())
+
+            checker = SummaryFidelityChecker(records=evidence_records)
+            results = checker.check_all(summaries)
+        except Exception as exc:
+            logger.warning("summary validate error: %s", exc)
+            results = []
+
+        return SummaryValidateResponse(
+            schema_version=DEFAULT_SCHEMA_VERSION_V2,
+            request_id=request.request_id,
+            results=results,
+        )
 
     @app.post("/v1/summarize")
     def summarize_stub() -> None:

--- a/photon_action_memory/eval/__init__.py
+++ b/photon_action_memory/eval/__init__.py
@@ -14,6 +14,7 @@ from photon_action_memory.eval.runner import (
     run_fixture,
     write_metrics_report,
 )
+from photon_action_memory.eval.summary_fidelity import SummaryFidelityChecker
 
 __all__ = [
     "EvalAction",
@@ -21,6 +22,7 @@ __all__ = [
     "EvalWarning",
     "MetricsReport",
     "ShadowEvalRecord",
+    "SummaryFidelityChecker",
     "build_metrics_report",
     "load_fixture",
     "run_eval",

--- a/photon_action_memory/eval/summary_fidelity.py
+++ b/photon_action_memory/eval/summary_fidelity.py
@@ -1,0 +1,262 @@
+"""Summary fidelity checker for ActionSummary validation."""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from typing import Any
+
+from photon_action_memory.api.schema_v2 import (
+    ActionSummary,
+    SummaryValidationIssue,
+    SummaryValidationResult,
+)
+
+_UNCERTAINTY_KEYWORDS: tuple[str, ...] = (
+    "appears",
+    "could",
+    "likely",
+    "maybe",
+    "might",
+    "perhaps",
+    "possibly",
+    "presumably",
+    "seems",
+    "suspect",
+    "unclear",
+    "uncertain",
+    "probably",
+)
+_UNCERTAINTY_PATTERN: re.Pattern[str] = re.compile(
+    r"\b(?:" + "|".join(re.escape(kw) for kw in _UNCERTAINTY_KEYWORDS) + r")\b",
+    re.IGNORECASE,
+)
+_FAILURE_OUTCOMES: frozenset[str] = frozenset({"failed", "failure", "error", "fail"})
+_BLOCKING_KINDS: frozenset[str] = frozenset(
+    {
+        "missing_evidence_id",
+        "ungrounded_fact",
+        "failed_action_misclassified",
+    }
+)
+_TEXT_FIELDS: tuple[str, ...] = ("content", "text", "message", "output", "body")
+_STOP_WORDS: frozenset[str] = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "at",
+        "be",
+        "by",
+        "for",
+        "from",
+        "has",
+        "have",
+        "in",
+        "is",
+        "it",
+        "of",
+        "on",
+        "or",
+        "that",
+        "the",
+        "this",
+        "to",
+        "was",
+        "were",
+        "with",
+    }
+)
+_WORD_PATTERN: re.Pattern[str] = re.compile(r"[a-z0-9_]+")
+
+
+class SummaryFidelityChecker:
+    """Validates ActionSummary objects against fidelity and grounding criteria.
+
+    Pass evidence records at construction time to enable grounding checks.
+    Without records, only structural checks (missing evidence_ids, uncertainty
+    language in facts) are run.
+    """
+
+    def __init__(self, records: list[dict[str, Any]] | None = None) -> None:
+        self._evidence_ids: set[str] = set()
+        self._evidence_text_by_id: dict[str, str] = {}
+        for record in records or []:
+            eid = record.get("evidence_id") or record.get("event_id")
+            if isinstance(eid, str) and eid:
+                self._evidence_ids.add(eid)
+                text = self._extract_evidence_text(record)
+                if text:
+                    self._evidence_text_by_id[eid] = text
+
+    def check(self, summary: ActionSummary) -> SummaryValidationResult:
+        """Run all fidelity checks on one ActionSummary."""
+        issues: list[SummaryValidationIssue] = []
+        self._check_facts(summary, issues)
+        self._check_actions_done(summary, issues)
+        score = self._compute_score(summary, issues)
+        status = self._compute_status(issues)
+        return SummaryValidationResult(
+            summary_id=summary.summary_id,
+            status=status,
+            score=score,
+            issues=issues,
+            checked_at=datetime.now(UTC).isoformat(),
+        )
+
+    def check_all(self, summaries: list[ActionSummary]) -> list[SummaryValidationResult]:
+        """Run fidelity checks on a list of ActionSummary objects."""
+        return [self.check(s) for s in summaries]
+
+    def _check_facts(self, summary: ActionSummary, issues: list[SummaryValidationIssue]) -> None:
+        for i, fact in enumerate(summary.facts):
+            if not fact.evidence_ids:
+                issues.append(
+                    SummaryValidationIssue(
+                        kind="missing_evidence_id",
+                        message=f"facts[{i}]: no evidence_ids provided",
+                    )
+                )
+            elif self._evidence_ids:
+                missing = [eid for eid in fact.evidence_ids if eid not in self._evidence_ids]
+                if missing:
+                    safe_ids = ", ".join(missing[:3])
+                    issues.append(
+                        SummaryValidationIssue(
+                            kind="ungrounded_fact",
+                            message=(
+                                f"facts[{i}]: {len(missing)} evidence_id(s) not found"
+                                f" in records ({safe_ids})"
+                            ),
+                        )
+                    )
+                else:
+                    texts = [
+                        self._evidence_text_by_id[eid]
+                        for eid in fact.evidence_ids
+                        if eid in self._evidence_text_by_id
+                    ]
+                    if texts and not self._fact_supported_by_evidence(fact.text, texts):
+                        safe_ids = ", ".join(fact.evidence_ids[:3])
+                        issues.append(
+                            SummaryValidationIssue(
+                                kind="ungrounded_fact",
+                                message=(
+                                    f"facts[{i}]: fact text not supported by evidence"
+                                    f" ids ({safe_ids})"
+                                ),
+                            )
+                        )
+
+            m = _UNCERTAINTY_PATTERN.search(fact.text)
+            if m:
+                issues.append(
+                    SummaryValidationIssue(
+                        kind="hypothesis_as_fact",
+                        message=(
+                            f"facts[{i}]: uncertainty language detected ({m.group()!r});"
+                            " consider moving to hypotheses"
+                        ),
+                    )
+                )
+
+    def _check_actions_done(
+        self, summary: ActionSummary, issues: list[SummaryValidationIssue]
+    ) -> None:
+        for i, action in enumerate(summary.actions_done):
+            outcome_lower = action.outcome.strip().lower()
+            status_lower = action.status.strip().lower()
+            is_failure = outcome_lower in _FAILURE_OUTCOMES or status_lower in _FAILURE_OUTCOMES
+
+            if is_failure:
+                cmd = (action.command or action.target or "").strip().lower()
+                if cmd:
+                    in_failed = any(
+                        cmd in fa.action.strip().lower() or fa.action.strip().lower() in cmd
+                        for fa in summary.failed_attempts
+                    )
+                    if not in_failed:
+                        issues.append(
+                            SummaryValidationIssue(
+                                kind="failed_action_misclassified",
+                                message=(
+                                    f"actions_done[{i}]: outcome/status indicates failure"
+                                    " but action is not tracked in failed_attempts"
+                                ),
+                            )
+                        )
+            else:
+                cmd = (action.command or action.target or "").strip().lower()
+                if cmd:
+                    for j, fa in enumerate(summary.failed_attempts):
+                        fa_lower = fa.action.strip().lower()
+                        if fa_lower and (cmd == fa_lower or cmd in fa_lower or fa_lower in cmd):
+                            issues.append(
+                                SummaryValidationIssue(
+                                    kind="failed_action_misclassified",
+                                    message=(
+                                        f"actions_done[{i}]: recorded as successful"
+                                        f" but failed_attempts[{j}] records this action"
+                                        " as failed"
+                                    ),
+                                )
+                            )
+                            break
+
+    def _compute_score(self, summary: ActionSummary, issues: list[SummaryValidationIssue]) -> float:
+        n_total = max(
+            1,
+            len(summary.facts) + len(summary.failed_attempts) + len(summary.actions_done),
+        )
+        n_blocking = sum(1 for iss in issues if iss.kind in _BLOCKING_KINDS)
+        n_non_blocking = len(issues) - n_blocking
+        deduction = min(1.0, (n_blocking + n_non_blocking * 0.5) / n_total)
+        return round(max(0.0, 1.0 - deduction), 4)
+
+    def _compute_status(self, issues: list[SummaryValidationIssue]) -> str:
+        if not issues:
+            return "valid"
+        if any(iss.kind in _BLOCKING_KINDS for iss in issues):
+            return "invalid"
+        return "partial"
+
+    def _extract_evidence_text(self, record: dict[str, Any]) -> str:
+        values: list[str] = []
+        self._collect_text_values(record, values)
+        return "\n".join(values)
+
+    def _collect_text_values(self, value: Any, values: list[str]) -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                if key in _TEXT_FIELDS and isinstance(child, str) and child.strip():
+                    values.append(child)
+                elif isinstance(child, dict | list):
+                    self._collect_text_values(child, values)
+        elif isinstance(value, list):
+            for child in value:
+                if isinstance(child, dict | list):
+                    self._collect_text_values(child, values)
+
+    def _fact_supported_by_evidence(self, fact_text: str, evidence_texts: list[str]) -> bool:
+        fact_norm = " ".join(self._tokens(fact_text))
+        evidence_norm = " ".join(self._tokens("\n".join(evidence_texts)))
+        if not fact_norm or not evidence_norm:
+            return True
+        if fact_norm in evidence_norm:
+            return True
+        fact_tokens = set(fact_norm.split())
+        evidence_tokens = set(evidence_norm.split())
+        overlap = fact_tokens & evidence_tokens
+        return len(overlap) / len(fact_tokens) >= 0.6
+
+    def _tokens(self, text: str) -> list[str]:
+        return [
+            word
+            for word in _WORD_PATTERN.findall(text.lower())
+            if len(word) > 2 and word not in _STOP_WORDS
+        ]
+
+
+__all__ = ["SummaryFidelityChecker"]

--- a/tests/test_summary_fidelity.py
+++ b/tests/test_summary_fidelity.py
@@ -1,0 +1,571 @@
+"""Tests for SummaryFidelityChecker and POST /v1/summary/validate.
+
+Acceptance criteria covered:
+- missing evidence IDs are reported
+- facts with evidence pass
+- facts without evidence are flagged
+- fact text unsupported by evidence is flagged
+- hypothesis-like uncertainty in facts is flagged, while hypotheses are allowed
+- failed action recorded as successful action is flagged
+- score is computed and bounded
+- result is aggregate/prompt-safe and does not leak raw full evidence
+- API route works with request extras
+- API route fail-open behavior
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    ActionDone,
+    ActionSummary,
+    Fact,
+    FailedAttempt,
+    Hypothesis,
+)
+from photon_action_memory.api.server import create_app
+from photon_action_memory.eval.summary_fidelity import SummaryFidelityChecker
+from photon_action_memory.memory.store import SQLiteEventStore
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SV2 = DEFAULT_SCHEMA_VERSION_V2
+
+
+def _summary(
+    summary_id: str = "sum-001",
+    facts: list[Fact] | None = None,
+    hypotheses: list[Hypothesis] | None = None,
+    failed_attempts: list[FailedAttempt] | None = None,
+    actions_done: list[ActionDone] | None = None,
+) -> ActionSummary:
+    return ActionSummary(
+        schema_version=SV2,
+        summary_id=summary_id,
+        facts=facts or [],
+        hypotheses=hypotheses or [],
+        failed_attempts=failed_attempts or [],
+        actions_done=actions_done or [],
+    )
+
+
+def _fact(text: str, evidence_ids: list[str] | None = None) -> Fact:
+    return Fact(text=text, evidence_ids=evidence_ids or [])
+
+
+def _hypothesis(text: str, evidence_ids: list[str] | None = None) -> Hypothesis:
+    return Hypothesis(text=text, evidence_ids=evidence_ids or [])
+
+
+def _action_done(
+    kind: str = "test_verification",
+    command: str | None = "pytest",
+    outcome: str = "success",
+    status: str = "success",
+    target: str | None = None,
+    evidence_ids: list[str] | None = None,
+) -> ActionDone:
+    return ActionDone(
+        kind=kind,
+        command=command,
+        target=target,
+        outcome=outcome,
+        status=status,
+        evidence_ids=evidence_ids or [],
+    )
+
+
+def _failed_attempt(action: str = "pytest", outcome: str = "exit code 1") -> FailedAttempt:
+    return FailedAttempt(action=action, outcome=outcome)
+
+
+def _record(evidence_id: str, **kwargs: Any) -> dict[str, Any]:
+    return {
+        "evidence_id": evidence_id,
+        "kind": kwargs.pop("kind", "file_inspection"),
+        "summary": kwargs.pop("summary", "test summary"),
+        **kwargs,
+    }
+
+
+def _api_client(tmp_path: Path) -> TestClient:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    return TestClient(app)
+
+
+def _validate_payload(
+    summary_id: str = "sum-001",
+    summaries: list[dict[str, Any]] | None = None,
+    evidence_records: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    req: dict[str, Any] = {
+        "schema_version": SV2,
+        "request_id": "req-validate-001",
+        "summary_ids": [summary_id],
+    }
+    if summaries is not None:
+        req["summaries"] = summaries
+    if evidence_records is not None:
+        req["evidence_records"] = evidence_records
+    return req
+
+
+def _summary_dict(
+    summary_id: str = "sum-001",
+    facts: list[dict[str, Any]] | None = None,
+    failed_attempts: list[dict[str, Any]] | None = None,
+    actions_done: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": SV2,
+        "summary_id": summary_id,
+        "facts": facts or [],
+        "hypotheses": [],
+        "failed_attempts": failed_attempts or [],
+        "actions_done": actions_done or [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# SummaryFidelityChecker - missing evidence_id
+# ---------------------------------------------------------------------------
+
+
+def test_missing_evidence_ids_reported() -> None:
+    checker = SummaryFidelityChecker()
+    result = checker.check(_summary(facts=[_fact("the test passed")]))
+    assert any(iss.kind == "missing_evidence_id" for iss in result.issues)
+    assert result.status == "invalid"
+
+
+def test_facts_without_evidence_flagged() -> None:
+    checker = SummaryFidelityChecker()
+    result = checker.check(_summary(facts=[_fact("the build succeeded", [])]))
+    assert any(iss.kind == "missing_evidence_id" for iss in result.issues)
+
+
+def test_multiple_facts_missing_evidence_all_reported() -> None:
+    checker = SummaryFidelityChecker()
+    result = checker.check(
+        _summary(facts=[_fact("fact one"), _fact("fact two"), _fact("fact three")])
+    )
+    missing = [iss for iss in result.issues if iss.kind == "missing_evidence_id"]
+    assert len(missing) == 3
+
+
+# ---------------------------------------------------------------------------
+# SummaryFidelityChecker - facts with evidence pass
+# ---------------------------------------------------------------------------
+
+
+def test_facts_with_evidence_pass() -> None:
+    records = [_record("ev-001")]
+    checker = SummaryFidelityChecker(records=records)
+    result = checker.check(_summary(facts=[_fact("the test passed", ["ev-001"])]))
+    blocking = [
+        iss for iss in result.issues if iss.kind in ("missing_evidence_id", "ungrounded_fact")
+    ]
+    assert not blocking
+    assert result.status == "valid"
+
+
+def test_facts_with_evidence_and_no_records_not_flagged_as_ungrounded() -> None:
+    checker = SummaryFidelityChecker(records=None)
+    result = checker.check(_summary(facts=[_fact("fact text", ["ev-999"])]))
+    assert not any(iss.kind == "ungrounded_fact" for iss in result.issues)
+
+
+# ---------------------------------------------------------------------------
+# SummaryFidelityChecker - ungrounded facts (unsupported by evidence)
+# ---------------------------------------------------------------------------
+
+
+def test_fact_text_unsupported_by_evidence_flagged() -> None:
+    records = [_record("ev-001")]
+    checker = SummaryFidelityChecker(records=records)
+    result = checker.check(_summary(facts=[_fact("the test passed", ["ev-999"])]))
+    assert any(iss.kind == "ungrounded_fact" for iss in result.issues)
+    assert result.status == "invalid"
+
+
+def test_fact_text_contradicts_evidence_content_flagged() -> None:
+    records = [_record("ev-001", content="pytest failed with exit code 1")]
+    checker = SummaryFidelityChecker(records=records)
+    result = checker.check(_summary(facts=[_fact("pytest passed", ["ev-001"])]))
+    assert any(iss.kind == "ungrounded_fact" for iss in result.issues)
+    assert result.status == "invalid"
+
+
+def test_fact_text_supported_by_evidence_content_passes() -> None:
+    records = [_record("ev-001", content="pytest passed and all checks completed")]
+    checker = SummaryFidelityChecker(records=records)
+    result = checker.check(_summary(facts=[_fact("pytest passed", ["ev-001"])]))
+    assert not any(iss.kind == "ungrounded_fact" for iss in result.issues)
+    assert result.status == "valid"
+
+
+def test_fact_grounding_uses_nested_payload_content() -> None:
+    records = [_record("ev-001", payload={"message": "database migration completed"})]
+    checker = SummaryFidelityChecker(records=records)
+    result = checker.check(_summary(facts=[_fact("migration completed", ["ev-001"])]))
+    assert result.status == "valid"
+
+
+def test_ungrounded_fact_message_contains_evidence_id_not_full_content() -> None:
+    raw_content = "SECRET_KEY=abc123 raw full evidence body here"
+    records = [_record("ev-001", content=raw_content)]
+    checker = SummaryFidelityChecker(records=records)
+    result = checker.check(_summary(facts=[_fact("the test passed", ["ev-bad"])]))
+    issue = next(iss for iss in result.issues if iss.kind == "ungrounded_fact")
+    assert "ev-bad" in issue.message
+    assert "SECRET_KEY" not in issue.message
+    assert raw_content not in issue.message
+
+
+def test_partial_evidence_ids_some_missing_flagged() -> None:
+    records = [_record("ev-001"), _record("ev-002")]
+    checker = SummaryFidelityChecker(records=records)
+    result = checker.check(_summary(facts=[_fact("fact", ["ev-001", "ev-bad"])]))
+    assert any(iss.kind == "ungrounded_fact" for iss in result.issues)
+
+
+def test_all_evidence_ids_found_no_ungrounded_issue() -> None:
+    records = [_record("ev-001"), _record("ev-002")]
+    checker = SummaryFidelityChecker(records=records)
+    result = checker.check(_summary(facts=[_fact("fact", ["ev-001", "ev-002"])]))
+    assert not any(iss.kind == "ungrounded_fact" for iss in result.issues)
+
+
+# ---------------------------------------------------------------------------
+# SummaryFidelityChecker - hypothesis-like uncertainty in facts
+# ---------------------------------------------------------------------------
+
+
+def test_uncertainty_language_in_fact_flagged() -> None:
+    records = [_record("ev-001")]
+    checker = SummaryFidelityChecker(records=records)
+    result = checker.check(_summary(facts=[_fact("the test might have passed", ["ev-001"])]))
+    assert any(iss.kind == "hypothesis_as_fact" for iss in result.issues)
+    assert result.status == "partial"
+
+
+def test_maybe_keyword_triggers_hypothesis_as_fact() -> None:
+    records = [_record("ev-001")]
+    checker = SummaryFidelityChecker(records=records)
+    result = checker.check(_summary(facts=[_fact("maybe the fix is ready", ["ev-001"])]))
+    assert any(iss.kind == "hypothesis_as_fact" for iss in result.issues)
+
+
+def test_probably_keyword_triggers_hypothesis_as_fact() -> None:
+    records = [_record("ev-001")]
+    checker = SummaryFidelityChecker(records=records)
+    result = checker.check(_summary(facts=[_fact("the build probably succeeded", ["ev-001"])]))
+    assert any(iss.kind == "hypothesis_as_fact" for iss in result.issues)
+
+
+def test_uncertain_keyword_triggers_hypothesis_as_fact() -> None:
+    records = [_record("ev-001")]
+    checker = SummaryFidelityChecker(records=records)
+    result = checker.check(_summary(facts=[_fact("the outcome is unclear", ["ev-001"])]))
+    assert any(iss.kind == "hypothesis_as_fact" for iss in result.issues)
+
+
+def test_hypotheses_with_uncertainty_allowed() -> None:
+    checker = SummaryFidelityChecker()
+    result = checker.check(_summary(hypotheses=[_hypothesis("the test might have passed")]))
+    assert not any(iss.kind == "hypothesis_as_fact" for iss in result.issues)
+
+
+def test_clear_language_fact_not_flagged() -> None:
+    records = [_record("ev-001")]
+    checker = SummaryFidelityChecker(records=records)
+    result = checker.check(_summary(facts=[_fact("the test passed", ["ev-001"])]))
+    assert not any(iss.kind == "hypothesis_as_fact" for iss in result.issues)
+
+
+def test_hypothesis_as_fact_message_is_prompt_safe() -> None:
+    raw_content = "PRIVATE_TOKEN=secret123"
+    records = [_record("ev-001", content=raw_content)]
+    checker = SummaryFidelityChecker(records=records)
+    result = checker.check(_summary(facts=[_fact("the test might have passed", ["ev-001"])]))
+    issue = next(iss for iss in result.issues if iss.kind == "hypothesis_as_fact")
+    assert "PRIVATE_TOKEN" not in issue.message
+    assert raw_content not in issue.message
+
+
+# ---------------------------------------------------------------------------
+# SummaryFidelityChecker - failed action misclassification
+# ---------------------------------------------------------------------------
+
+
+def test_failed_action_recorded_as_successful_flagged() -> None:
+    checker = SummaryFidelityChecker()
+    summary = _summary(
+        failed_attempts=[_failed_attempt(action="pytest", outcome="exit code 1")],
+        actions_done=[_action_done(command="pytest", outcome="success", status="success")],
+    )
+    result = checker.check(summary)
+    assert any(iss.kind == "failed_action_misclassified" for iss in result.issues)
+    assert result.status == "invalid"
+
+
+def test_action_done_with_failed_status_not_in_failed_attempts_flagged() -> None:
+    checker = SummaryFidelityChecker()
+    summary = _summary(
+        actions_done=[_action_done(command="npm test", outcome="failed", status="failed")],
+        failed_attempts=[],
+    )
+    result = checker.check(summary)
+    assert any(iss.kind == "failed_action_misclassified" for iss in result.issues)
+    assert result.status == "invalid"
+
+
+def test_action_done_with_error_status_flagged() -> None:
+    checker = SummaryFidelityChecker()
+    summary = _summary(
+        actions_done=[_action_done(command="make build", outcome="error", status="error")],
+    )
+    result = checker.check(summary)
+    assert any(iss.kind == "failed_action_misclassified" for iss in result.issues)
+
+
+def test_action_done_with_failed_status_in_failed_attempts_not_flagged() -> None:
+    checker = SummaryFidelityChecker()
+    summary = _summary(
+        failed_attempts=[_failed_attempt(action="pytest", outcome="exit code 1")],
+        actions_done=[_action_done(command="pytest", outcome="failed", status="failed")],
+    )
+    result = checker.check(summary)
+    assert not any(iss.kind == "failed_action_misclassified" for iss in result.issues)
+
+
+def test_successful_action_not_in_failed_attempts_clean() -> None:
+    checker = SummaryFidelityChecker()
+    summary = _summary(
+        actions_done=[_action_done(command="pytest", outcome="success", status="success")],
+        failed_attempts=[],
+    )
+    result = checker.check(summary)
+    assert not any(iss.kind == "failed_action_misclassified" for iss in result.issues)
+
+
+def test_failed_action_misclassified_message_prompt_safe() -> None:
+    checker = SummaryFidelityChecker()
+    summary = _summary(
+        failed_attempts=[_failed_attempt(action="pytest", outcome="exit code 1")],
+        actions_done=[_action_done(command="pytest", outcome="success", status="success")],
+    )
+    result = checker.check(summary)
+    issue = next(iss for iss in result.issues if iss.kind == "failed_action_misclassified")
+    assert len(issue.message) < 300
+
+
+# ---------------------------------------------------------------------------
+# SummaryFidelityChecker - score and status
+# ---------------------------------------------------------------------------
+
+
+def test_score_is_one_for_valid_summary() -> None:
+    records = [_record("ev-001")]
+    checker = SummaryFidelityChecker(records=records)
+    result = checker.check(_summary(facts=[_fact("test passed", ["ev-001"])]))
+    assert result.score is not None
+    assert result.score == 1.0
+
+
+def test_score_bounded_between_zero_and_one() -> None:
+    checker = SummaryFidelityChecker()
+    facts = [_fact(f"fact {i}") for i in range(10)]
+    result = checker.check(_summary(facts=facts))
+    assert result.score is not None
+    assert 0.0 <= result.score <= 1.0
+
+
+def test_score_lower_for_invalid_summary() -> None:
+    checker = SummaryFidelityChecker(records=[_record("ev-001")])
+    result = checker.check(_summary(facts=[_fact("test passed", ["ev-bad"])]))
+    assert result.score is not None
+    assert result.score < 1.0
+
+
+def test_valid_status_when_no_issues() -> None:
+    records = [_record("ev-001")]
+    checker = SummaryFidelityChecker(records=records)
+    result = checker.check(_summary(facts=[_fact("test passed", ["ev-001"])]))
+    assert result.status == "valid"
+
+
+def test_partial_status_for_non_blocking_issue_only() -> None:
+    records = [_record("ev-001")]
+    checker = SummaryFidelityChecker(records=records)
+    result = checker.check(_summary(facts=[_fact("the test might have passed", ["ev-001"])]))
+    assert result.status == "partial"
+
+
+def test_invalid_status_for_blocking_issue() -> None:
+    checker = SummaryFidelityChecker()
+    result = checker.check(_summary(facts=[_fact("no evidence fact")]))
+    assert result.status == "invalid"
+
+
+def test_empty_summary_is_valid_with_score_one() -> None:
+    checker = SummaryFidelityChecker()
+    result = checker.check(_summary())
+    assert result.status == "valid"
+    assert result.score == 1.0
+
+
+def test_checked_at_is_set() -> None:
+    checker = SummaryFidelityChecker()
+    result = checker.check(_summary())
+    assert result.checked_at is not None
+
+
+# ---------------------------------------------------------------------------
+# SummaryFidelityChecker - prompt-safety (no raw evidence in messages)
+# ---------------------------------------------------------------------------
+
+
+def test_result_does_not_leak_raw_evidence_content() -> None:
+    raw_body = "SECRET_PASSWORD=hunter2 full raw evidence body spanning many lines"
+    records = [_record("ev-001", content=raw_body)]
+    checker = SummaryFidelityChecker(records=records)
+    result = checker.check(_summary(facts=[_fact("test passed", ["ev-bad"])]))
+    for issue in result.issues:
+        assert raw_body not in issue.message
+        assert "hunter2" not in issue.message
+
+
+def test_issue_messages_contain_only_ids_and_counts() -> None:
+    records = [_record("ev-001")]
+    checker = SummaryFidelityChecker(records=records)
+    result = checker.check(_summary(facts=[_fact("test passed", ["ev-bad"])]))
+    issue = next(iss for iss in result.issues if iss.kind == "ungrounded_fact")
+    assert "ev-bad" in issue.message
+    assert "not found" in issue.message
+
+
+# ---------------------------------------------------------------------------
+# SummaryFidelityChecker - check_all
+# ---------------------------------------------------------------------------
+
+
+def test_check_all_returns_one_result_per_summary() -> None:
+    checker = SummaryFidelityChecker()
+    summaries = [_summary("s1"), _summary("s2"), _summary("s3")]
+    results = checker.check_all(summaries)
+    assert len(results) == 3
+    assert {r.summary_id for r in results} == {"s1", "s2", "s3"}
+
+
+def test_check_all_empty_list_returns_empty() -> None:
+    checker = SummaryFidelityChecker()
+    assert checker.check_all([]) == []
+
+
+# ---------------------------------------------------------------------------
+# API route - POST /v1/summary/validate
+# ---------------------------------------------------------------------------
+
+
+def test_api_validate_empty_summaries_returns_empty_results(tmp_path: Path) -> None:
+    response = _api_client(tmp_path).post(
+        "/v1/summary/validate",
+        json=_validate_payload(summaries=[]),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["request_id"] == "req-validate-001"
+    assert data["results"] == []
+
+
+def test_api_validate_with_summaries_extra(tmp_path: Path) -> None:
+    response = _api_client(tmp_path).post(
+        "/v1/summary/validate",
+        json=_validate_payload(summaries=[_summary_dict()]),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["results"]) == 1
+    assert data["results"][0]["summary_id"] == "sum-001"
+    assert data["results"][0]["status"] == "valid"
+
+
+def test_api_validate_flags_missing_evidence(tmp_path: Path) -> None:
+    summaries = [_summary_dict(facts=[{"text": "test passed", "evidence_ids": []}])]
+    response = _api_client(tmp_path).post(
+        "/v1/summary/validate",
+        json=_validate_payload(summaries=summaries),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["results"][0]["status"] == "invalid"
+    assert any(iss["kind"] == "missing_evidence_id" for iss in data["results"][0]["issues"])
+
+
+def test_api_validate_with_evidence_records_extra(tmp_path: Path) -> None:
+    evidence_records = [{"evidence_id": "ev-001", "kind": "file_inspection", "summary": "ok"}]
+    summaries = [_summary_dict(facts=[{"text": "test passed", "evidence_ids": ["ev-001"]}])]
+    response = _api_client(tmp_path).post(
+        "/v1/summary/validate",
+        json=_validate_payload(summaries=summaries, evidence_records=evidence_records),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["results"][0]["status"] == "valid"
+
+
+def test_api_validate_flags_ungrounded_fact_via_evidence_records(tmp_path: Path) -> None:
+    evidence_records = [{"evidence_id": "ev-001", "kind": "file_inspection", "summary": "ok"}]
+    summaries = [_summary_dict(facts=[{"text": "test passed", "evidence_ids": ["ev-bad"]}])]
+    response = _api_client(tmp_path).post(
+        "/v1/summary/validate",
+        json=_validate_payload(summaries=summaries, evidence_records=evidence_records),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["results"][0]["status"] == "invalid"
+    assert any(iss["kind"] == "ungrounded_fact" for iss in data["results"][0]["issues"])
+
+
+def test_api_validate_schema_version_in_response(tmp_path: Path) -> None:
+    response = _api_client(tmp_path).post(
+        "/v1/summary/validate",
+        json=_validate_payload(summaries=[]),
+    )
+    assert response.status_code == 200
+    assert response.json()["schema_version"] == SV2
+
+
+def test_api_validate_fail_open_on_checker_error(tmp_path: Path) -> None:
+    with patch(
+        "photon_action_memory.api.server.SummaryFidelityChecker.check_all",
+        side_effect=RuntimeError("checker exploded"),
+    ):
+        response = _api_client(tmp_path).post(
+            "/v1/summary/validate",
+            json=_validate_payload(summaries=[_summary_dict()]),
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["request_id"] == "req-validate-001"
+    assert data["results"] == []
+
+
+def test_api_validate_multiple_summaries(tmp_path: Path) -> None:
+    summaries = [_summary_dict(f"sum-{i:03d}") for i in range(3)]
+    response = _api_client(tmp_path).post(
+        "/v1/summary/validate",
+        json=_validate_payload(summaries=summaries),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["results"]) == 3


### PR DESCRIPTION
## Summary
- Add `SummaryFidelityChecker` for missing evidence, evidence grounding, hypothesis-as-fact, failed-action misclassification, scoring, and prompt-safe validation messages.
- Add `POST /v1/summary/validate` fail-open API wiring.
- Add focused regression tests and dev reports for issue #39.

## Verification
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m mypy photon_action_memory tests`
- `python -m pytest -q`

Closes #39