### PR TITLE
#42 Update eval runner for Context Firewall comparisons

### DIFF
--- a/dev-reports/issue-42/implementation-summary.md
+++ b/dev-reports/issue-42/implementation-summary.md
@@ -1,0 +1,128 @@
+# Issue #42 - Update Eval Runner for Context Firewall Comparisons: Implementation Summary
+
+## What Was Built
+
+### `photon_action_memory/eval/comparison.py` (new)
+
+Implements comparison-specific APIs exported via `__all__`:
+
+**`COMPARISON_REPORT_SCHEMA`** - Schema version string `"comparison-metrics.v1"`.
+
+**`EVAL_CONDITIONS`** - Frozenset of the six named conditions:
+`no_memory`, `full_transcript`, `static_summary_memory`, `retrieval_memory`,
+`photon_summary_only`, `photon_summary_evidence`.
+
+**`ComparisonRecord`** - Pydantic model for one normalized comparison turn record.
+
+Fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `condition` | str | Named eval condition; defaults to `no_memory` |
+| `outcome` | str or None | Turn outcome for task_success_rate computation |
+| `repeated_exploration_occurred` | bool | True when the agent re-explored already-visited paths |
+| `failed_action_retry` | bool | True when the agent retried a previously failed action |
+| `duplicate_context_incidents` | int | Per-turn duplicate context count from pollution.py |
+| `ungrounded_fact_incidents` | int | Per-turn ungrounded fact count from pollution.py |
+| `hypothesis_as_fact_incidents` | int | Per-turn hypothesis-as-fact count from pollution.py |
+| `total_summaries_evaluated` | int | Per-turn summary evaluation count |
+| `total_facts_evaluated` | int | Per-turn fact evaluation count |
+
+Extra fields are silently ignored (`extra="ignore"`) so raw prompt/log/tool-output
+fields in fixture JSON are never stored or reported.
+
+**`ConditionSummary`** - Aggregate metrics for one named condition.
+
+Fields: `condition`, `total_records`, `task_success_rate`,
+`repeated_exploration_rate`, `failed_action_retry_rate`,
+`duplicate_context_rate`, `ungrounded_fact_rate`, `hypothesis_as_fact_rate`.
+
+**`ComparisonReport`** - Aggregate-only report across all conditions.
+
+Fields: `schema_version`, `total_records`, `conditions` (sorted alphabetically).
+
+**`build_comparison_report(records)`** - Aggregates a `Sequence[RawComparisonRecord]`
+into a `ComparisonReport`.  Records are grouped by `condition`; each group produces
+one `ConditionSummary`.  Rates return `0.0` on zero denominator.
+
+Success outcomes: `"accepted"`, `"success"`, `"completed"`.
+
+### `photon_action_memory/eval/runner.py` (modified)
+
+Three new functions added alongside the existing runner, preserving all existing behavior:
+
+**`run_comparison(records, *, output_path)`** - Runs comparison eval over
+condition-labeled records and optionally writes aggregate JSON.
+
+**`run_comparison_fixture(fixture_path, *, output_path)`** - Loads a JSON fixture
+(list or `{records: [...]}` object) via the existing `load_fixture` and runs
+comparison eval.
+
+**`write_comparison_report(report, output_path)`** - Writes the aggregate
+`ComparisonReport` as JSON; creates parent directories automatically.
+
+### `photon_action_memory/eval/__init__.py` (modified)
+
+Added imports and `__all__` entries for:
+- `COMPARISON_REPORT_SCHEMA`
+- `EVAL_CONDITIONS`
+- `ComparisonRecord`
+- `ComparisonReport`
+- `ConditionSummary`
+- `build_comparison_report`
+- `run_comparison`
+- `run_comparison_fixture`
+- `write_comparison_report`
+
+### `tests/test_eval_runner_comparison.py` (new)
+
+33 focused tests covering:
+
+- `EVAL_CONDITIONS` contains all six named conditions.
+- Empty input produces zero report.
+- `task_success_rate` for `accepted`, `success`, `completed`, and non-success outcomes.
+- `repeated_exploration_rate` computed correctly.
+- `failed_action_retry_rate` computed correctly.
+- Pollution rates (`duplicate_context_rate`, `ungrounded_fact_rate`,
+  `hypothesis_as_fact_rate`) computed per condition from incident fields.
+- Zero-denominator rates return `0.0`.
+- Multiple conditions grouped and sorted alphabetically.
+- All six named conditions can appear in one report.
+- Dict (fixture-style) records parsed correctly; unknown fields ignored.
+- Report dump contains no raw log, prompt, tool_output, or per-record fields.
+- `schema_version` is `"comparison-metrics.v1"`.
+- `run_comparison` returns a `ComparisonReport`.
+- `run_comparison` writes aggregate-only JSON; no raw fields in output file.
+- `run_comparison` with no `output_path` does not write any file.
+- `run_comparison_fixture` loads JSON list fixture.
+- `run_comparison_fixture` loads `{records: [...]}` fixture.
+- `run_comparison_fixture` writes output when path provided.
+- `ComparisonRecord` defaults are safe.
+- Negative incident counts are rejected by Pydantic validation.
+
+## Design Decisions
+
+**New module `comparison.py` rather than extending `metrics.py`.** The comparison
+semantics (condition grouping, retry tracking, pollution integration) are orthogonal
+to shadow-mode next-action hit evaluation.  A separate module keeps both surfaces
+focused and independently testable.
+
+**Pollution metrics integrated via per-record incident counts, not by importing
+`PollutionRecord`.** The `ComparisonRecord` carries the five pollution count fields
+that `PollutionRecord` exposes.  Callers measure one `PollutionRecord` per turn and
+copy the relevant fields into `ComparisonRecord`.  This avoids duplicating
+`pollution.py` logic while still surfacing pollution rates per condition.
+
+**`extra="ignore"` on `ComparisonRecord`.** Consistent with `ShadowEvalRecord` and
+`EvalModel`.  Raw log, prompt, and tool-output fields in fixture JSON are silently
+dropped so they never reach the aggregate report.
+
+**`RawComparisonRecord = ComparisonRecord | Mapping[str, Any]`.** Mirrors the
+`RawRecord` alias in `metrics.py`, allowing `run_comparison` to accept both typed
+objects and raw dict records from `load_fixture`.
+
+**Conditions sorted alphabetically in output.** Deterministic ordering makes diffs
+stable across fixture changes.
+
+**Success outcomes: `accepted`, `success`, `completed`.** Derived from the outcome
+vocabulary used in existing fixtures and `MetricsReport.outcome_counts`.

--- a/dev-reports/issue-42/verification.md
+++ b/dev-reports/issue-42/verification.md
@@ -1,0 +1,75 @@
+# Issue #42 - Update Eval Runner for Context Firewall Comparisons: Verification
+
+## Commands Run
+
+```
+python -m ruff format --check .
+python -m ruff check .
+python -m mypy photon_action_memory tests
+python -m pytest -q
+```
+
+## Results
+
+### ruff format
+
+```
+65 files already formatted
+```
+
+Exit code: 0 - PASS
+
+### ruff check
+
+```
+All checks passed!
+```
+
+Exit code: 0 - PASS
+
+### mypy
+
+```
+Success: no issues found in 63 source files
+```
+
+Exit code: 0 - PASS
+
+### pytest
+
+```
+509 passed, 1 skipped in 1.21s
+```
+
+1 skipped test: `tests/integration/test_mlx_smoke.py` - opt-in MLX smoke test, not
+relevant to this change.
+
+Exit code: 0 - PASS
+
+## New Tests Added
+
+`tests/test_eval_runner_comparison.py` - 33 new tests, all passing:
+
+| Group | Count | Coverage |
+|---|---|---|
+| EVAL_CONDITIONS constant | 1 | six named conditions present |
+| Empty and single record | 4 | zero report, success, non-success, no outcome |
+| task_success_rate | 3 | accepted, success, completed outcomes |
+| repeated_exploration_rate | 2 | mixed true/false, all false |
+| failed_action_retry_rate | 2 | partial, all retried |
+| Pollution rates | 5 | duplicate, ungrounded, hypothesis per condition; zero denominators |
+| Multi-condition grouping | 3 | grouping, alphabetical sort, all six conditions |
+| Dict record input | 2 | extra fields ignored, no raw fields in dump |
+| Report shape | 3 | schema version, aggregate-only shape, condition summary fields |
+| run_comparison | 3 | returns report, writes aggregate JSON, no write with no output_path |
+| run_comparison_fixture | 3 | JSON list fixture, records-object fixture, writes output |
+| ComparisonRecord fields | 2 | defaults, negative incidents rejected |
+
+## Regression Checks
+
+All 476 pre-existing tests continue to pass.  Changes to existing files are
+limited to:
+- `photon_action_memory/eval/runner.py`: three new functions and updated `__all__`
+- `photon_action_memory/eval/__init__.py`: nine new imports and `__all__` entries
+
+No existing function signatures, logic, or test assertions were modified.

--- a/photon_action_memory/eval/__init__.py
+++ b/photon_action_memory/eval/__init__.py
@@ -1,5 +1,13 @@
 """Offline and shadow evaluation utilities."""
 
+from photon_action_memory.eval.comparison import (
+    COMPARISON_REPORT_SCHEMA,
+    EVAL_CONDITIONS,
+    ComparisonRecord,
+    ComparisonReport,
+    ConditionSummary,
+    build_comparison_report,
+)
 from photon_action_memory.eval.metrics import (
     EvalAction,
     EvalSuggestion,
@@ -16,26 +24,38 @@ from photon_action_memory.eval.pollution import (
 )
 from photon_action_memory.eval.runner import (
     load_fixture,
+    run_comparison,
+    run_comparison_fixture,
     run_eval,
     run_fixture,
+    write_comparison_report,
     write_metrics_report,
 )
 from photon_action_memory.eval.summary_fidelity import SummaryFidelityChecker
 
 __all__ = [
+    "COMPARISON_REPORT_SCHEMA",
+    "EVAL_CONDITIONS",
     "EvalAction",
     "EvalSuggestion",
     "EvalWarning",
+    "ComparisonRecord",
+    "ComparisonReport",
+    "ConditionSummary",
     "MetricsReport",
     "PollutionRecord",
     "PollutionReport",
     "ShadowEvalRecord",
     "SummaryFidelityChecker",
+    "build_comparison_report",
     "build_metrics_report",
     "build_pollution_report",
     "load_fixture",
     "measure_context_pack",
+    "run_comparison",
+    "run_comparison_fixture",
     "run_eval",
     "run_fixture",
+    "write_comparison_report",
     "write_metrics_report",
 ]

--- a/photon_action_memory/eval/comparison.py
+++ b/photon_action_memory/eval/comparison.py
@@ -1,0 +1,133 @@
+"""Context Firewall condition comparison metrics."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+COMPARISON_REPORT_SCHEMA: str = "comparison-metrics.v1"
+
+# Named evaluation conditions for Context Firewall comparisons (issue #42).
+EVAL_CONDITIONS: frozenset[str] = frozenset(
+    {
+        "no_memory",
+        "full_transcript",
+        "static_summary_memory",
+        "retrieval_memory",
+        "photon_summary_only",
+        "photon_summary_evidence",
+    }
+)
+
+_SUCCESS_OUTCOMES: frozenset[str] = frozenset({"success", "accepted", "completed"})
+
+
+class ComparisonRecord(BaseModel):
+    """Normalized record for Context Firewall condition comparison.
+
+    Carries the condition label, retry flag, and optional per-turn pollution
+    counts sourced from PollutionRecord measurements (see pollution.py).
+    Raw logs, prompts, and tool outputs are intentionally excluded.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    condition: str = "no_memory"
+    outcome: str | None = None
+    repeated_exploration_occurred: bool = False
+    failed_action_retry: bool = False
+    # Per-turn pollution counts; aggregate from pollution.py PollutionRecord
+    duplicate_context_incidents: int = Field(default=0, ge=0)
+    ungrounded_fact_incidents: int = Field(default=0, ge=0)
+    hypothesis_as_fact_incidents: int = Field(default=0, ge=0)
+    total_summaries_evaluated: int = Field(default=0, ge=0)
+    total_facts_evaluated: int = Field(default=0, ge=0)
+
+
+class ConditionSummary(BaseModel):
+    """Aggregate metrics for one named eval condition."""
+
+    condition: str
+    total_records: int
+    task_success_rate: float
+    repeated_exploration_rate: float
+    failed_action_retry_rate: float
+    duplicate_context_rate: float
+    ungrounded_fact_rate: float
+    hypothesis_as_fact_rate: float
+
+
+class ComparisonReport(BaseModel):
+    """Aggregate-only comparison report across named eval conditions.
+
+    All values are counts or rates.  No raw logs, prompts, or tool outputs
+    are included.
+    """
+
+    schema_version: Literal["comparison-metrics.v1"] = "comparison-metrics.v1"
+    total_records: int
+    conditions: list[ConditionSummary]
+
+
+RawComparisonRecord = ComparisonRecord | Mapping[str, Any]
+
+
+def build_comparison_report(
+    records: Sequence[RawComparisonRecord],
+) -> ComparisonReport:
+    """Build an aggregate comparison report grouped by condition."""
+    parsed = [_coerce(r) for r in records]
+
+    groups: dict[str, list[ComparisonRecord]] = {}
+    for record in parsed:
+        groups.setdefault(record.condition, []).append(record)
+
+    conditions = [_summarise_condition(cond, group) for cond, group in sorted(groups.items())]
+    return ComparisonReport(total_records=len(parsed), conditions=conditions)
+
+
+def _coerce(record: RawComparisonRecord) -> ComparisonRecord:
+    if isinstance(record, ComparisonRecord):
+        return record
+    return ComparisonRecord.model_validate(record)
+
+
+def _summarise_condition(condition: str, records: list[ComparisonRecord]) -> ConditionSummary:
+    n = len(records)
+    successes = sum(1 for r in records if r.outcome in _SUCCESS_OUTCOMES)
+    repeated = sum(1 for r in records if r.repeated_exploration_occurred)
+    retries = sum(1 for r in records if r.failed_action_retry)
+    dup_incidents = sum(r.duplicate_context_incidents for r in records)
+    ungrounded = sum(r.ungrounded_fact_incidents for r in records)
+    hypothesis = sum(r.hypothesis_as_fact_incidents for r in records)
+    total_summaries = sum(r.total_summaries_evaluated for r in records)
+    total_facts = sum(r.total_facts_evaluated for r in records)
+    return ConditionSummary(
+        condition=condition,
+        total_records=n,
+        task_success_rate=_rate(successes, n),
+        repeated_exploration_rate=_rate(repeated, n),
+        failed_action_retry_rate=_rate(retries, n),
+        duplicate_context_rate=_rate(dup_incidents, total_summaries),
+        ungrounded_fact_rate=_rate(ungrounded, total_facts),
+        hypothesis_as_fact_rate=_rate(hypothesis, total_facts),
+    )
+
+
+def _rate(numerator: int, denominator: int) -> float:
+    if denominator == 0:
+        return 0.0
+    return numerator / denominator
+
+
+__all__ = [
+    "COMPARISON_REPORT_SCHEMA",
+    "EVAL_CONDITIONS",
+    "ComparisonRecord",
+    "ComparisonReport",
+    "ConditionSummary",
+    "RawComparisonRecord",
+    "build_comparison_report",
+]

--- a/photon_action_memory/eval/runner.py
+++ b/photon_action_memory/eval/runner.py
@@ -7,6 +7,11 @@ from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any
 
+from photon_action_memory.eval.comparison import (
+    ComparisonReport,
+    RawComparisonRecord,
+    build_comparison_report,
+)
 from photon_action_memory.eval.metrics import MetricsReport, RawRecord, build_metrics_report
 
 
@@ -31,6 +36,27 @@ def run_fixture(
 ) -> MetricsReport:
     """Load a JSON fixture and run aggregate eval metrics."""
     return run_eval(load_fixture(fixture_path), top_k=top_k, output_path=output_path)
+
+
+def run_comparison(
+    records: Iterable[RawComparisonRecord],
+    *,
+    output_path: str | Path | None = None,
+) -> ComparisonReport:
+    """Run comparison eval over condition-labeled records and optionally write aggregate JSON."""
+    report = build_comparison_report(list(records))
+    if output_path is not None:
+        write_comparison_report(report, output_path)
+    return report
+
+
+def run_comparison_fixture(
+    fixture_path: str | Path,
+    *,
+    output_path: str | Path | None = None,
+) -> ComparisonReport:
+    """Load a JSON fixture and run aggregate comparison metrics."""
+    return run_comparison(load_fixture(fixture_path), output_path=output_path)
 
 
 def load_fixture(fixture_path: str | Path) -> list[Mapping[str, Any]]:
@@ -58,9 +84,19 @@ def write_metrics_report(report: MetricsReport, output_path: str | Path) -> None
     path.write_text(report.model_dump_json(indent=2) + "\n", encoding="utf-8")
 
 
+def write_comparison_report(report: ComparisonReport, output_path: str | Path) -> None:
+    """Write the aggregate comparison report without raw fixture records."""
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(report.model_dump_json(indent=2) + "\n", encoding="utf-8")
+
+
 __all__ = [
     "load_fixture",
+    "run_comparison",
+    "run_comparison_fixture",
     "run_eval",
     "run_fixture",
+    "write_comparison_report",
     "write_metrics_report",
 ]

--- a/tests/test_eval_runner_comparison.py
+++ b/tests/test_eval_runner_comparison.py
@@ -1,0 +1,466 @@
+"""Tests for Context Firewall condition comparison eval runner (issue #42)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from photon_action_memory.eval.comparison import (
+    COMPARISON_REPORT_SCHEMA,
+    EVAL_CONDITIONS,
+    ComparisonRecord,
+    ComparisonReport,
+    ConditionSummary,
+    build_comparison_report,
+)
+from photon_action_memory.eval.runner import run_comparison, run_comparison_fixture
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _rec(
+    condition: str = "no_memory",
+    outcome: str | None = None,
+    *,
+    repeated: bool = False,
+    retry: bool = False,
+    dup: int = 0,
+    ungrounded: int = 0,
+    hypothesis: int = 0,
+    summaries: int = 0,
+    facts: int = 0,
+) -> ComparisonRecord:
+    return ComparisonRecord(
+        condition=condition,
+        outcome=outcome,
+        repeated_exploration_occurred=repeated,
+        failed_action_retry=retry,
+        duplicate_context_incidents=dup,
+        ungrounded_fact_incidents=ungrounded,
+        hypothesis_as_fact_incidents=hypothesis,
+        total_summaries_evaluated=summaries,
+        total_facts_evaluated=facts,
+    )
+
+
+def _find(report: ComparisonReport, condition: str) -> ConditionSummary:
+    for cs in report.conditions:
+        if cs.condition == condition:
+            return cs
+    raise KeyError(condition)
+
+
+# ---------------------------------------------------------------------------
+# EVAL_CONDITIONS constant
+# ---------------------------------------------------------------------------
+
+
+def test_eval_conditions_contains_all_named_conditions() -> None:
+    expected = {
+        "no_memory",
+        "full_transcript",
+        "static_summary_memory",
+        "retrieval_memory",
+        "photon_summary_only",
+        "photon_summary_evidence",
+    }
+    assert expected <= EVAL_CONDITIONS
+
+
+# ---------------------------------------------------------------------------
+# build_comparison_report - empty and single record
+# ---------------------------------------------------------------------------
+
+
+def test_empty_records_yields_zero_report() -> None:
+    report = build_comparison_report([])
+    assert report.total_records == 0
+    assert report.conditions == []
+
+
+def test_single_record_success() -> None:
+    report = build_comparison_report([_rec("no_memory", "accepted")])
+    assert report.total_records == 1
+    cs = _find(report, "no_memory")
+    assert cs.task_success_rate == 1.0
+    assert cs.repeated_exploration_rate == 0.0
+    assert cs.failed_action_retry_rate == 0.0
+
+
+def test_single_record_non_success_outcome() -> None:
+    report = build_comparison_report([_rec("no_memory", "ignored")])
+    cs = _find(report, "no_memory")
+    assert cs.task_success_rate == 0.0
+
+
+def test_single_record_no_outcome_is_not_success() -> None:
+    report = build_comparison_report([_rec("no_memory", None)])
+    cs = _find(report, "no_memory")
+    assert cs.task_success_rate == 0.0
+
+
+# ---------------------------------------------------------------------------
+# build_comparison_report - task_success_rate
+# ---------------------------------------------------------------------------
+
+
+def test_task_success_rate_accepted() -> None:
+    records = [
+        _rec("photon_summary_only", "accepted"),
+        _rec("photon_summary_only", "accepted"),
+        _rec("photon_summary_only", "ignored"),
+    ]
+    report = build_comparison_report(records)
+    cs = _find(report, "photon_summary_only")
+    assert cs.task_success_rate == pytest.approx(2 / 3)
+
+
+def test_task_success_rate_success_outcome() -> None:
+    records = [
+        _rec("retrieval_memory", "success"),
+        _rec("retrieval_memory", "fail"),
+    ]
+    report = build_comparison_report(records)
+    cs = _find(report, "retrieval_memory")
+    assert cs.task_success_rate == 0.5
+
+
+def test_task_success_rate_completed_outcome() -> None:
+    records = [_rec("full_transcript", "completed")]
+    report = build_comparison_report(records)
+    cs = _find(report, "full_transcript")
+    assert cs.task_success_rate == 1.0
+
+
+# ---------------------------------------------------------------------------
+# build_comparison_report - repeated_exploration_rate
+# ---------------------------------------------------------------------------
+
+
+def test_repeated_exploration_rate() -> None:
+    records = [
+        _rec("photon_summary_evidence", repeated=True),
+        _rec("photon_summary_evidence", repeated=True),
+        _rec("photon_summary_evidence", repeated=False),
+        _rec("photon_summary_evidence", repeated=False),
+    ]
+    report = build_comparison_report(records)
+    cs = _find(report, "photon_summary_evidence")
+    assert cs.repeated_exploration_rate == 0.5
+
+
+def test_repeated_exploration_rate_zero_when_none_occurred() -> None:
+    records = [_rec("no_memory"), _rec("no_memory")]
+    report = build_comparison_report(records)
+    cs = _find(report, "no_memory")
+    assert cs.repeated_exploration_rate == 0.0
+
+
+# ---------------------------------------------------------------------------
+# build_comparison_report - failed_action_retry_rate
+# ---------------------------------------------------------------------------
+
+
+def test_failed_action_retry_rate() -> None:
+    records = [
+        _rec("static_summary_memory", retry=True),
+        _rec("static_summary_memory", retry=False),
+        _rec("static_summary_memory", retry=False),
+    ]
+    report = build_comparison_report(records)
+    cs = _find(report, "static_summary_memory")
+    assert cs.failed_action_retry_rate == pytest.approx(1 / 3)
+
+
+def test_failed_action_retry_rate_all_retried() -> None:
+    records = [_rec("full_transcript", retry=True) for _ in range(3)]
+    report = build_comparison_report(records)
+    cs = _find(report, "full_transcript")
+    assert cs.failed_action_retry_rate == 1.0
+
+
+# ---------------------------------------------------------------------------
+# build_comparison_report - pollution rates integrated from issue #41
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_context_rate_by_condition() -> None:
+    records = [
+        _rec("photon_summary_evidence", dup=1, summaries=4),
+        _rec("photon_summary_evidence", dup=1, summaries=4),
+    ]
+    report = build_comparison_report(records)
+    cs = _find(report, "photon_summary_evidence")
+    assert cs.duplicate_context_rate == pytest.approx(2 / 8)
+
+
+def test_ungrounded_fact_rate_by_condition() -> None:
+    records = [
+        _rec("photon_summary_only", ungrounded=3, facts=10),
+        _rec("photon_summary_only", ungrounded=1, facts=10),
+    ]
+    report = build_comparison_report(records)
+    cs = _find(report, "photon_summary_only")
+    assert cs.ungrounded_fact_rate == pytest.approx(4 / 20)
+
+
+def test_hypothesis_as_fact_rate_by_condition() -> None:
+    records = [
+        _rec("retrieval_memory", hypothesis=2, facts=8),
+    ]
+    report = build_comparison_report(records)
+    cs = _find(report, "retrieval_memory")
+    assert cs.hypothesis_as_fact_rate == pytest.approx(2 / 8)
+
+
+def test_pollution_rates_zero_when_no_facts_evaluated() -> None:
+    records = [_rec("no_memory", ungrounded=0, hypothesis=0, facts=0)]
+    report = build_comparison_report(records)
+    cs = _find(report, "no_memory")
+    assert cs.ungrounded_fact_rate == 0.0
+    assert cs.hypothesis_as_fact_rate == 0.0
+
+
+def test_pollution_rates_zero_when_no_summaries_evaluated() -> None:
+    records = [_rec("no_memory", dup=0, summaries=0)]
+    report = build_comparison_report(records)
+    cs = _find(report, "no_memory")
+    assert cs.duplicate_context_rate == 0.0
+
+
+# ---------------------------------------------------------------------------
+# build_comparison_report - multiple conditions grouped and sorted
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_conditions_grouped() -> None:
+    records = [
+        _rec("no_memory", "accepted"),
+        _rec("photon_summary_evidence", "ignored"),
+        _rec("no_memory", "ignored"),
+        _rec("photon_summary_evidence", "accepted"),
+    ]
+    report = build_comparison_report(records)
+    assert report.total_records == 4
+    assert len(report.conditions) == 2
+    nm = _find(report, "no_memory")
+    pse = _find(report, "photon_summary_evidence")
+    assert nm.total_records == 2
+    assert pse.total_records == 2
+    assert nm.task_success_rate == 0.5
+    assert pse.task_success_rate == 0.5
+
+
+def test_conditions_sorted_alphabetically() -> None:
+    records = [
+        _rec("retrieval_memory"),
+        _rec("no_memory"),
+        _rec("full_transcript"),
+    ]
+    report = build_comparison_report(records)
+    names = [cs.condition for cs in report.conditions]
+    assert names == sorted(names)
+
+
+def test_six_named_conditions_all_present() -> None:
+    records = [_rec(c) for c in sorted(EVAL_CONDITIONS)]
+    report = build_comparison_report(records)
+    assert {cs.condition for cs in report.conditions} == EVAL_CONDITIONS
+
+
+# ---------------------------------------------------------------------------
+# build_comparison_report - dict records (fixture-style input)
+# ---------------------------------------------------------------------------
+
+
+def test_dict_records_parsed_correctly() -> None:
+    raw = [
+        {
+            "condition": "photon_summary_only",
+            "outcome": "accepted",
+            "repeated_exploration_occurred": True,
+            "failed_action_retry": False,
+            "raw_log": "must be ignored by extra=ignore",
+        }
+    ]
+    report = build_comparison_report(raw)
+    cs = _find(report, "photon_summary_only")
+    assert cs.task_success_rate == 1.0
+    assert cs.repeated_exploration_rate == 1.0
+
+
+def test_unknown_fields_ignored_via_extra_ignore() -> None:
+    raw = [{"condition": "no_memory", "outcome": "success", "prompt": "secret prompt text"}]
+    report = build_comparison_report(raw)
+    dump = report.model_dump(mode="json")
+    assert "prompt" not in dump
+    assert "prompt" not in str(dump)
+
+
+# ---------------------------------------------------------------------------
+# build_comparison_report - report shape (aggregate-only)
+# ---------------------------------------------------------------------------
+
+
+def test_schema_version_is_comparison_metrics_v1() -> None:
+    report = build_comparison_report([])
+    assert report.schema_version == COMPARISON_REPORT_SCHEMA
+    assert report.schema_version == "comparison-metrics.v1"
+
+
+def test_report_is_aggregate_only() -> None:
+    """Report dump must not include raw logs, prompts, or tool outputs."""
+    records = [_rec("no_memory", "accepted", repeated=True, retry=False)]
+    report = build_comparison_report(records)
+    dump = report.model_dump(mode="json")
+
+    assert "total_records" in dump
+    assert "conditions" in dump
+    assert "schema_version" in dump
+
+    assert "raw_log" not in dump
+    assert "prompt" not in dump
+    assert "tool_output" not in dump
+    assert "events" not in dump
+    assert "suggestions" not in dump
+    assert "actual_next_action" not in dump
+
+
+def test_condition_summary_fields_present() -> None:
+    records = [_rec("full_transcript", "accepted", repeated=True, retry=True)]
+    report = build_comparison_report(records)
+    cs = _find(report, "full_transcript")
+    assert hasattr(cs, "task_success_rate")
+    assert hasattr(cs, "repeated_exploration_rate")
+    assert hasattr(cs, "failed_action_retry_rate")
+    assert hasattr(cs, "duplicate_context_rate")
+    assert hasattr(cs, "ungrounded_fact_rate")
+    assert hasattr(cs, "hypothesis_as_fact_rate")
+
+
+# ---------------------------------------------------------------------------
+# run_comparison - runner integration
+# ---------------------------------------------------------------------------
+
+
+def test_run_comparison_returns_report() -> None:
+    records = [_rec("no_memory", "success"), _rec("full_transcript", "success")]
+    report = run_comparison(records)
+    assert isinstance(report, ComparisonReport)
+    assert report.total_records == 2
+
+
+def test_run_comparison_writes_aggregate_json(tmp_path: Path) -> None:
+    records = [
+        _rec("photon_summary_evidence", "accepted", dup=1, summaries=4, facts=6),
+        _rec("no_memory", "ignored"),
+    ]
+    output_path = tmp_path / "comparison.json"
+    report = run_comparison(records, output_path=output_path)
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload == report.model_dump(mode="json")
+
+    # Aggregate-only: no raw fields
+    assert "raw_log" not in payload
+    assert "prompt" not in payload
+    assert "tool_output" not in payload
+    assert "records" not in payload
+    assert "total_records" in payload
+    assert "conditions" in payload
+
+
+def test_run_comparison_no_output_path_does_not_write(tmp_path: Path) -> None:
+    records = [_rec("no_memory")]
+    run_comparison(records, output_path=None)
+    assert list(tmp_path.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# run_comparison_fixture - fixture loading
+# ---------------------------------------------------------------------------
+
+
+def test_run_comparison_fixture_from_json_list(tmp_path: Path) -> None:
+    fixture_path = tmp_path / "fixture.json"
+    fixture_path.write_text(
+        json.dumps(
+            [
+                {"condition": "photon_summary_only", "outcome": "accepted"},
+                {"condition": "photon_summary_only", "outcome": "ignored"},
+                {"condition": "no_memory", "outcome": "accepted"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    report = run_comparison_fixture(fixture_path)
+    assert report.total_records == 3
+    cs = _find(report, "photon_summary_only")
+    assert cs.task_success_rate == 0.5
+    assert cs.total_records == 2
+
+
+def test_run_comparison_fixture_from_records_object(tmp_path: Path) -> None:
+    fixture_path = tmp_path / "fixture.json"
+    fixture_path.write_text(
+        json.dumps(
+            {
+                "records": [
+                    {
+                        "condition": "retrieval_memory",
+                        "outcome": "success",
+                        "repeated_exploration_occurred": True,
+                        "failed_action_retry": True,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    report = run_comparison_fixture(fixture_path)
+    assert report.total_records == 1
+    cs = _find(report, "retrieval_memory")
+    assert cs.repeated_exploration_rate == 1.0
+    assert cs.failed_action_retry_rate == 1.0
+
+
+def test_run_comparison_fixture_writes_output(tmp_path: Path) -> None:
+    fixture_path = tmp_path / "fixture.json"
+    fixture_path.write_text(
+        json.dumps([{"condition": "no_memory", "outcome": "accepted"}]),
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "out" / "comparison.json"
+    report = run_comparison_fixture(fixture_path, output_path=output_path)
+    assert output_path.exists()
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload == report.model_dump(mode="json")
+
+
+# ---------------------------------------------------------------------------
+# ComparisonRecord field validation
+# ---------------------------------------------------------------------------
+
+
+def test_comparison_record_defaults() -> None:
+    rec = ComparisonRecord()
+    assert rec.condition == "no_memory"
+    assert rec.outcome is None
+    assert rec.repeated_exploration_occurred is False
+    assert rec.failed_action_retry is False
+    assert rec.duplicate_context_incidents == 0
+    assert rec.ungrounded_fact_incidents == 0
+    assert rec.hypothesis_as_fact_incidents == 0
+    assert rec.total_summaries_evaluated == 0
+    assert rec.total_facts_evaluated == 0
+
+
+def test_comparison_record_negative_incidents_rejected() -> None:
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError):
+        ComparisonRecord(duplicate_context_incidents=-1)


### PR DESCRIPTION
## Summary
- Add condition comparison metrics for Context Firewall eval modes.
- Add comparison runner APIs and aggregate JSON writer while preserving existing eval runner behavior.
- Report task success, repeated exploration, failed action retry, and pollution rates by condition.
- Add focused comparison tests and dev reports for issue #42.

## Verification
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m mypy photon_action_memory tests`
- `python -m pytest -q`

Closes #42