### PR TITLE
#41 Add context pollution metrics

### DIFF
--- a/dev-reports/issue-41/implementation-summary.md
+++ b/dev-reports/issue-41/implementation-summary.md
@@ -1,0 +1,89 @@
+# Issue #41 - Add Context Pollution Metrics: Implementation Summary
+
+## What Was Built
+
+### `photon_action_memory/eval/pollution.py` (new)
+
+Implements four public symbols exported via `__all__`:
+
+**`POLLUTION_REPORT_SCHEMA`** - Schema version string `"pollution-metrics.v1"`.
+
+**`PollutionRecord`** - Dataclass representing per-turn pollution measurements.
+
+Fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `context_pack_tokens` | int | Estimated tokens in admitted ContextPack items |
+| `summary_tokens_in_prompt` | int | Tokens from admitted action_summary items |
+| `raw_tool_tokens_in_prompt` | int | Tokens from raw tool items in admitted list (always 0 with deny policy) |
+| `tokens_saved_vs_raw` | int | From `token_budget.tokens_saved_vs_raw` |
+| `tokens_saved_vs_full_transcript` | int or None | `full_transcript_tokens - context_pack_tokens` when provided |
+| `stale_summary_incidents` | int | Omitted summaries with stale/contradicted reason |
+| `duplicate_context_incidents` | int | Omitted summaries with duplicate reason |
+| `ungrounded_fact_incidents` | int | Issues with kind `ungrounded_fact` from validation results |
+| `hypothesis_as_fact_incidents` | int | Issues with kind `hypothesis_as_fact` from validation results |
+| `total_summaries_evaluated` | int | Admitted + omitted action_summary items |
+| `total_facts_evaluated` | int | Sum of `len(s.facts)` across input summaries |
+
+**`PollutionReport`** - Pydantic model for the aggregate report. Aggregate-only: no raw logs, prompts, or tool outputs.
+
+Fields: `schema_version`, `total_records`, `total_context_pack_tokens`, `total_summary_tokens_in_prompt`, `total_raw_tool_tokens_in_prompt`, `total_tokens_saved_vs_raw`, `tokens_saved_vs_full_transcript`, `stale_summary_incidents`, `duplicate_context_incidents`, `ungrounded_fact_incidents`, `hypothesis_as_fact_incidents`, `duplicate_context_rate`, `ungrounded_fact_rate`, `hypothesis_as_fact_rate`.
+
+Rates computed as `incidents / total_evaluated`; return `0.0` when denominator is zero.
+
+**`measure_context_pack(pack, *, summaries, validation_results, full_transcript_tokens)`** - Computes one `PollutionRecord` from a `ContextPack`.
+
+- Token measurements come from `pack.items` using `estimate_tokens` from `context.render`.
+- Stale/duplicate incidents come from `pack.omitted[*].reason` substring matching.
+- Fidelity incidents come from `SummaryValidationResult.issues[*].kind`.
+- `total_facts_evaluated` requires the original `summaries` list to be passed.
+
+**`build_pollution_report(records)`** - Aggregates a `Sequence[PollutionRecord]` into a `PollutionReport`.
+
+### `photon_action_memory/eval/__init__.py` (modified)
+
+Added imports and `__all__` entries for:
+- `PollutionRecord`
+- `PollutionReport`
+- `build_pollution_report`
+- `measure_context_pack`
+
+### `tests/test_context_pollution.py` (new)
+
+33 focused tests covering:
+
+- Empty pack yields all-zero record.
+- `raw_tool_tokens_in_prompt == 0` with only raw items (fixture proving default deny policy).
+- `raw_tool_tokens_in_prompt == 0` with mixed summaries and raw items.
+- Admitted summary tokens counted correctly.
+- `tokens_saved_vs_raw` comes from `token_budget`.
+- `tokens_saved_vs_full_transcript` computed and non-negative.
+- `tokens_saved_vs_full_transcript` is None when not provided.
+- Stale and contradicted summaries counted as incidents.
+- Duplicate omissions counted as duplicate_context_incidents.
+- Ungrounded fact incidents from validation results.
+- Hypothesis-as-fact incidents from validation results.
+- Total facts and summaries evaluated correctly.
+- Aggregate report tokens summed.
+- Stale incidents summed across records.
+- Rates computed correctly (duplicate, ungrounded, hypothesis-as-fact).
+- Rates are 0.0 when denominator is zero.
+- `tokens_saved_vs_full_transcript` aggregated, None when all None, partial aggregation.
+- Report shape: required fields present, raw content fields absent.
+- Schema version correct.
+- Total records matches input length.
+- End-to-end: raw deny keeps aggregate `total_raw_tool_tokens_in_prompt == 0`.
+- End-to-end: full pipeline produces a valid report with expected values.
+
+## Design Decisions
+
+**Dataclass for PollutionRecord, Pydantic for PollutionReport.** Follows local style: `raw_policy.py` uses dataclasses for intermediate data; `metrics.py` uses Pydantic for aggregate report output.
+
+**Incident detection via reason substring matching.** Stale/duplicate incidents are detected by substring in `OmittedItem.reason`. This is deterministic and requires no additional context, since the admission controller writes these reasons explicitly.
+
+**`total_facts_evaluated` requires caller to pass summaries.** The ContextPack does not retain the original fact count. Callers pass the same `summaries` list used to build the pack.
+
+**`raw_tool_tokens_in_prompt` is structurally zero.** The deny policy in `build_context_pack` ensures raw items never reach `pack.items`. The measurement still checks `item.kind` against `_RAW_ITEM_KINDS` to guard against future policy changes.
+
+**Rates return 0.0 on zero denominator.** Consistent with the `_rate` helper in `metrics.py`.

--- a/dev-reports/issue-41/verification.md
+++ b/dev-reports/issue-41/verification.md
@@ -1,0 +1,66 @@
+# Issue #41 - Add Context Pollution Metrics: Verification
+
+## Commands Run
+
+```
+python -m ruff format --check .
+python -m ruff check .
+python -m mypy photon_action_memory tests
+python -m pytest -q
+```
+
+## Results
+
+### ruff format
+
+```
+63 files already formatted
+```
+
+Exit code: 0 - PASS
+
+### ruff check
+
+```
+All checks passed!
+```
+
+Exit code: 0 - PASS
+
+### mypy
+
+```
+Success: no issues found in 61 source files
+```
+
+Exit code: 0 - PASS
+
+### pytest
+
+```
+476 passed, 1 skipped in 1.16s
+```
+
+1 skipped test: `tests/integration/test_mlx_smoke.py` - opt-in MLX smoke test, not relevant to this change.
+
+Exit code: 0 - PASS
+
+## New Tests Added
+
+`tests/test_context_pollution.py` - 33 new tests, all passing:
+
+| Group | Count | Coverage |
+|---|---|---|
+| Token measurements | 6 | empty pack, summary tokens, tokens_saved_vs_raw, full transcript savings |
+| Raw-tool-deny fixture | 2 | all raw kinds denied, mixed summaries + raw |
+| Incident detection | 5 | stale, contradicted, duplicate, ungrounded fact, hypothesis-as-fact |
+| Totals | 3 | total facts, total summaries, no summaries passed |
+| Aggregate report | 10 | sums, rates, zero denominators, partial transcript savings, None handling |
+| Report shape | 3 | required fields, excluded fields, schema version, record count |
+| End-to-end | 2 | raw deny keeps total_raw_tool_tokens_in_prompt == 0, full pipeline |
+
+## Regression Checks
+
+All 443 pre-existing tests continue to pass. The only change to an existing file is
+`photon_action_memory/eval/__init__.py` (added 4 new imports and 4 new `__all__` entries).
+No existing behavior was modified.

--- a/photon_action_memory/eval/__init__.py
+++ b/photon_action_memory/eval/__init__.py
@@ -8,6 +8,12 @@ from photon_action_memory.eval.metrics import (
     ShadowEvalRecord,
     build_metrics_report,
 )
+from photon_action_memory.eval.pollution import (
+    PollutionRecord,
+    PollutionReport,
+    build_pollution_report,
+    measure_context_pack,
+)
 from photon_action_memory.eval.runner import (
     load_fixture,
     run_eval,
@@ -21,10 +27,14 @@ __all__ = [
     "EvalSuggestion",
     "EvalWarning",
     "MetricsReport",
+    "PollutionRecord",
+    "PollutionReport",
     "ShadowEvalRecord",
     "SummaryFidelityChecker",
     "build_metrics_report",
+    "build_pollution_report",
     "load_fixture",
+    "measure_context_pack",
     "run_eval",
     "run_fixture",
     "write_metrics_report",

--- a/photon_action_memory/eval/pollution.py
+++ b/photon_action_memory/eval/pollution.py
@@ -1,0 +1,221 @@
+"""Context pollution metrics for v0.2 ContextPack evaluation."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+from pydantic import BaseModel
+
+from photon_action_memory.api.schema_v2 import (
+    ActionSummary,
+    ContextPack,
+    SummaryValidationResult,
+)
+from photon_action_memory.context.render import estimate_tokens
+
+POLLUTION_REPORT_SCHEMA: str = "pollution-metrics.v1"
+
+_RAW_ITEM_KINDS: frozenset[str] = frozenset(
+    {
+        "stdout",
+        "stderr",
+        "grep_output",
+        "build_log",
+        "file_content",
+        "raw_output",
+        "tool_output",
+        "raw_tool_log",
+        "shell_output",
+        "command_output",
+    }
+)
+_STALE_MARKERS: tuple[str, ...] = ("stale", "contradicted")
+_DUPLICATE_MARKER: str = "duplicate"
+
+
+@dataclass
+class PollutionRecord:
+    """Per-turn context pollution measurements.
+
+    Collect one record per context pack build and pass a list of records to
+    ``build_pollution_report`` for an aggregate summary.
+    """
+
+    context_pack_tokens: int = 0
+    summary_tokens_in_prompt: int = 0
+    raw_tool_tokens_in_prompt: int = 0
+    tokens_saved_vs_raw: int = 0
+    tokens_saved_vs_full_transcript: int | None = None
+    stale_summary_incidents: int = 0
+    duplicate_context_incidents: int = 0
+    ungrounded_fact_incidents: int = 0
+    hypothesis_as_fact_incidents: int = 0
+    total_summaries_evaluated: int = 0
+    total_facts_evaluated: int = 0
+
+
+class PollutionReport(BaseModel):
+    """Aggregate-only context pollution report.
+
+    All values are sums or rates across the input records.  No raw logs,
+    prompts, or tool outputs are included.
+    """
+
+    schema_version: Literal["pollution-metrics.v1"] = "pollution-metrics.v1"
+    total_records: int
+    total_context_pack_tokens: int
+    total_summary_tokens_in_prompt: int
+    total_raw_tool_tokens_in_prompt: int
+    total_tokens_saved_vs_raw: int
+    tokens_saved_vs_full_transcript: int | None
+    stale_summary_incidents: int
+    duplicate_context_incidents: int
+    ungrounded_fact_incidents: int
+    hypothesis_as_fact_incidents: int
+    duplicate_context_rate: float
+    ungrounded_fact_rate: float
+    hypothesis_as_fact_rate: float
+
+
+def measure_context_pack(
+    pack: ContextPack,
+    *,
+    summaries: list[ActionSummary] | None = None,
+    validation_results: list[SummaryValidationResult] | None = None,
+    full_transcript_tokens: int | None = None,
+) -> PollutionRecord:
+    """Compute a PollutionRecord from one ContextPack.
+
+    ``summaries`` should be the original list passed to ``build_context_pack``
+    so that ``total_facts_evaluated`` can be counted.  ``validation_results``
+    should come from ``SummaryFidelityChecker.check_all`` for fidelity metrics.
+    ``full_transcript_tokens`` enables savings-vs-transcript reporting.
+    """
+    context_pack_tokens = 0
+    summary_tokens_in_prompt = 0
+    raw_tool_tokens_in_prompt = 0
+
+    for item in pack.items:
+        tokens = estimate_tokens(item.text)
+        context_pack_tokens += tokens
+        if item.kind == "action_summary":
+            summary_tokens_in_prompt += tokens
+        elif item.kind in _RAW_ITEM_KINDS:
+            raw_tool_tokens_in_prompt += tokens
+
+    tokens_saved_vs_raw = pack.token_budget.tokens_saved_vs_raw or 0
+    tokens_saved_vs_full_transcript: int | None = None
+    if full_transcript_tokens is not None:
+        tokens_saved_vs_full_transcript = max(0, full_transcript_tokens - context_pack_tokens)
+
+    stale_summary_incidents = 0
+    duplicate_context_incidents = 0
+    for omitted in pack.omitted:
+        reason_lower = (omitted.reason or "").lower()
+        if any(m in reason_lower for m in _STALE_MARKERS):
+            stale_summary_incidents += 1
+        elif _DUPLICATE_MARKER in reason_lower:
+            duplicate_context_incidents += 1
+
+    ungrounded_fact_incidents = 0
+    hypothesis_as_fact_incidents = 0
+    for result in validation_results or []:
+        for issue in result.issues:
+            if issue.kind == "ungrounded_fact":
+                ungrounded_fact_incidents += 1
+            elif issue.kind == "hypothesis_as_fact":
+                hypothesis_as_fact_incidents += 1
+
+    total_summaries_evaluated = sum(1 for i in pack.items if i.kind == "action_summary") + sum(
+        1 for o in pack.omitted if o.kind == "action_summary"
+    )
+
+    total_facts_evaluated = sum(len(s.facts) for s in (summaries or []))
+
+    return PollutionRecord(
+        context_pack_tokens=context_pack_tokens,
+        summary_tokens_in_prompt=summary_tokens_in_prompt,
+        raw_tool_tokens_in_prompt=raw_tool_tokens_in_prompt,
+        tokens_saved_vs_raw=tokens_saved_vs_raw,
+        tokens_saved_vs_full_transcript=tokens_saved_vs_full_transcript,
+        stale_summary_incidents=stale_summary_incidents,
+        duplicate_context_incidents=duplicate_context_incidents,
+        ungrounded_fact_incidents=ungrounded_fact_incidents,
+        hypothesis_as_fact_incidents=hypothesis_as_fact_incidents,
+        total_summaries_evaluated=total_summaries_evaluated,
+        total_facts_evaluated=total_facts_evaluated,
+    )
+
+
+def build_pollution_report(records: Sequence[PollutionRecord]) -> PollutionReport:
+    """Aggregate a sequence of PollutionRecords into a PollutionReport."""
+    if not records:
+        return PollutionReport(
+            total_records=0,
+            total_context_pack_tokens=0,
+            total_summary_tokens_in_prompt=0,
+            total_raw_tool_tokens_in_prompt=0,
+            total_tokens_saved_vs_raw=0,
+            tokens_saved_vs_full_transcript=None,
+            stale_summary_incidents=0,
+            duplicate_context_incidents=0,
+            ungrounded_fact_incidents=0,
+            hypothesis_as_fact_incidents=0,
+            duplicate_context_rate=0.0,
+            ungrounded_fact_rate=0.0,
+            hypothesis_as_fact_rate=0.0,
+        )
+
+    total_context_pack_tokens = sum(r.context_pack_tokens for r in records)
+    total_summary_tokens_in_prompt = sum(r.summary_tokens_in_prompt for r in records)
+    total_raw_tool_tokens_in_prompt = sum(r.raw_tool_tokens_in_prompt for r in records)
+    total_tokens_saved_vs_raw = sum(r.tokens_saved_vs_raw for r in records)
+
+    transcript_savings = [
+        r.tokens_saved_vs_full_transcript
+        for r in records
+        if r.tokens_saved_vs_full_transcript is not None
+    ]
+    tokens_saved_vs_full_transcript: int | None = (
+        sum(transcript_savings) if transcript_savings else None
+    )
+
+    stale_summary_incidents = sum(r.stale_summary_incidents for r in records)
+    total_duplicate_incidents = sum(r.duplicate_context_incidents for r in records)
+    total_summaries_evaluated = sum(r.total_summaries_evaluated for r in records)
+    total_ungrounded_fact_incidents = sum(r.ungrounded_fact_incidents for r in records)
+    total_hypothesis_as_fact_incidents = sum(r.hypothesis_as_fact_incidents for r in records)
+    total_facts_evaluated = sum(r.total_facts_evaluated for r in records)
+
+    return PollutionReport(
+        total_records=len(records),
+        total_context_pack_tokens=total_context_pack_tokens,
+        total_summary_tokens_in_prompt=total_summary_tokens_in_prompt,
+        total_raw_tool_tokens_in_prompt=total_raw_tool_tokens_in_prompt,
+        total_tokens_saved_vs_raw=total_tokens_saved_vs_raw,
+        tokens_saved_vs_full_transcript=tokens_saved_vs_full_transcript,
+        stale_summary_incidents=stale_summary_incidents,
+        duplicate_context_incidents=total_duplicate_incidents,
+        ungrounded_fact_incidents=total_ungrounded_fact_incidents,
+        hypothesis_as_fact_incidents=total_hypothesis_as_fact_incidents,
+        duplicate_context_rate=_rate(total_duplicate_incidents, total_summaries_evaluated),
+        ungrounded_fact_rate=_rate(total_ungrounded_fact_incidents, total_facts_evaluated),
+        hypothesis_as_fact_rate=_rate(total_hypothesis_as_fact_incidents, total_facts_evaluated),
+    )
+
+
+def _rate(numerator: int, denominator: int) -> float:
+    if denominator == 0:
+        return 0.0
+    return numerator / denominator
+
+
+__all__ = [
+    "POLLUTION_REPORT_SCHEMA",
+    "PollutionRecord",
+    "PollutionReport",
+    "build_pollution_report",
+    "measure_context_pack",
+]

--- a/tests/test_context_pollution.py
+++ b/tests/test_context_pollution.py
@@ -1,0 +1,434 @@
+"""Tests for context pollution metrics (issue #41)."""
+
+from __future__ import annotations
+
+import pytest
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    ActionSummary,
+    ContextPackBudget,
+    Fact,
+    Hypothesis,
+    SummaryValidationIssue,
+    SummaryValidationResult,
+    TokenCost,
+    Validity,
+)
+from photon_action_memory.context.pack import build_context_pack
+from photon_action_memory.context.raw_policy import RawEvidenceItem
+from photon_action_memory.eval.pollution import (
+    PollutionRecord,
+    build_pollution_report,
+    measure_context_pack,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fact(text: str, evidence_id: str = "ev-1") -> Fact:
+    return Fact(text=text, evidence_ids=[evidence_id], confidence=0.9)
+
+
+def _hypothesis(text: str) -> Hypothesis:
+    return Hypothesis(text=text, evidence_ids=["ev-1"], confidence=0.5)
+
+
+def _summary(
+    summary_id: str,
+    facts: list[Fact] | None = None,
+    hypotheses: list[Hypothesis] | None = None,
+    validity_status: str = "valid",
+    token_cost: TokenCost | None = None,
+) -> ActionSummary:
+    return ActionSummary(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        summary_id=summary_id,
+        facts=facts or [],
+        hypotheses=hypotheses or [],
+        validity=Validity(status=validity_status),
+        token_cost=token_cost,
+    )
+
+
+def _raw(item_id: str, kind: str = "stdout", content: str = "raw output") -> RawEvidenceItem:
+    return RawEvidenceItem(item_id=item_id, kind=kind, content=content)
+
+
+def _pack_with(
+    summaries: list[ActionSummary] | None = None,
+    raw_items: list[RawEvidenceItem] | None = None,
+    max_tokens: int = 800,
+) -> tuple:  # type: ignore[type-arg]
+    return build_context_pack(
+        request_id="req-test",
+        session_id=None,
+        repo_id=None,
+        summaries=summaries or [],
+        budget=ContextPackBudget(max_memory_tokens=max_tokens),
+        raw_items=raw_items,
+    )
+
+
+def _validation_issue(kind: str, message: str = "issue") -> SummaryValidationIssue:
+    return SummaryValidationIssue(kind=kind, message=message)
+
+
+def _validation_result(
+    summary_id: str,
+    issues: list[SummaryValidationIssue],
+) -> SummaryValidationResult:
+    return SummaryValidationResult(
+        summary_id=summary_id,
+        status="invalid" if issues else "valid",
+        score=0.5,
+        issues=issues,
+    )
+
+
+# ---------------------------------------------------------------------------
+# measure_context_pack - token measurements
+# ---------------------------------------------------------------------------
+
+
+def test_empty_pack_yields_zero_tokens() -> None:
+    pack, _ = _pack_with()
+    record = measure_context_pack(pack)
+    assert record.context_pack_tokens == 0
+    assert record.summary_tokens_in_prompt == 0
+    assert record.raw_tool_tokens_in_prompt == 0
+    assert record.tokens_saved_vs_raw == 0
+    assert record.tokens_saved_vs_full_transcript is None
+
+
+def test_admitted_summary_tokens_counted() -> None:
+    summaries = [_summary("s-1", facts=[_fact("the thing is done")])]
+    pack, _ = _pack_with(summaries=summaries)
+    record = measure_context_pack(pack)
+    assert record.summary_tokens_in_prompt > 0
+    assert record.context_pack_tokens == record.summary_tokens_in_prompt
+
+
+def test_tokens_saved_vs_raw_from_budget() -> None:
+    tc = TokenCost(estimated_summary_tokens=10, estimated_raw_tokens=100, tokens_saved_vs_raw=90)
+    s = _summary("s-tc", facts=[_fact("some fact")], token_cost=tc)
+    pack, _ = _pack_with(summaries=[s])
+    record = measure_context_pack(pack)
+    assert record.tokens_saved_vs_raw >= 0
+
+
+def test_tokens_saved_vs_full_transcript_computed() -> None:
+    summaries = [_summary("s-1", facts=[_fact("fact")])]
+    pack, _ = _pack_with(summaries=summaries)
+    record = measure_context_pack(pack, full_transcript_tokens=1000)
+    assert record.tokens_saved_vs_full_transcript == max(0, 1000 - record.context_pack_tokens)
+
+
+def test_tokens_saved_vs_full_transcript_none_when_not_provided() -> None:
+    pack, _ = _pack_with()
+    record = measure_context_pack(pack)
+    assert record.tokens_saved_vs_full_transcript is None
+
+
+def test_tokens_saved_vs_full_transcript_non_negative() -> None:
+    summaries = [_summary("s-1", facts=[_fact("f")])]
+    pack, _ = _pack_with(summaries=summaries)
+    record = measure_context_pack(pack, full_transcript_tokens=0)
+    assert record.tokens_saved_vs_full_transcript == 0
+
+
+# ---------------------------------------------------------------------------
+# measure_context_pack - raw-tool-deny policy fixture
+# ---------------------------------------------------------------------------
+
+
+def test_raw_tool_deny_policy_keeps_raw_tokens_at_zero() -> None:
+    """Fixture: default raw-tool-deny policy must keep raw_tool_tokens_in_prompt == 0."""
+    raw_items = [
+        _raw(f"r-{i}", kind, "x" * 2000)
+        for i, kind in enumerate(["stdout", "stderr", "grep_output", "build_log", "file_content"])
+    ]
+    pack, _ = _pack_with(raw_items=raw_items)
+    record = measure_context_pack(pack)
+    assert record.raw_tool_tokens_in_prompt == 0
+
+
+def test_raw_tokens_zero_with_mixed_summaries_and_raw() -> None:
+    """Raw items must not contribute tokens even when summaries are also present."""
+    summaries = [_summary("s-1", facts=[_fact("server lives in api/")])]
+    raw_items = [_raw("r-1", "stdout", "cargo build output " * 50)]
+    pack, _ = _pack_with(summaries=summaries, raw_items=raw_items)
+    record = measure_context_pack(pack)
+    assert record.raw_tool_tokens_in_prompt == 0
+    assert record.summary_tokens_in_prompt > 0
+
+
+# ---------------------------------------------------------------------------
+# measure_context_pack - incident detection
+# ---------------------------------------------------------------------------
+
+
+def test_stale_summary_incidents_counted() -> None:
+    stale = _summary("s-stale", facts=[_fact("old fact")], validity_status="stale")
+    valid = _summary("s-valid", facts=[_fact("current fact")])
+    pack, _ = _pack_with(summaries=[stale, valid])
+    record = measure_context_pack(pack)
+    assert record.stale_summary_incidents == 1
+
+
+def test_contradicted_summary_counted_as_stale_incident() -> None:
+    contradicted = _summary("s-contra", facts=[_fact("wrong")], validity_status="contradicted")
+    pack, _ = _pack_with(summaries=[contradicted])
+    record = measure_context_pack(pack)
+    assert record.stale_summary_incidents == 1
+
+
+def test_duplicate_context_incidents_counted() -> None:
+    facts = [_fact("same fact text")]
+    s1 = _summary("s-1", facts=facts)
+    s2 = _summary("s-2", facts=facts)
+    pack, _ = _pack_with(summaries=[s1, s2])
+    record = measure_context_pack(pack)
+    assert record.duplicate_context_incidents == 1
+
+
+def test_ungrounded_fact_incidents_from_validation_results() -> None:
+    vr = _validation_result(
+        "s-1",
+        [
+            _validation_issue("ungrounded_fact", "no evidence"),
+            _validation_issue("ungrounded_fact", "another missing"),
+        ],
+    )
+    pack, _ = _pack_with()
+    record = measure_context_pack(pack, validation_results=[vr])
+    assert record.ungrounded_fact_incidents == 2
+
+
+def test_hypothesis_as_fact_incidents_from_validation_results() -> None:
+    vr = _validation_result(
+        "s-1",
+        [_validation_issue("hypothesis_as_fact", "uncertainty language detected")],
+    )
+    pack, _ = _pack_with()
+    record = measure_context_pack(pack, validation_results=[vr])
+    assert record.hypothesis_as_fact_incidents == 1
+
+
+def test_no_incidents_when_no_validation_results() -> None:
+    pack, _ = _pack_with()
+    record = measure_context_pack(pack)
+    assert record.ungrounded_fact_incidents == 0
+    assert record.hypothesis_as_fact_incidents == 0
+
+
+# ---------------------------------------------------------------------------
+# measure_context_pack - totals
+# ---------------------------------------------------------------------------
+
+
+def test_total_facts_evaluated_from_summaries() -> None:
+    summaries = [
+        _summary("s-1", facts=[_fact("f1"), _fact("f2")]),
+        _summary("s-2", facts=[_fact("f3")]),
+    ]
+    pack, _ = _pack_with(summaries=summaries)
+    record = measure_context_pack(pack, summaries=summaries)
+    assert record.total_facts_evaluated == 3
+
+
+def test_total_summaries_evaluated_includes_omitted() -> None:
+    stale = _summary("s-stale", facts=[_fact("old")], validity_status="stale")
+    valid = _summary("s-valid", facts=[_fact("new")])
+    pack, _ = _pack_with(summaries=[stale, valid])
+    record = measure_context_pack(pack)
+    assert record.total_summaries_evaluated == 2
+
+
+def test_total_facts_zero_when_no_summaries_passed() -> None:
+    pack, _ = _pack_with()
+    record = measure_context_pack(pack)
+    assert record.total_facts_evaluated == 0
+
+
+# ---------------------------------------------------------------------------
+# build_pollution_report - aggregation
+# ---------------------------------------------------------------------------
+
+
+def test_empty_records_yields_zero_report() -> None:
+    report = build_pollution_report([])
+    assert report.total_records == 0
+    assert report.total_context_pack_tokens == 0
+    assert report.total_raw_tool_tokens_in_prompt == 0
+    assert report.stale_summary_incidents == 0
+    assert report.duplicate_context_incidents == 0
+    assert report.ungrounded_fact_incidents == 0
+    assert report.hypothesis_as_fact_incidents == 0
+    assert report.duplicate_context_rate == 0.0
+    assert report.ungrounded_fact_rate == 0.0
+    assert report.hypothesis_as_fact_rate == 0.0
+
+
+def test_aggregate_tokens_summed() -> None:
+    r1 = PollutionRecord(context_pack_tokens=100, summary_tokens_in_prompt=100)
+    r2 = PollutionRecord(context_pack_tokens=50, summary_tokens_in_prompt=50)
+    report = build_pollution_report([r1, r2])
+    assert report.total_context_pack_tokens == 150
+    assert report.total_summary_tokens_in_prompt == 150
+
+
+def test_stale_incidents_summed() -> None:
+    r1 = PollutionRecord(stale_summary_incidents=2, total_summaries_evaluated=5)
+    r2 = PollutionRecord(stale_summary_incidents=1, total_summaries_evaluated=3)
+    report = build_pollution_report([r1, r2])
+    assert report.stale_summary_incidents == 3
+
+
+def test_duplicate_context_rate_computed() -> None:
+    r1 = PollutionRecord(duplicate_context_incidents=1, total_summaries_evaluated=4)
+    r2 = PollutionRecord(duplicate_context_incidents=1, total_summaries_evaluated=4)
+    report = build_pollution_report([r1, r2])
+    assert report.duplicate_context_incidents == 2
+    assert report.duplicate_context_rate == pytest.approx(2 / 8)
+
+
+def test_ungrounded_fact_rate_computed() -> None:
+    r1 = PollutionRecord(ungrounded_fact_incidents=2, total_facts_evaluated=10)
+    r2 = PollutionRecord(ungrounded_fact_incidents=1, total_facts_evaluated=5)
+    report = build_pollution_report([r1, r2])
+    assert report.ungrounded_fact_incidents == 3
+    assert report.ungrounded_fact_rate == pytest.approx(3 / 15)
+
+
+def test_hypothesis_as_fact_rate_computed() -> None:
+    r1 = PollutionRecord(hypothesis_as_fact_incidents=1, total_facts_evaluated=5)
+    report = build_pollution_report([r1])
+    assert report.hypothesis_as_fact_incidents == 1
+    assert report.hypothesis_as_fact_rate == pytest.approx(1 / 5)
+
+
+def test_rates_zero_when_no_facts_evaluated() -> None:
+    r1 = PollutionRecord(ungrounded_fact_incidents=0, total_facts_evaluated=0)
+    report = build_pollution_report([r1])
+    assert report.ungrounded_fact_rate == 0.0
+    assert report.hypothesis_as_fact_rate == 0.0
+
+
+def test_rates_zero_when_no_summaries_evaluated() -> None:
+    r1 = PollutionRecord(duplicate_context_incidents=0, total_summaries_evaluated=0)
+    report = build_pollution_report([r1])
+    assert report.duplicate_context_rate == 0.0
+
+
+def test_tokens_saved_vs_full_transcript_aggregated() -> None:
+    r1 = PollutionRecord(tokens_saved_vs_full_transcript=100)
+    r2 = PollutionRecord(tokens_saved_vs_full_transcript=200)
+    report = build_pollution_report([r1, r2])
+    assert report.tokens_saved_vs_full_transcript == 300
+
+
+def test_tokens_saved_vs_full_transcript_none_when_all_none() -> None:
+    r1 = PollutionRecord()
+    r2 = PollutionRecord()
+    report = build_pollution_report([r1, r2])
+    assert report.tokens_saved_vs_full_transcript is None
+
+
+def test_tokens_saved_vs_full_transcript_partial_some_none() -> None:
+    r1 = PollutionRecord(tokens_saved_vs_full_transcript=50)
+    r2 = PollutionRecord(tokens_saved_vs_full_transcript=None)
+    report = build_pollution_report([r1, r2])
+    assert report.tokens_saved_vs_full_transcript == 50
+
+
+# ---------------------------------------------------------------------------
+# build_pollution_report - report shape and safety
+# ---------------------------------------------------------------------------
+
+
+def test_report_is_aggregate_only() -> None:
+    """Reports must be aggregate-only with no raw logs, prompts, or tool outputs."""
+    r1 = PollutionRecord(context_pack_tokens=100, stale_summary_incidents=1)
+    report = build_pollution_report([r1])
+    dump = report.model_dump(mode="json")
+    assert "total_records" in dump
+    assert "stale_summary_incidents" in dump
+    assert "duplicate_context_incidents" in dump
+    assert "ungrounded_fact_incidents" in dump
+    assert "hypothesis_as_fact_incidents" in dump
+    assert "duplicate_context_rate" in dump
+    assert "ungrounded_fact_rate" in dump
+    assert "hypothesis_as_fact_rate" in dump
+    assert "items" not in dump
+    assert "omitted" not in dump
+    assert "events" not in dump
+    assert "tool_output" not in dump
+
+
+def test_schema_version_is_pollution_metrics_v1() -> None:
+    report = build_pollution_report([])
+    assert report.schema_version == "pollution-metrics.v1"
+
+
+def test_total_records_matches_input_length() -> None:
+    records = [PollutionRecord() for _ in range(5)]
+    report = build_pollution_report(records)
+    assert report.total_records == 5
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: raw deny policy through measure_context_pack -> build_pollution_report
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_raw_deny_keeps_raw_tokens_at_zero_in_aggregate() -> None:
+    """Default deny policy must keep total_raw_tool_tokens_in_prompt at 0."""
+    all_records: list[PollutionRecord] = []
+    for i in range(3):
+        raw_items = [_raw(f"r-{i}-{j}", "stdout", "x" * 500) for j in range(3)]
+        pack, _ = _pack_with(raw_items=raw_items)
+        all_records.append(measure_context_pack(pack))
+
+    report = build_pollution_report(all_records)
+    assert report.total_raw_tool_tokens_in_prompt == 0
+    assert report.total_records == 3
+
+
+def test_e2e_full_pipeline_produces_valid_report() -> None:
+    """Full pipeline: build pack, measure, aggregate into report."""
+    summaries_a = [
+        _summary("s-1", facts=[_fact("fact one"), _fact("fact two")]),
+        _summary("s-2", facts=[_fact("fact three")], validity_status="stale"),
+    ]
+    summaries_b = [
+        _summary("s-3", facts=[_fact("x")]),
+        _summary("s-4", facts=[_fact("x")]),
+    ]
+
+    pack_a, _ = _pack_with(summaries=summaries_a)
+    pack_b, _ = _pack_with(summaries=summaries_b)
+
+    vr = _validation_result(
+        "s-1",
+        [
+            _validation_issue("ungrounded_fact", "no evidence"),
+            _validation_issue("hypothesis_as_fact", "uncertainty"),
+        ],
+    )
+
+    rec_a = measure_context_pack(
+        pack_a, summaries=summaries_a, validation_results=[vr], full_transcript_tokens=500
+    )
+    rec_b = measure_context_pack(pack_b, summaries=summaries_b, full_transcript_tokens=500)
+
+    report = build_pollution_report([rec_a, rec_b])
+
+    assert report.total_records == 2
+    assert report.stale_summary_incidents == 1
+    assert report.ungrounded_fact_rate > 0.0
+    assert report.hypothesis_as_fact_rate > 0.0
+    assert report.total_raw_tool_tokens_in_prompt == 0
+    assert report.tokens_saved_vs_full_transcript is not None


### PR DESCRIPTION
## Summary
- Add aggregate-only context pollution metrics in `photon_action_memory/eval/pollution.py`.
- Measure context pack, summary, raw tool, raw savings, and full transcript savings tokens.
- Aggregate stale, duplicate, ungrounded fact, and hypothesis-as-fact incidents and rates.
- Add tests and dev reports for issue #41.

## Verification
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m mypy photon_action_memory tests`
- `python -m pytest -q`

Closes #41