### PR TITLE
#43 Add Anvil ContextPack integration contract

### DIFF
--- a/dev-reports/issue-43/implementation-summary.md
+++ b/dev-reports/issue-43/implementation-summary.md
@@ -1,0 +1,103 @@
+# Issue #43 — Anvil ContextPack Integration Contract: Implementation Summary
+
+## Scope
+
+Add a neutral ContextPack integration contract for `POST /v1/context/pack` before
+LLM prompt construction, optional `POST /v1/evidence/expand` when more detail is
+needed, ContextPack adoption/ignored/outcome logging through `POST /v1/evaluate`,
+and privacy-safe neutral fixtures.
+
+---
+
+## Changes
+
+### 1. Schema — `photon_action_memory/api/schema_v2.py`
+
+Added three new models under a `POST /v1/evaluate` section:
+
+| Model | Purpose |
+|---|---|
+| `ContextPackEvalEvent` | One turn's ContextPack adoption event: `adoption_status`, `ignored_reason`, `evidence_expand_requested`, `evidence_ids_expanded`, `items_adopted_count`, `items_ignored_count`, `outcome`, `outcome_detail`, `latency_ms` |
+| `EvaluateRequest` | Request body for `POST /v1/evaluate`; carries an optional `context_pack_event` |
+| `EvaluateResponse` | Response body: `logged` count, `status`, `warnings` |
+
+`ContextPackAdoptionStatus = Literal["adopted", "ignored", "partial"]` added as a
+named type alias.  All three models added to `__all__`.
+
+### 2. Server — `photon_action_memory/api/server.py`
+
+Replaced the `501 evaluate_stub` with a working `POST /v1/evaluate` endpoint:
+
+- If `context_pack_event` is present, stores a `type=context_pack_eval` event
+  in the SQLite event store and returns `logged=1`.
+- Fail-open: errors are caught, logged to `warnings`, and `status="degraded"`.
+- No event → `logged=0`, `status="ok"`.
+
+### 3. Eval module — `photon_action_memory/eval/context_pack_log.py` (new)
+
+Provides offline aggregation of ContextPack eval records:
+
+| Symbol | Purpose |
+|---|---|
+| `ContextPackEvalRecord` | Normalized single-turn record (pydantic, `extra="ignore"`) |
+| `ContextPackAdoptionReport` | Aggregate: adoption rate, evidence-expand rate, task success rate, ignored-reason counts, outcome counts |
+| `aggregate_context_pack_eval(records)` | Builds `ContextPackAdoptionReport` from a sequence of records or raw dicts |
+
+### 4. Integration contract — `photon_action_memory/integration/context_pack_contract.py` (new)
+
+Defines the neutral three-step calling sequence:
+
+1. `POST /v1/context/pack` — required, before prompt assembly
+2. `POST /v1/evidence/expand` — optional, when items carry `expand_policy="on_demand_only"`
+3. `POST /v1/evaluate` — required, after the turn completes
+
+| Symbol | Purpose |
+|---|---|
+| `IntegrationStepKind` | `Literal["context_pack", "evidence_expand", "evaluate"]` |
+| `IntegrationStep` | Frozen dataclass: kind, endpoint, when, required |
+| `IntegrationContract` | Frozen dataclass: steps tuple + invariants tuple |
+| `CONTEXT_PACK_CONTRACT` | Module-level constant instance |
+| `REQUIRED_STEPS` / `OPTIONAL_STEPS` | Frozensets for quick membership checks |
+| `validate_call_sequence(step_kinds)` | Returns a list of contract violations; empty = valid |
+
+Also added `photon_action_memory/integration/__init__.py`.
+
+### 5. Fixtures — `tests/fixtures/v0.2/` (three new files)
+
+| File | Content |
+|---|---|
+| `evaluate_context_pack_adopted.json` | POST /v1/evaluate body with `adoption_status="adopted"`, `outcome="success"` |
+| `evaluate_context_pack_ignored.json` | POST /v1/evaluate body with `adoption_status="ignored"`, `ignored_reason="existing_plan_had_higher_priority"` |
+| `context_pack_adoption_log.json` | Five-record multi-turn fixture for `aggregate_context_pack_eval` testing |
+
+All fixtures are privacy-safe: no real file paths, user data, or code snippets.
+
+### 6. Tests — `tests/test_evaluate.py` (new, 30 tests)
+
+Covers:
+
+- HTTP endpoint: adopted / ignored / no-event / logs-to-store / evidence-expand fields
+- Schema round-trip: `EvaluateRequest`, `EvaluateResponse`
+- Fixture validation: all three new fixtures parse correctly
+- `aggregate_context_pack_eval`: empty, all-adopted, mixed, from fixture file
+- `validate_call_sequence`: valid complete, valid with expand, missing steps, wrong order, expand without pack
+- Contract structure: required steps present, optional steps present, invariants non-empty, required flags, endpoints
+
+---
+
+## Design decisions
+
+**Agent-neutral contract**: `context_pack_contract.py` never imports or references
+Anvil internals.  The module docstring names Anvil as a concrete example only.
+
+**Fail-open evaluate endpoint**: matches the existing fail-open pattern in
+`/v1/context/pack`; eval errors must not disrupt the calling agent's turn.
+
+**Flat event store**: `ContextPackEvalEvent` is stored as a plain dict via the
+existing `SQLiteEventStore.append()` so it can be replayed or aggregated later
+without schema migration.
+
+**Separation of concerns**: HTTP schema (`schema_v2.py`), offline aggregation
+(`eval/context_pack_log.py`), and the calling contract
+(`integration/context_pack_contract.py`) are in separate modules so each can
+evolve independently.

--- a/dev-reports/issue-43/verification.md
+++ b/dev-reports/issue-43/verification.md
@@ -1,0 +1,86 @@
+# Issue #43 — Verification Report
+
+## Tool run results
+
+### ruff format
+```
+69 files left unchanged
+```
+No reformatting needed after final pass.
+
+### ruff check
+```
+All checks passed!
+```
+
+### mypy
+```
+Success: no issues found in 67 source files
+```
+Checked `photon_action_memory/` (all modules) and `tests/` (all test files).
+
+### pytest
+```
+536 passed, 1 skipped in 1.27s
+```
+The skipped test is `tests/integration/test_mlx_smoke.py` — opt-in only, unchanged.
+
+---
+
+## New tests: 27 total (26 in `test_evaluate.py` + 1 updated in `test_sidecar_api.py`)
+
+| Test | Result |
+|---|---|
+| `test_evaluate_adopted_context_pack_returns_logged_one` | PASS |
+| `test_evaluate_ignored_context_pack_returns_logged_one` | PASS |
+| `test_evaluate_no_context_pack_event_returns_logged_zero` | PASS |
+| `test_evaluate_logs_event_to_store` | PASS |
+| `test_evaluate_with_evidence_expand_fields` | PASS |
+| `test_evaluate_request_schema_round_trip` | PASS |
+| `test_evaluate_response_schema_round_trip` | PASS |
+| `test_evaluate_adopted_fixture_validates` | PASS |
+| `test_evaluate_ignored_fixture_validates` | PASS |
+| `test_adoption_log_fixture_records_validate` | PASS |
+| `test_aggregate_empty_records_returns_zero_report` | PASS |
+| `test_aggregate_all_adopted` | PASS |
+| `test_aggregate_mixed_adoption_and_outcomes` | PASS |
+| `test_aggregate_from_fixture_file` | PASS |
+| `test_valid_complete_sequence` | PASS |
+| `test_valid_sequence_with_evidence_expand` | PASS |
+| `test_missing_context_pack_step_is_violation` | PASS |
+| `test_missing_evaluate_step_is_violation` | PASS |
+| `test_wrong_order_is_violation` | PASS |
+| `test_evidence_expand_without_context_pack_is_violation` | PASS |
+| `test_empty_sequence_has_violations` | PASS |
+| `test_contract_has_all_required_steps` | PASS |
+| `test_contract_has_optional_steps` | PASS |
+| `test_contract_invariants_are_non_empty` | PASS |
+| `test_required_steps_are_marked_required` | PASS |
+| `test_contract_steps_have_endpoints` | PASS |
+| `test_evaluate_returns_ok_for_valid_request` (sidecar_api) | PASS |
+
+---
+
+## Changed files summary
+
+| File | Change |
+|---|---|
+| `photon_action_memory/api/schema_v2.py` | Added `ContextPackAdoptionStatus`, `ContextPackEvalEvent`, `EvaluateRequest`, `EvaluateResponse` |
+| `photon_action_memory/api/server.py` | Replaced 501 evaluate stub with working endpoint; imports updated |
+| `photon_action_memory/eval/context_pack_log.py` | New: `ContextPackEvalRecord`, `ContextPackAdoptionReport`, `aggregate_context_pack_eval` |
+| `photon_action_memory/integration/__init__.py` | New: package init |
+| `photon_action_memory/integration/context_pack_contract.py` | New: `IntegrationContract`, `CONTEXT_PACK_CONTRACT`, `validate_call_sequence` |
+| `tests/fixtures/v0.2/evaluate_context_pack_adopted.json` | New fixture |
+| `tests/fixtures/v0.2/evaluate_context_pack_ignored.json` | New fixture |
+| `tests/fixtures/v0.2/context_pack_adoption_log.json` | New multi-turn fixture |
+| `tests/test_evaluate.py` | New: 26 tests |
+| `tests/test_sidecar_api.py` | Updated: split stub test, added evaluate 200 test |
+
+---
+
+## Regression check
+
+No previously passing tests were broken.  The only pre-existing test that touched
+`/v1/evaluate` (`test_summarize_and_evaluate_are_m2_stubs`) was split:
+- `test_summarize_is_m2_stub` — unchanged, still expects 501
+- `test_evaluate_returns_ok_for_valid_request` — new assertion against the live endpoint

--- a/photon_action_memory/api/schema_v2.py
+++ b/photon_action_memory/api/schema_v2.py
@@ -434,6 +434,54 @@ class SummaryValidateResponse(SidecarModel):
     results: list[SummaryValidationResult] = Field(default_factory=list)
 
 
+# ---------------------------------------------------------------------------
+# POST /v1/evaluate — ContextPack adoption and outcome logging
+# ---------------------------------------------------------------------------
+
+ContextPackAdoptionStatus = Literal["adopted", "ignored", "partial"]
+
+
+class ContextPackEvalEvent(SidecarModel):
+    """One turn's ContextPack adoption event logged through POST /v1/evaluate.
+
+    Records whether the ContextPack built by POST /v1/context/pack was actually
+    injected into the LLM prompt, partially used, or ignored, along with the
+    final task outcome.  Any coding agent (not just Anvil) should log this after
+    every turn where a ContextPack was requested.
+    """
+
+    context_pack_request_id: str
+    adoption_status: ContextPackAdoptionStatus | str = "adopted"
+    ignored_reason: str | None = None
+    evidence_expand_requested: bool = False
+    evidence_ids_expanded: list[str] = Field(default_factory=list)
+    items_adopted_count: int = Field(default=0, ge=0)
+    items_ignored_count: int = Field(default=0, ge=0)
+    outcome: str | None = None
+    outcome_detail: str | None = None
+    latency_ms: float | None = Field(default=None, ge=0)
+
+
+class EvaluateRequest(SidecarModel):
+    """Request body for POST /v1/evaluate."""
+
+    schema_version: SchemaVersionV2
+    request_id: str
+    session_id: str | None = None
+    agent: AgentInfo | None = None
+    context_pack_event: ContextPackEvalEvent | None = None
+
+
+class EvaluateResponse(SidecarModel):
+    """Response body for POST /v1/evaluate."""
+
+    schema_version: SchemaVersionV2
+    request_id: str
+    logged: int = Field(default=0, ge=0)
+    status: str = "ok"
+    warnings: list[ContextPackWarning] = Field(default_factory=list)
+
+
 __all__ = [
     "DEFAULT_SCHEMA_VERSION_V2",
     "ActionChunk",
@@ -446,12 +494,16 @@ __all__ = [
     "ChunkOutcome",
     "ContextAdmissionDecision",
     "ContextPack",
+    "ContextPackAdoptionStatus",
     "ContextPackBudget",
+    "ContextPackEvalEvent",
     "ContextPackItem",
     "ContextPackMode",
     "ContextPackRequest",
     "ContextPackResponse",
     "ContextPackWarning",
+    "EvaluateRequest",
+    "EvaluateResponse",
     "EvidenceExpandBudget",
     "EvidenceExpandPolicy",
     "EvidenceExpandRequest",

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -28,6 +28,8 @@ from photon_action_memory.api.schema_v2 import (
     ContextPackRequest,
     ContextPackResponse,
     ContextPackWarning,
+    EvaluateRequest,
+    EvaluateResponse,
     EvidenceExpandRequest,
     EvidenceExpandResponse,
     OmittedEvidence,
@@ -200,9 +202,42 @@ def create_app(store: SQLiteEventStore | None = None) -> FastAPI:
     def summarize_stub() -> None:
         raise HTTPException(status_code=501, detail="summarize is not implemented in M2")
 
-    @app.post("/v1/evaluate")
-    def evaluate_stub() -> None:
-        raise HTTPException(status_code=501, detail="evaluate is not implemented in M2")
+    @app.post("/v1/evaluate", response_model=EvaluateResponse)
+    def evaluate(request: EvaluateRequest) -> EvaluateResponse:
+        logged = 0
+        route_warnings: list[ContextPackWarning] = []
+        try:
+            if request.context_pack_event is not None:
+                evt = request.context_pack_event
+                payload: dict[str, Any] = {
+                    "event_type": "context_pack_eval",
+                    "session_id": request.session_id or request.request_id,
+                    "turn_id": request.request_id,
+                    "repo_id": "unknown",
+                    "request_id": request.request_id,
+                    "context_pack_request_id": evt.context_pack_request_id,
+                    "adoption_status": evt.adoption_status,
+                    "ignored_reason": evt.ignored_reason,
+                    "evidence_expand_requested": evt.evidence_expand_requested,
+                    "evidence_ids_expanded": evt.evidence_ids_expanded,
+                    "items_adopted_count": evt.items_adopted_count,
+                    "items_ignored_count": evt.items_ignored_count,
+                    "outcome": evt.outcome,
+                    "outcome_detail": evt.outcome_detail,
+                    "latency_ms": evt.latency_ms,
+                }
+                event_store.append(payload)
+                logged += 1
+        except Exception as exc:
+            logger.warning("evaluate log error: %s", exc)
+            route_warnings.append(ContextPackWarning(kind="eval_log_error", message=str(exc)))
+        return EvaluateResponse(
+            schema_version=DEFAULT_SCHEMA_VERSION_V2,
+            request_id=request.request_id,
+            logged=logged,
+            status="ok" if not route_warnings else "degraded",
+            warnings=route_warnings,
+        )
 
     return app
 

--- a/photon_action_memory/eval/context_pack_log.py
+++ b/photon_action_memory/eval/context_pack_log.py
@@ -1,0 +1,107 @@
+"""ContextPack adoption and outcome evaluation logging.
+
+Provides normalized record types and an aggregation function for multi-turn
+ContextPack evaluation data collected through POST /v1/evaluate.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+CONTEXT_PACK_LOG_SCHEMA = "context-pack-eval.v1"
+
+_SUCCESS_OUTCOMES: frozenset[str] = frozenset({"success", "accepted", "completed"})
+
+
+class ContextPackEvalRecord(BaseModel):
+    """Normalized single-turn record of ContextPack adoption and task outcome."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    context_pack_request_id: str = ""
+    adoption_status: str = "adopted"
+    ignored_reason: str | None = None
+    evidence_expand_requested: bool = False
+    evidence_ids_expanded: list[str] = Field(default_factory=list)
+    items_adopted_count: int = Field(default=0, ge=0)
+    items_ignored_count: int = Field(default=0, ge=0)
+    outcome: str | None = None
+    latency_ms: float | None = Field(default=None, ge=0)
+
+
+class ContextPackAdoptionReport(BaseModel):
+    """Aggregate ContextPack adoption report across multiple turns."""
+
+    schema_version: Literal["context-pack-eval.v1"] = "context-pack-eval.v1"
+    total_turns: int
+    adopted_count: int
+    ignored_count: int
+    partial_count: int
+    adoption_rate: float
+    evidence_expand_rate: float
+    task_success_rate: float
+    ignored_reason_counts: dict[str, int]
+    outcome_counts: dict[str, int]
+
+
+RawContextPackEvalRecord = ContextPackEvalRecord | Mapping[str, Any]
+
+
+def aggregate_context_pack_eval(
+    records: Sequence[RawContextPackEvalRecord],
+) -> ContextPackAdoptionReport:
+    """Build an aggregate adoption report from normalized eval records."""
+    parsed = [_coerce(r) for r in records]
+    n = len(parsed)
+
+    adopted = sum(1 for r in parsed if r.adoption_status == "adopted")
+    ignored = sum(1 for r in parsed if r.adoption_status == "ignored")
+    partial = sum(1 for r in parsed if r.adoption_status == "partial")
+    expand_used = sum(1 for r in parsed if r.evidence_expand_requested)
+    successes = sum(1 for r in parsed if r.outcome in _SUCCESS_OUTCOMES)
+
+    ignored_reasons: dict[str, int] = {}
+    for r in parsed:
+        if r.adoption_status == "ignored" and r.ignored_reason:
+            ignored_reasons[r.ignored_reason] = ignored_reasons.get(r.ignored_reason, 0) + 1
+
+    outcome_counts: dict[str, int] = {}
+    for r in parsed:
+        key = r.outcome or "unknown"
+        outcome_counts[key] = outcome_counts.get(key, 0) + 1
+
+    return ContextPackAdoptionReport(
+        total_turns=n,
+        adopted_count=adopted,
+        ignored_count=ignored,
+        partial_count=partial,
+        adoption_rate=_rate(adopted + partial, n),
+        evidence_expand_rate=_rate(expand_used, n),
+        task_success_rate=_rate(successes, n),
+        ignored_reason_counts=dict(sorted(ignored_reasons.items())),
+        outcome_counts=dict(sorted(outcome_counts.items())),
+    )
+
+
+def _coerce(record: RawContextPackEvalRecord) -> ContextPackEvalRecord:
+    if isinstance(record, ContextPackEvalRecord):
+        return record
+    return ContextPackEvalRecord.model_validate(record)
+
+
+def _rate(numerator: int, denominator: int) -> float:
+    if denominator == 0:
+        return 0.0
+    return numerator / denominator
+
+
+__all__ = [
+    "CONTEXT_PACK_LOG_SCHEMA",
+    "ContextPackAdoptionReport",
+    "ContextPackEvalRecord",
+    "RawContextPackEvalRecord",
+    "aggregate_context_pack_eval",
+]

--- a/photon_action_memory/integration/__init__.py
+++ b/photon_action_memory/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration contracts for PHOTON Action Memory sidecar endpoints."""

--- a/photon_action_memory/integration/context_pack_contract.py
+++ b/photon_action_memory/integration/context_pack_contract.py
@@ -1,0 +1,131 @@
+"""Neutral ContextPack integration contract for LLM prompt construction.
+
+Defines the three-step calling sequence any coding agent should follow when
+integrating PHOTON Action Memory ContextPack into its prompt-building pipeline.
+Anvil is used as one concrete example; the contract is intentionally
+agent-neutral and applies to any tool-use agent with a sidecar.
+
+Calling sequence
+----------------
+1. POST /v1/context/pack  — before assembling the LLM prompt (required)
+2. POST /v1/evidence/expand — when pack items need more detail (optional)
+3. POST /v1/evaluate       — after the turn completes to log adoption/outcome (required)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+IntegrationStepKind = Literal["context_pack", "evidence_expand", "evaluate"]
+
+REQUIRED_STEPS: frozenset[IntegrationStepKind] = frozenset({"context_pack", "evaluate"})
+OPTIONAL_STEPS: frozenset[IntegrationStepKind] = frozenset({"evidence_expand"})
+
+
+@dataclass(frozen=True)
+class IntegrationStep:
+    """One named step in the ContextPack integration sequence."""
+
+    kind: IntegrationStepKind
+    endpoint: str
+    when: str
+    required: bool
+
+
+@dataclass(frozen=True)
+class IntegrationContract:
+    """Full ContextPack integration contract.
+
+    Any coding agent that embeds PHOTON Action Memory should execute these
+    steps in order for every LLM turn where a ContextPack is requested.
+    Skipping required steps breaks adoption tracking and degrades eval signal.
+    """
+
+    steps: tuple[IntegrationStep, ...]
+    invariants: tuple[str, ...]
+
+
+_CONTRACT_STEPS: tuple[IntegrationStep, ...] = (
+    IntegrationStep(
+        kind="context_pack",
+        endpoint="POST /v1/context/pack",
+        when="Before assembling the LLM prompt for the current turn.",
+        required=True,
+    ),
+    IntegrationStep(
+        kind="evidence_expand",
+        endpoint="POST /v1/evidence/expand",
+        when=(
+            "After receiving the ContextPack, when one or more items carry "
+            "expand_policy='on_demand_only' and the agent needs the full snippet "
+            "before including the item in the prompt."
+        ),
+        required=False,
+    ),
+    IntegrationStep(
+        kind="evaluate",
+        endpoint="POST /v1/evaluate",
+        when=(
+            "After the LLM responds and the agent has determined whether the "
+            "ContextPack items were adopted (injected), partially used, or ignored."
+        ),
+        required=True,
+    ),
+)
+
+_CONTRACT_INVARIANTS: tuple[str, ...] = (
+    "context_pack must be called before the LLM prompt is assembled.",
+    "evidence_expand may be omitted; call it only when items signal on_demand_only.",
+    "evaluate must be called after every turn; omitting it breaks adoption tracking.",
+    (
+        "The context_pack_request_id in EvaluateRequest.context_pack_event "
+        "must reference the request_id from the preceding ContextPackRequest."
+    ),
+)
+
+CONTEXT_PACK_CONTRACT: IntegrationContract = IntegrationContract(
+    steps=_CONTRACT_STEPS,
+    invariants=_CONTRACT_INVARIANTS,
+)
+
+
+def validate_call_sequence(
+    step_kinds: list[IntegrationStepKind],
+) -> list[str]:
+    """Return a list of contract violations for the given calling sequence.
+
+    An empty list means the sequence is valid.  Call this in tests or CI to
+    verify that a recorded agent trace follows the integration contract.
+    """
+    violations: list[str] = []
+    seen = set(step_kinds)
+
+    for step in CONTEXT_PACK_CONTRACT.steps:
+        if step.required and step.kind not in seen:
+            violations.append(f"required step '{step.kind}' was not called")
+
+    if "context_pack" in seen and "evaluate" in seen:
+        try:
+            cp_index = step_kinds.index("context_pack")
+            ev_index = step_kinds.index("evaluate")
+            if cp_index > ev_index:
+                violations.append("'context_pack' must be called before 'evaluate'")
+        except ValueError:
+            pass
+
+    if "evidence_expand" in seen and "context_pack" not in seen:
+        violations.append("'evidence_expand' was called without a preceding 'context_pack' call")
+
+    return violations
+
+
+__all__ = [
+    "CONTEXT_PACK_CONTRACT",
+    "IntegrationContract",
+    "IntegrationStep",
+    "IntegrationStepKind",
+    "OPTIONAL_STEPS",
+    "REQUIRED_STEPS",
+    "validate_call_sequence",
+]

--- a/tests/fixtures/v0.2/context_pack_adoption_log.json
+++ b/tests/fixtures/v0.2/context_pack_adoption_log.json
@@ -1,0 +1,61 @@
+{
+  "schema": "context-pack-eval.v1",
+  "description": "Multi-turn ContextPack adoption log fixture for aggregate eval testing.",
+  "records": [
+    {
+      "context_pack_request_id": "pack-req-001",
+      "adoption_status": "adopted",
+      "ignored_reason": null,
+      "evidence_expand_requested": false,
+      "evidence_ids_expanded": [],
+      "items_adopted_count": 3,
+      "items_ignored_count": 0,
+      "outcome": "success",
+      "latency_ms": 142.5
+    },
+    {
+      "context_pack_request_id": "pack-req-002",
+      "adoption_status": "ignored",
+      "ignored_reason": "existing_plan_had_higher_priority",
+      "evidence_expand_requested": false,
+      "evidence_ids_expanded": [],
+      "items_adopted_count": 0,
+      "items_ignored_count": 2,
+      "outcome": "partial",
+      "latency_ms": 88.0
+    },
+    {
+      "context_pack_request_id": "pack-req-003",
+      "adoption_status": "adopted",
+      "ignored_reason": null,
+      "evidence_expand_requested": true,
+      "evidence_ids_expanded": ["ev-ref-007"],
+      "items_adopted_count": 2,
+      "items_ignored_count": 1,
+      "outcome": "success",
+      "latency_ms": 210.3
+    },
+    {
+      "context_pack_request_id": "pack-req-004",
+      "adoption_status": "partial",
+      "ignored_reason": null,
+      "evidence_expand_requested": false,
+      "evidence_ids_expanded": [],
+      "items_adopted_count": 1,
+      "items_ignored_count": 2,
+      "outcome": "success",
+      "latency_ms": 175.0
+    },
+    {
+      "context_pack_request_id": "pack-req-005",
+      "adoption_status": "ignored",
+      "ignored_reason": "context_pack_empty",
+      "evidence_expand_requested": false,
+      "evidence_ids_expanded": [],
+      "items_adopted_count": 0,
+      "items_ignored_count": 0,
+      "outcome": "failure",
+      "latency_ms": 55.1
+    }
+  ]
+}

--- a/tests/fixtures/v0.2/evaluate_context_pack_adopted.json
+++ b/tests/fixtures/v0.2/evaluate_context_pack_adopted.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "action-memory.v0.2",
+  "request_id": "eval-req-adopted-001",
+  "session_id": "sess_eval_001",
+  "agent": {
+    "name": "example-coding-agent",
+    "version": "0.3.0"
+  },
+  "context_pack_event": {
+    "context_pack_request_id": "pack-req-001",
+    "adoption_status": "adopted",
+    "ignored_reason": null,
+    "evidence_expand_requested": false,
+    "evidence_ids_expanded": [],
+    "items_adopted_count": 3,
+    "items_ignored_count": 0,
+    "outcome": "success",
+    "outcome_detail": "Task completed after injecting three ContextPack items into the prompt.",
+    "latency_ms": 142.5
+  }
+}

--- a/tests/fixtures/v0.2/evaluate_context_pack_ignored.json
+++ b/tests/fixtures/v0.2/evaluate_context_pack_ignored.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "action-memory.v0.2",
+  "request_id": "eval-req-ignored-001",
+  "session_id": "sess_eval_001",
+  "agent": {
+    "name": "example-coding-agent",
+    "version": "0.3.0"
+  },
+  "context_pack_event": {
+    "context_pack_request_id": "pack-req-002",
+    "adoption_status": "ignored",
+    "ignored_reason": "existing_plan_had_higher_priority",
+    "evidence_expand_requested": false,
+    "evidence_ids_expanded": [],
+    "items_adopted_count": 0,
+    "items_ignored_count": 2,
+    "outcome": "partial",
+    "outcome_detail": "Agent proceeded with an existing in-progress plan; ContextPack was available but not injected.",
+    "latency_ms": 88.0
+  }
+}

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,0 +1,390 @@
+"""Tests for POST /v1/evaluate ContextPack adoption logging and integration contract.
+
+Acceptance criteria covered:
+- POST /v1/evaluate with adopted ContextPack logs the event and returns logged=1
+- POST /v1/evaluate with ignored ContextPack logs the event and returns ignored_reason
+- POST /v1/evaluate with no context_pack_event returns logged=0
+- Evaluate endpoint logs the event to the SQLite store
+- EvaluateRequest and EvaluateResponse schema round-trip correctly
+- Fixture JSON validates against the schema
+- aggregate_context_pack_eval() computes correct adoption and outcome rates
+- validate_call_sequence() correctly identifies contract violations
+- IntegrationContract invariants are present and non-empty
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    EvaluateRequest,
+    EvaluateResponse,
+)
+from photon_action_memory.api.server import create_app
+from photon_action_memory.eval.context_pack_log import (
+    ContextPackAdoptionReport,
+    ContextPackEvalRecord,
+    aggregate_context_pack_eval,
+)
+from photon_action_memory.integration.context_pack_contract import (
+    CONTEXT_PACK_CONTRACT,
+    OPTIONAL_STEPS,
+    REQUIRED_STEPS,
+    validate_call_sequence,
+)
+from photon_action_memory.memory.store import SQLiteEventStore
+
+FIXTURES_V2 = Path(__file__).parent / "fixtures" / "v0.2"
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/evaluate — HTTP endpoint tests
+# ---------------------------------------------------------------------------
+
+
+def _make_client(tmp_path: Path) -> tuple[TestClient, SQLiteEventStore]:
+    store = SQLiteEventStore(tmp_path / "events.sqlite")
+    return TestClient(create_app(store)), store
+
+
+def test_evaluate_adopted_context_pack_returns_logged_one(tmp_path: Path) -> None:
+    client, _ = _make_client(tmp_path)
+    body = {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "eval-req-001",
+        "session_id": "sess-1",
+        "context_pack_event": {
+            "context_pack_request_id": "pack-req-001",
+            "adoption_status": "adopted",
+            "items_adopted_count": 2,
+            "items_ignored_count": 0,
+            "outcome": "success",
+            "latency_ms": 120.0,
+        },
+    }
+    response = client.post("/v1/evaluate", json=body)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["logged"] == 1
+    assert data["status"] == "ok"
+    assert data["request_id"] == "eval-req-001"
+
+
+def test_evaluate_ignored_context_pack_returns_logged_one(tmp_path: Path) -> None:
+    client, _ = _make_client(tmp_path)
+    body = {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "eval-req-002",
+        "context_pack_event": {
+            "context_pack_request_id": "pack-req-002",
+            "adoption_status": "ignored",
+            "ignored_reason": "existing_plan_had_higher_priority",
+            "items_adopted_count": 0,
+            "items_ignored_count": 3,
+            "outcome": "partial",
+            "latency_ms": 90.0,
+        },
+    }
+    response = client.post("/v1/evaluate", json=body)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["logged"] == 1
+    assert data["status"] == "ok"
+
+
+def test_evaluate_no_context_pack_event_returns_logged_zero(tmp_path: Path) -> None:
+    client, _ = _make_client(tmp_path)
+    body = {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "eval-req-003",
+    }
+    response = client.post("/v1/evaluate", json=body)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["logged"] == 0
+    assert data["status"] == "ok"
+
+
+def test_evaluate_logs_event_to_store(tmp_path: Path) -> None:
+    client, store = _make_client(tmp_path)
+    body = {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "eval-req-004",
+        "context_pack_event": {
+            "context_pack_request_id": "pack-req-004",
+            "adoption_status": "adopted",
+            "evidence_expand_requested": True,
+            "evidence_ids_expanded": ["ev-ref-007"],
+            "items_adopted_count": 1,
+            "items_ignored_count": 0,
+            "outcome": "success",
+        },
+    }
+    response = client.post("/v1/evaluate", json=body)
+    assert response.status_code == 200
+    assert store.count() == 1
+    stored = store.list_events()[0]
+    assert stored.payload["event_type"] == "context_pack_eval"
+    assert stored.payload["adoption_status"] == "adopted"
+    assert stored.payload["evidence_expand_requested"] is True
+    assert stored.payload["evidence_ids_expanded"] == ["ev-ref-007"]
+
+
+def test_evaluate_with_evidence_expand_fields(tmp_path: Path) -> None:
+    client, store = _make_client(tmp_path)
+    body = {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "eval-req-005",
+        "context_pack_event": {
+            "context_pack_request_id": "pack-req-005",
+            "adoption_status": "adopted",
+            "evidence_expand_requested": True,
+            "evidence_ids_expanded": ["ev-ref-a", "ev-ref-b"],
+            "items_adopted_count": 3,
+            "items_ignored_count": 0,
+            "outcome": "success",
+            "latency_ms": 195.0,
+        },
+    }
+    response = client.post("/v1/evaluate", json=body)
+    assert response.status_code == 200
+    assert response.json()["logged"] == 1
+    stored = store.list_events()[0]
+    assert stored.payload["evidence_ids_expanded"] == ["ev-ref-a", "ev-ref-b"]
+
+
+# ---------------------------------------------------------------------------
+# Schema round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_request_schema_round_trip() -> None:
+    raw = {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "rt-req-001",
+        "session_id": "sess-rt-1",
+        "context_pack_event": {
+            "context_pack_request_id": "pack-rt-001",
+            "adoption_status": "partial",
+            "items_adopted_count": 1,
+            "items_ignored_count": 2,
+            "outcome": "success",
+        },
+    }
+    req = EvaluateRequest.model_validate(raw)
+    assert req.request_id == "rt-req-001"
+    assert req.context_pack_event is not None
+    assert req.context_pack_event.adoption_status == "partial"
+    dumped = req.model_dump(mode="json")
+    req2 = EvaluateRequest.model_validate(dumped)
+    assert req2.context_pack_event is not None
+    assert req2.context_pack_event.items_ignored_count == 2
+
+
+def test_evaluate_response_schema_round_trip() -> None:
+    resp = EvaluateResponse(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        request_id="rt-resp-001",
+        logged=1,
+        status="ok",
+    )
+    dumped = resp.model_dump(mode="json")
+    resp2 = EvaluateResponse.model_validate(dumped)
+    assert resp2.logged == 1
+    assert resp2.status == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Fixture validation
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_adopted_fixture_validates() -> None:
+    raw = json.loads((FIXTURES_V2 / "evaluate_context_pack_adopted.json").read_text())
+    req = EvaluateRequest.model_validate(raw)
+    assert req.context_pack_event is not None
+    assert req.context_pack_event.adoption_status == "adopted"
+    assert req.context_pack_event.outcome == "success"
+
+
+def test_evaluate_ignored_fixture_validates() -> None:
+    raw = json.loads((FIXTURES_V2 / "evaluate_context_pack_ignored.json").read_text())
+    req = EvaluateRequest.model_validate(raw)
+    assert req.context_pack_event is not None
+    assert req.context_pack_event.adoption_status == "ignored"
+    assert req.context_pack_event.ignored_reason == "existing_plan_had_higher_priority"
+
+
+def test_adoption_log_fixture_records_validate() -> None:
+    raw = json.loads((FIXTURES_V2 / "context_pack_adoption_log.json").read_text())
+    records = [ContextPackEvalRecord.model_validate(r) for r in raw["records"]]
+    assert len(records) == 5
+    statuses = {r.adoption_status for r in records}
+    assert "adopted" in statuses
+    assert "ignored" in statuses
+    assert "partial" in statuses
+
+
+# ---------------------------------------------------------------------------
+# aggregate_context_pack_eval
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_empty_records_returns_zero_report() -> None:
+    report = aggregate_context_pack_eval([])
+    assert report.total_turns == 0
+    assert report.adoption_rate == 0.0
+    assert report.task_success_rate == 0.0
+
+
+def test_aggregate_all_adopted() -> None:
+    records = [
+        ContextPackEvalRecord(
+            context_pack_request_id=f"p-{i}",
+            adoption_status="adopted",
+            outcome="success",
+        )
+        for i in range(4)
+    ]
+    report = aggregate_context_pack_eval(records)
+    assert report.total_turns == 4
+    assert report.adopted_count == 4
+    assert report.ignored_count == 0
+    assert report.adoption_rate == 1.0
+    assert report.task_success_rate == 1.0
+
+
+def test_aggregate_mixed_adoption_and_outcomes() -> None:
+    raw_records: list[dict[str, Any]] = [
+        {
+            "context_pack_request_id": "p-1",
+            "adoption_status": "adopted",
+            "outcome": "success",
+            "latency_ms": 100.0,
+        },
+        {
+            "context_pack_request_id": "p-2",
+            "adoption_status": "ignored",
+            "ignored_reason": "existing_plan_had_higher_priority",
+            "outcome": "partial",
+        },
+        {
+            "context_pack_request_id": "p-3",
+            "adoption_status": "adopted",
+            "evidence_expand_requested": True,
+            "outcome": "success",
+        },
+        {
+            "context_pack_request_id": "p-4",
+            "adoption_status": "partial",
+            "outcome": "success",
+        },
+        {
+            "context_pack_request_id": "p-5",
+            "adoption_status": "ignored",
+            "ignored_reason": "context_pack_empty",
+            "outcome": "failure",
+        },
+    ]
+    report = aggregate_context_pack_eval(raw_records)
+    assert report.total_turns == 5
+    assert report.adopted_count == 2
+    assert report.ignored_count == 2
+    assert report.partial_count == 1
+    assert report.adoption_rate == pytest.approx(3 / 5)
+    assert report.evidence_expand_rate == pytest.approx(1 / 5)
+    assert report.task_success_rate == pytest.approx(3 / 5)
+    assert report.ignored_reason_counts == {
+        "context_pack_empty": 1,
+        "existing_plan_had_higher_priority": 1,
+    }
+
+
+def test_aggregate_from_fixture_file() -> None:
+    raw = json.loads((FIXTURES_V2 / "context_pack_adoption_log.json").read_text())
+    report = aggregate_context_pack_eval(raw["records"])
+    assert isinstance(report, ContextPackAdoptionReport)
+    assert report.total_turns == 5
+    assert report.adopted_count == 2
+    assert report.ignored_count == 2
+    assert report.partial_count == 1
+    assert report.evidence_expand_rate == pytest.approx(1 / 5)
+
+
+# ---------------------------------------------------------------------------
+# Integration contract — validate_call_sequence
+# ---------------------------------------------------------------------------
+
+
+def test_valid_complete_sequence() -> None:
+    violations = validate_call_sequence(["context_pack", "evaluate"])
+    assert violations == []
+
+
+def test_valid_sequence_with_evidence_expand() -> None:
+    violations = validate_call_sequence(["context_pack", "evidence_expand", "evaluate"])
+    assert violations == []
+
+
+def test_missing_context_pack_step_is_violation() -> None:
+    violations = validate_call_sequence(["evaluate"])
+    assert any("context_pack" in v for v in violations)
+
+
+def test_missing_evaluate_step_is_violation() -> None:
+    violations = validate_call_sequence(["context_pack"])
+    assert any("evaluate" in v for v in violations)
+
+
+def test_wrong_order_is_violation() -> None:
+    violations = validate_call_sequence(["evaluate", "context_pack"])
+    assert any("before" in v for v in violations)
+
+
+def test_evidence_expand_without_context_pack_is_violation() -> None:
+    violations = validate_call_sequence(["evidence_expand", "evaluate"])
+    assert any("evidence_expand" in v for v in violations)
+
+
+def test_empty_sequence_has_violations() -> None:
+    violations = validate_call_sequence([])
+    assert len(violations) >= 2
+
+
+# ---------------------------------------------------------------------------
+# Integration contract — contract structure
+# ---------------------------------------------------------------------------
+
+
+def test_contract_has_all_required_steps() -> None:
+    step_kinds = {step.kind for step in CONTEXT_PACK_CONTRACT.steps}
+    assert REQUIRED_STEPS <= step_kinds
+
+
+def test_contract_has_optional_steps() -> None:
+    step_kinds = {step.kind for step in CONTEXT_PACK_CONTRACT.steps}
+    assert OPTIONAL_STEPS <= step_kinds
+
+
+def test_contract_invariants_are_non_empty() -> None:
+    assert len(CONTEXT_PACK_CONTRACT.invariants) >= 4
+
+
+def test_required_steps_are_marked_required() -> None:
+    for step in CONTEXT_PACK_CONTRACT.steps:
+        if step.kind in REQUIRED_STEPS:
+            assert step.required is True
+        elif step.kind in OPTIONAL_STEPS:
+            assert step.required is False
+
+
+def test_contract_steps_have_endpoints() -> None:
+    for step in CONTEXT_PACK_CONTRACT.steps:
+        assert step.endpoint.startswith("POST /v1/")
+        assert len(step.when) > 0

--- a/tests/test_sidecar_api.py
+++ b/tests/test_sidecar_api.py
@@ -96,15 +96,31 @@ def test_suggest_returns_no_model_fallback(tmp_path: Path) -> None:
     ]
 
 
-def test_summarize_and_evaluate_are_m2_stubs(tmp_path: Path) -> None:
+def test_summarize_is_m2_stub(tmp_path: Path) -> None:
     app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
 
     with TestClient(app) as client:
         summarize_response = client.post("/v1/summarize", json={})
-        evaluate_response = client.post("/v1/evaluate", json={})
 
     assert summarize_response.status_code == 501
-    assert evaluate_response.status_code == 501
+
+
+def test_evaluate_returns_ok_for_valid_request(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+
+    with TestClient(app) as client:
+        evaluate_response = client.post(
+            "/v1/evaluate",
+            json={
+                "schema_version": "action-memory.v0.2",
+                "request_id": "sidecar-eval-001",
+            },
+        )
+
+    assert evaluate_response.status_code == 200
+    data = evaluate_response.json()
+    assert data["logged"] == 0
+    assert data["status"] == "ok"
 
 
 def test_client_suggest_fails_open_on_sidecar_error() -> None:


### PR DESCRIPTION
## Summary
- Add neutral ContextPack integration contract for prompt-construction flows.
- Add `/v1/evaluate` request/response schema and server logging for ContextPack adoption, ignored, evidence expansion, and outcome events.
- Add aggregate-only ContextPack adoption metrics plus privacy-safe fixtures.
- Add focused API, contract, fixture, and aggregation tests with dev reports for issue #43.

## Verification
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m mypy photon_action_memory tests`
- `python -m pytest -q`

Closes #43