### PR TITLE
#44 Add local LLM metrics hooks

### DIFF
--- a/dev-reports/issue-44/implementation-summary.md
+++ b/dev-reports/issue-44/implementation-summary.md
@@ -1,0 +1,112 @@
+# Issue #44 – Add Local LLM Metrics Hooks: Implementation Summary
+
+## What Was Built
+
+### `photon_action_memory/eval/local_llm.py` (new)
+
+Implements five public symbols exported via `__all__`:
+
+**`LOCAL_LLM_REPORT_SCHEMA`** – Schema version string `"local-llm-metrics.v1"`.
+
+**`LocalLLMModelMeta`** – Pydantic model for model-level metadata passed to the report. All fields optional; extra fields silently ignored.
+
+| Field | Type | Description |
+|---|---|---|
+| `model_size_b` | `float \| None` | Model size in billions of parameters |
+| `quantization` | `str \| None` | Quantization scheme (e.g. `"q4_0"`, `"q8_0"`, `"f16"`) |
+| `context_length` | `int \| None` | Maximum context length in tokens |
+| `backend` | `str \| None` | Inference backend (e.g. `"mlx"`, `"llama.cpp"`, `"ollama"`) |
+
+**`LocalLLMRecord`** – Pydantic model for per-turn local LLM performance measurements. Extra fields are silently ignored (`extra="ignore"`) so raw prompts and tool outputs in caller dicts never reach the record.
+
+| Field | Type | Description |
+|---|---|---|
+| `prompt_tokens_per_turn` | `int` | Tokens in the prompt for this turn (required, default 0) |
+| `context_pack_tokens` | `int` | Tokens in the admitted ContextPack (required, default 0) |
+| `prefill_time_ms` | `float \| None` | TTFT / prefill latency in milliseconds |
+| `decode_tokens_per_second` | `float \| None` | Decoding throughput in tokens per second |
+| `peak_vram_mb` | `float \| None` | Peak GPU VRAM usage in megabytes |
+| `context_length_used` | `int \| None` | Actual context length consumed this turn |
+| `cpu_fallback_occurred` | `bool` | Whether any computation fell back to CPU |
+
+**`LocalLLMReport`** – Aggregate-only Pydantic report. Contains no raw records, prompts, or tool outputs.
+
+| Field | Type | Description |
+|---|---|---|
+| `schema_version` | literal | `"local-llm-metrics.v1"` |
+| `total_records` | `int` | Number of input records |
+| `model_meta` | `LocalLLMModelMeta \| None` | Forwarded from caller |
+| `total_prompt_tokens` | `int` | Sum of `prompt_tokens_per_turn` |
+| `avg_prompt_tokens_per_turn` | `float` | Mean prompt tokens; `0.0` on empty |
+| `total_context_pack_tokens` | `int` | Sum of `context_pack_tokens` |
+| `avg_context_pack_tokens_per_turn` | `float` | Mean context pack tokens; `0.0` on empty |
+| `prefill_time_ms_p50` | `float \| None` | p50 of records with `prefill_time_ms` set |
+| `prefill_time_ms_p95` | `float \| None` | p95 of records with `prefill_time_ms` set |
+| `decode_tokens_per_second_p50` | `float \| None` | p50 decode throughput |
+| `decode_tokens_per_second_p95` | `float \| None` | p95 decode throughput |
+| `peak_vram_mb_p50` | `float \| None` | p50 peak VRAM |
+| `peak_vram_mb_p95` | `float \| None` | p95 peak VRAM |
+| `cpu_fallback_rate` | `float` | Fraction of turns with CPU fallback; `0.0` on empty |
+| `context_length_used_p50` | `float \| None` | p50 context length used |
+| `context_length_used_p95` | `float \| None` | p95 context length used |
+
+Optional-metric percentiles are `None` when no record in the input provides that field. They never distort the remaining metrics.
+
+**`build_local_llm_report(records, *, model_meta=None)`** – Aggregates a `Sequence[LocalLLMRecord | Mapping[str, Any]]` into a `LocalLLMReport`. Dict records are coerced via `model_validate`; unknown fields are dropped.
+
+### `photon_action_memory/eval/runner.py` (modified)
+
+Added three runner functions following the existing `run_eval` / `run_fixture` / `write_metrics_report` pattern:
+
+- **`run_local_llm(records, *, model_meta, output_path)`** – Run over an iterable and optionally write JSON.
+- **`run_local_llm_fixture(fixture_path, *, model_meta, output_path)`** – Load from a JSON list or `{"records": [...]}` file and run.
+- **`write_local_llm_report(report, output_path)`** – Write aggregate JSON; creates parent directories.
+
+### `photon_action_memory/eval/__init__.py` (modified)
+
+Added imports and `__all__` entries for:
+- `LOCAL_LLM_REPORT_SCHEMA`
+- `LocalLLMModelMeta`
+- `LocalLLMRecord`
+- `LocalLLMReport`
+- `build_local_llm_report`
+- `run_local_llm`
+- `run_local_llm_fixture`
+- `write_local_llm_report`
+
+### `tests/test_local_llm_metrics.py` (new)
+
+32 focused tests covering:
+
+- Empty records produce all-zero / all-None aggregate fields.
+- Single record with required fields only.
+- Prompt tokens and context pack tokens summed and averaged.
+- `prefill_time_ms` p50/p95 with full, absent, and partial records.
+- `decode_tokens_per_second` p50/p95 with full and absent data.
+- `peak_vram_mb` p50/p95 with full and absent data.
+- `context_length_used` p50/p95 with full and absent data.
+- `cpu_fallback_rate` at 0%, 50%, and 100%.
+- `model_meta` accepted as `LocalLLMModelMeta`, partial dict, full dict, or dict with unknown fields.
+- Schema version constant and report field.
+- Report JSON excludes raw fields (`prompt`, `raw`, `records`, `cpu_fallback_occurred`).
+- Extra dict fields in records are silently ignored.
+- All optional metrics absent → all percentile fields are `None`.
+- Runner returns `LocalLLMReport` instance.
+- Runner writes aggregate JSON; raw keys absent from output.
+- Fixture loading from JSON list and `{"records": [...]}` object.
+- Fixture runner forwards `model_meta`.
+- `write_local_llm_report` creates missing parent directories.
+
+## Design Decisions
+
+**Pydantic for both `LocalLLMRecord` and `LocalLLMModelMeta`.** Unlike `PollutionRecord` (dataclass), `LocalLLMRecord` is expected to come from JSON fixtures as well as programmatic construction. Pydantic's `model_validate` handles both paths with `extra="ignore"`, which is the primary guard ensuring raw prompts never appear in records.
+
+**Optional metrics use `None` sentinel, not 0.** A `prefill_time_ms` of `None` means "not measured this turn", which is structurally distinct from a measured value of `0 ms`. Using `None` lets the aggregator exclude absent records from percentile computation without distorting the result.
+
+**`cpu_fallback_occurred: bool` in record → `cpu_fallback_rate: float` in report.** Per-turn CPU fallback is a binary event. The aggregate rate is more useful for comparing backends or quantization schemes and is the format requested in the issue.
+
+**Percentile implementation is ceiling-indexed (same as `metrics.py`).** Consistent with the existing `_percentile` helper; returns an actual observed value rather than an interpolated one.
+
+**`model_meta` is caller-supplied, not per-record.** Model configuration (size, quantization, backend) is constant across all turns in a single eval run, so it is passed once to `build_local_llm_report` rather than repeated in every record.
+
+**Averages return `0.0` on empty input.** Consistent with the `_rate` helper pattern used throughout the eval package.

--- a/dev-reports/issue-44/verification.md
+++ b/dev-reports/issue-44/verification.md
@@ -1,0 +1,77 @@
+# Issue #44 – Add Local LLM Metrics Hooks: Verification
+
+## Tool Runs
+
+### ruff format
+
+```
+$ python -m ruff format photon_action_memory/eval/local_llm.py \
+    photon_action_memory/eval/runner.py \
+    photon_action_memory/eval/__init__.py \
+    tests/test_local_llm_metrics.py
+3 files reformatted, 1 file left unchanged
+```
+
+All files are ruff-formatted.
+
+### ruff check
+
+```
+$ python -m ruff check photon_action_memory/eval/local_llm.py \
+    photon_action_memory/eval/runner.py \
+    photon_action_memory/eval/__init__.py \
+    tests/test_local_llm_metrics.py
+All checks passed!
+```
+
+Zero lint violations after auto-fix of one import-sort issue in the test file.
+
+### mypy (strict)
+
+```
+$ python -m mypy photon_action_memory/eval/local_llm.py \
+    photon_action_memory/eval/runner.py \
+    photon_action_memory/eval/__init__.py
+Success: no issues found in 3 source files
+```
+
+All three modified/new source files pass strict mypy with no errors.
+
+### pytest
+
+```
+$ python -m pytest
+...
+tests/test_local_llm_metrics.py ................................ [ 51%]
+...
+======================== 541 passed, 1 skipped in 1.59s ========================
+```
+
+- **32 new tests** in `tests/test_local_llm_metrics.py`: all pass.
+- **509 pre-existing tests**: all pass, no regressions.
+- 1 skipped: `tests/integration/test_mlx_smoke.py` (opt-in, requires the macOS MLX workflow flag — unchanged from baseline).
+
+## Acceptance Checklist
+
+| Requirement | Status |
+|---|---|
+| `local_llm.py` created in `photon_action_memory/eval/` | ✅ |
+| `prompt_tokens_per_turn` metric | ✅ |
+| `context_pack_tokens` metric | ✅ |
+| Optional `prefill_time_ms` (p50/p95) | ✅ |
+| Optional `decode_tokens_per_second` (p50/p95) | ✅ |
+| Optional `peak_vram_mb` (p50/p95) | ✅ |
+| Optional `cpu_fallback_rate` (from `cpu_fallback_occurred`) | ✅ |
+| Optional `context_length_used` (p50/p95) | ✅ |
+| Model metadata: `model_size_b`, `quantization`, `context_length`, `backend` | ✅ |
+| Absent optional metrics do not break eval runner | ✅ |
+| Reports contain no raw prompts | ✅ |
+| Export APIs updated in `eval/__init__.py` | ✅ |
+| Runner functions added to `runner.py` | ✅ |
+| Focused tests in `tests/test_local_llm_metrics.py` | ✅ (32 tests) |
+| `dev-reports/issue-44/implementation-summary.md` | ✅ |
+| `dev-reports/issue-44/verification.md` | ✅ |
+| `ruff format` clean | ✅ |
+| `ruff check` clean | ✅ |
+| `mypy` strict clean | ✅ |
+| `pytest` all pass, no regressions | ✅ (541 passed, 1 skipped) |

--- a/photon_action_memory/eval/__init__.py
+++ b/photon_action_memory/eval/__init__.py
@@ -8,6 +8,13 @@ from photon_action_memory.eval.comparison import (
     ConditionSummary,
     build_comparison_report,
 )
+from photon_action_memory.eval.local_llm import (
+    LOCAL_LLM_REPORT_SCHEMA,
+    LocalLLMModelMeta,
+    LocalLLMRecord,
+    LocalLLMReport,
+    build_local_llm_report,
+)
 from photon_action_memory.eval.metrics import (
     EvalAction,
     EvalSuggestion,
@@ -28,7 +35,10 @@ from photon_action_memory.eval.runner import (
     run_comparison_fixture,
     run_eval,
     run_fixture,
+    run_local_llm,
+    run_local_llm_fixture,
     write_comparison_report,
+    write_local_llm_report,
     write_metrics_report,
 )
 from photon_action_memory.eval.summary_fidelity import SummaryFidelityChecker
@@ -36,18 +46,23 @@ from photon_action_memory.eval.summary_fidelity import SummaryFidelityChecker
 __all__ = [
     "COMPARISON_REPORT_SCHEMA",
     "EVAL_CONDITIONS",
+    "LOCAL_LLM_REPORT_SCHEMA",
     "EvalAction",
     "EvalSuggestion",
     "EvalWarning",
     "ComparisonRecord",
     "ComparisonReport",
     "ConditionSummary",
+    "LocalLLMModelMeta",
+    "LocalLLMRecord",
+    "LocalLLMReport",
     "MetricsReport",
     "PollutionRecord",
     "PollutionReport",
     "ShadowEvalRecord",
     "SummaryFidelityChecker",
     "build_comparison_report",
+    "build_local_llm_report",
     "build_metrics_report",
     "build_pollution_report",
     "load_fixture",
@@ -56,6 +71,9 @@ __all__ = [
     "run_comparison_fixture",
     "run_eval",
     "run_fixture",
+    "run_local_llm",
+    "run_local_llm_fixture",
     "write_comparison_report",
+    "write_local_llm_report",
     "write_metrics_report",
 ]

--- a/photon_action_memory/eval/local_llm.py
+++ b/photon_action_memory/eval/local_llm.py
@@ -1,0 +1,157 @@
+"""Aggregate-only metrics hooks for local LLM evaluation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from math import ceil
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+LOCAL_LLM_REPORT_SCHEMA: str = "local-llm-metrics.v1"
+
+
+class LocalLLMModelMeta(BaseModel):
+    """Model metadata describing the local LLM under evaluation."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    model_size_b: float | None = None
+    quantization: str | None = None
+    context_length: int | None = None
+    backend: str | None = None
+
+
+class LocalLLMRecord(BaseModel):
+    """Per-turn local LLM performance measurements.
+
+    All optional fields default to ``None``; absent fields are excluded from
+    aggregate percentiles without affecting other metrics or breaking the runner.
+    Raw prompts and tool outputs are never part of this schema.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    prompt_tokens_per_turn: int = Field(default=0, ge=0)
+    context_pack_tokens: int = Field(default=0, ge=0)
+    prefill_time_ms: float | None = Field(default=None, ge=0)
+    decode_tokens_per_second: float | None = Field(default=None, ge=0)
+    peak_vram_mb: float | None = Field(default=None, ge=0)
+    context_length_used: int | None = Field(default=None, ge=0)
+    cpu_fallback_occurred: bool = False
+
+
+class LocalLLMReport(BaseModel):
+    """Aggregate-only local LLM metrics report.
+
+    All values are totals, averages, or percentiles across the input records.
+    No raw logs, prompts, or tool outputs are included.
+    """
+
+    schema_version: Literal["local-llm-metrics.v1"] = "local-llm-metrics.v1"
+    total_records: int
+    model_meta: LocalLLMModelMeta | None
+    total_prompt_tokens: int
+    avg_prompt_tokens_per_turn: float
+    total_context_pack_tokens: int
+    avg_context_pack_tokens_per_turn: float
+    prefill_time_ms_p50: float | None
+    prefill_time_ms_p95: float | None
+    decode_tokens_per_second_p50: float | None
+    decode_tokens_per_second_p95: float | None
+    peak_vram_mb_p50: float | None
+    peak_vram_mb_p95: float | None
+    cpu_fallback_rate: float
+    context_length_used_p50: float | None
+    context_length_used_p95: float | None
+
+
+RawLocalLLMRecord = LocalLLMRecord | Mapping[str, Any]
+
+
+def build_local_llm_report(
+    records: Sequence[RawLocalLLMRecord],
+    *,
+    model_meta: LocalLLMModelMeta | Mapping[str, Any] | None = None,
+) -> LocalLLMReport:
+    """Build an aggregate local LLM metrics report from per-turn records.
+
+    All optional per-turn fields are excluded from aggregate computation when
+    absent; missing fields never raise errors or distort other metrics.
+    """
+    parsed = [_coerce_record(r) for r in records]
+
+    coerced_meta: LocalLLMModelMeta | None = None
+    if model_meta is not None:
+        if isinstance(model_meta, LocalLLMModelMeta):
+            coerced_meta = model_meta
+        else:
+            coerced_meta = LocalLLMModelMeta.model_validate(model_meta)
+
+    total_prompt_tokens = sum(r.prompt_tokens_per_turn for r in parsed)
+    total_context_pack_tokens = sum(r.context_pack_tokens for r in parsed)
+
+    prefill_times = sorted(
+        float(r.prefill_time_ms) for r in parsed if r.prefill_time_ms is not None
+    )
+    decode_speeds = sorted(
+        float(r.decode_tokens_per_second) for r in parsed if r.decode_tokens_per_second is not None
+    )
+    vram_values = sorted(float(r.peak_vram_mb) for r in parsed if r.peak_vram_mb is not None)
+    context_lengths = sorted(
+        float(r.context_length_used) for r in parsed if r.context_length_used is not None
+    )
+
+    cpu_fallback_count = sum(1 for r in parsed if r.cpu_fallback_occurred)
+
+    return LocalLLMReport(
+        total_records=len(parsed),
+        model_meta=coerced_meta,
+        total_prompt_tokens=total_prompt_tokens,
+        avg_prompt_tokens_per_turn=_avg(total_prompt_tokens, len(parsed)),
+        total_context_pack_tokens=total_context_pack_tokens,
+        avg_context_pack_tokens_per_turn=_avg(total_context_pack_tokens, len(parsed)),
+        prefill_time_ms_p50=_percentile(prefill_times, 50),
+        prefill_time_ms_p95=_percentile(prefill_times, 95),
+        decode_tokens_per_second_p50=_percentile(decode_speeds, 50),
+        decode_tokens_per_second_p95=_percentile(decode_speeds, 95),
+        peak_vram_mb_p50=_percentile(vram_values, 50),
+        peak_vram_mb_p95=_percentile(vram_values, 95),
+        cpu_fallback_rate=_rate(cpu_fallback_count, len(parsed)),
+        context_length_used_p50=_percentile(context_lengths, 50),
+        context_length_used_p95=_percentile(context_lengths, 95),
+    )
+
+
+def _coerce_record(record: RawLocalLLMRecord) -> LocalLLMRecord:
+    if isinstance(record, LocalLLMRecord):
+        return record
+    return LocalLLMRecord.model_validate(record)
+
+
+def _avg(total: int, count: int) -> float:
+    if count == 0:
+        return 0.0
+    return total / count
+
+
+def _rate(count: int, total: int) -> float:
+    if total == 0:
+        return 0.0
+    return count / total
+
+
+def _percentile(sorted_values: Sequence[float], percentile: int) -> float | None:
+    if not sorted_values:
+        return None
+    index = max(0, ceil((percentile / 100) * len(sorted_values)) - 1)
+    return sorted_values[index]
+
+
+__all__ = [
+    "LOCAL_LLM_REPORT_SCHEMA",
+    "LocalLLMModelMeta",
+    "LocalLLMRecord",
+    "LocalLLMReport",
+    "build_local_llm_report",
+]

--- a/photon_action_memory/eval/runner.py
+++ b/photon_action_memory/eval/runner.py
@@ -12,6 +12,12 @@ from photon_action_memory.eval.comparison import (
     RawComparisonRecord,
     build_comparison_report,
 )
+from photon_action_memory.eval.local_llm import (
+    LocalLLMModelMeta,
+    LocalLLMReport,
+    RawLocalLLMRecord,
+    build_local_llm_report,
+)
 from photon_action_memory.eval.metrics import MetricsReport, RawRecord, build_metrics_report
 
 
@@ -91,12 +97,45 @@ def write_comparison_report(report: ComparisonReport, output_path: str | Path) -
     path.write_text(report.model_dump_json(indent=2) + "\n", encoding="utf-8")
 
 
+def run_local_llm(
+    records: Iterable[RawLocalLLMRecord],
+    *,
+    model_meta: LocalLLMModelMeta | Mapping[str, Any] | None = None,
+    output_path: str | Path | None = None,
+) -> LocalLLMReport:
+    """Run local LLM metrics over normalized records and optionally write aggregate JSON."""
+    report = build_local_llm_report(list(records), model_meta=model_meta)
+    if output_path is not None:
+        write_local_llm_report(report, output_path)
+    return report
+
+
+def run_local_llm_fixture(
+    fixture_path: str | Path,
+    *,
+    model_meta: LocalLLMModelMeta | Mapping[str, Any] | None = None,
+    output_path: str | Path | None = None,
+) -> LocalLLMReport:
+    """Load a JSON fixture and run aggregate local LLM metrics."""
+    return run_local_llm(load_fixture(fixture_path), model_meta=model_meta, output_path=output_path)
+
+
+def write_local_llm_report(report: LocalLLMReport, output_path: str | Path) -> None:
+    """Write the aggregate local LLM report without raw fixture records."""
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(report.model_dump_json(indent=2) + "\n", encoding="utf-8")
+
+
 __all__ = [
     "load_fixture",
     "run_comparison",
     "run_comparison_fixture",
     "run_eval",
     "run_fixture",
+    "run_local_llm",
+    "run_local_llm_fixture",
     "write_comparison_report",
+    "write_local_llm_report",
     "write_metrics_report",
 ]

--- a/tests/test_local_llm_metrics.py
+++ b/tests/test_local_llm_metrics.py
@@ -1,0 +1,417 @@
+"""Tests for photon_action_memory.eval.local_llm."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from photon_action_memory.eval.local_llm import (
+    LOCAL_LLM_REPORT_SCHEMA,
+    LocalLLMModelMeta,
+    LocalLLMRecord,
+    LocalLLMReport,
+    build_local_llm_report,
+)
+from photon_action_memory.eval.runner import (
+    run_local_llm,
+    run_local_llm_fixture,
+    write_local_llm_report,
+)
+
+# ---------------------------------------------------------------------------
+# Empty records
+# ---------------------------------------------------------------------------
+
+
+def test_empty_records_returns_zero_report() -> None:
+    report = build_local_llm_report([])
+
+    assert report.total_records == 0
+    assert report.total_prompt_tokens == 0
+    assert report.avg_prompt_tokens_per_turn == 0.0
+    assert report.total_context_pack_tokens == 0
+    assert report.avg_context_pack_tokens_per_turn == 0.0
+    assert report.prefill_time_ms_p50 is None
+    assert report.prefill_time_ms_p95 is None
+    assert report.decode_tokens_per_second_p50 is None
+    assert report.decode_tokens_per_second_p95 is None
+    assert report.peak_vram_mb_p50 is None
+    assert report.peak_vram_mb_p95 is None
+    assert report.cpu_fallback_rate == 0.0
+    assert report.context_length_used_p50 is None
+    assert report.context_length_used_p95 is None
+    assert report.model_meta is None
+
+
+# ---------------------------------------------------------------------------
+# Required fields: prompt_tokens_per_turn and context_pack_tokens
+# ---------------------------------------------------------------------------
+
+
+def test_single_record_required_only() -> None:
+    report = build_local_llm_report(
+        [LocalLLMRecord(prompt_tokens_per_turn=100, context_pack_tokens=50)]
+    )
+
+    assert report.total_records == 1
+    assert report.total_prompt_tokens == 100
+    assert report.avg_prompt_tokens_per_turn == 100.0
+    assert report.total_context_pack_tokens == 50
+    assert report.avg_context_pack_tokens_per_turn == 50.0
+    assert report.cpu_fallback_rate == 0.0
+
+
+def test_prompt_tokens_summed_and_averaged() -> None:
+    records = [
+        LocalLLMRecord(prompt_tokens_per_turn=100),
+        LocalLLMRecord(prompt_tokens_per_turn=200),
+        LocalLLMRecord(prompt_tokens_per_turn=300),
+    ]
+    report = build_local_llm_report(records)
+
+    assert report.total_prompt_tokens == 600
+    assert report.avg_prompt_tokens_per_turn == pytest.approx(200.0)
+
+
+def test_context_pack_tokens_summed_and_averaged() -> None:
+    records = [
+        LocalLLMRecord(context_pack_tokens=40),
+        LocalLLMRecord(context_pack_tokens=60),
+    ]
+    report = build_local_llm_report(records)
+
+    assert report.total_context_pack_tokens == 100
+    assert report.avg_context_pack_tokens_per_turn == 50.0
+
+
+# ---------------------------------------------------------------------------
+# Optional: prefill_time_ms percentiles
+# ---------------------------------------------------------------------------
+
+
+def test_prefill_time_percentiles() -> None:
+    records = [
+        LocalLLMRecord(prefill_time_ms=100.0),
+        LocalLLMRecord(prefill_time_ms=200.0),
+        LocalLLMRecord(prefill_time_ms=300.0),
+        LocalLLMRecord(prefill_time_ms=400.0),
+    ]
+    report = build_local_llm_report(records)
+
+    assert report.prefill_time_ms_p50 == 200.0
+    assert report.prefill_time_ms_p95 == 400.0
+
+
+def test_prefill_time_absent_gives_none() -> None:
+    report = build_local_llm_report([LocalLLMRecord(), LocalLLMRecord()])
+
+    assert report.prefill_time_ms_p50 is None
+    assert report.prefill_time_ms_p95 is None
+
+
+def test_partial_prefill_time_excludes_absent_records() -> None:
+    records = [
+        LocalLLMRecord(prefill_time_ms=100.0),
+        LocalLLMRecord(),
+        LocalLLMRecord(prefill_time_ms=300.0),
+    ]
+    report = build_local_llm_report(records)
+
+    assert report.prefill_time_ms_p50 == 100.0
+    assert report.prefill_time_ms_p95 == 300.0
+
+
+# ---------------------------------------------------------------------------
+# Optional: decode_tokens_per_second percentiles
+# ---------------------------------------------------------------------------
+
+
+def test_decode_throughput_percentiles() -> None:
+    records = [
+        LocalLLMRecord(decode_tokens_per_second=50.0),
+        LocalLLMRecord(decode_tokens_per_second=100.0),
+    ]
+    report = build_local_llm_report(records)
+
+    assert report.decode_tokens_per_second_p50 == 50.0
+    assert report.decode_tokens_per_second_p95 == 100.0
+
+
+def test_decode_throughput_absent_gives_none() -> None:
+    report = build_local_llm_report([LocalLLMRecord()])
+
+    assert report.decode_tokens_per_second_p50 is None
+    assert report.decode_tokens_per_second_p95 is None
+
+
+# ---------------------------------------------------------------------------
+# Optional: peak_vram_mb percentiles
+# ---------------------------------------------------------------------------
+
+
+def test_peak_vram_percentiles() -> None:
+    records = [
+        LocalLLMRecord(peak_vram_mb=1024.0),
+        LocalLLMRecord(peak_vram_mb=2048.0),
+        LocalLLMRecord(peak_vram_mb=4096.0),
+    ]
+    report = build_local_llm_report(records)
+
+    assert report.peak_vram_mb_p50 == 2048.0
+    assert report.peak_vram_mb_p95 == 4096.0
+
+
+def test_peak_vram_absent_gives_none() -> None:
+    report = build_local_llm_report([LocalLLMRecord()])
+
+    assert report.peak_vram_mb_p50 is None
+    assert report.peak_vram_mb_p95 is None
+
+
+# ---------------------------------------------------------------------------
+# Optional: context_length_used percentiles
+# ---------------------------------------------------------------------------
+
+
+def test_context_length_used_percentiles() -> None:
+    records = [
+        LocalLLMRecord(context_length_used=1000),
+        LocalLLMRecord(context_length_used=2000),
+        LocalLLMRecord(context_length_used=3000),
+    ]
+    report = build_local_llm_report(records)
+
+    assert report.context_length_used_p50 == 2000.0
+    assert report.context_length_used_p95 == 3000.0
+
+
+def test_context_length_used_absent_gives_none() -> None:
+    report = build_local_llm_report([LocalLLMRecord()])
+
+    assert report.context_length_used_p50 is None
+    assert report.context_length_used_p95 is None
+
+
+# ---------------------------------------------------------------------------
+# Optional: cpu_fallback_rate
+# ---------------------------------------------------------------------------
+
+
+def test_cpu_fallback_rate_zero_when_none_occurred() -> None:
+    records = [LocalLLMRecord(), LocalLLMRecord(), LocalLLMRecord()]
+    report = build_local_llm_report(records)
+
+    assert report.cpu_fallback_rate == 0.0
+
+
+def test_cpu_fallback_rate_computed_from_occurred() -> None:
+    records = [
+        LocalLLMRecord(cpu_fallback_occurred=True),
+        LocalLLMRecord(cpu_fallback_occurred=False),
+        LocalLLMRecord(cpu_fallback_occurred=True),
+        LocalLLMRecord(cpu_fallback_occurred=False),
+    ]
+    report = build_local_llm_report(records)
+
+    assert report.cpu_fallback_rate == pytest.approx(0.5)
+
+
+def test_cpu_fallback_rate_all_fallback() -> None:
+    records = [LocalLLMRecord(cpu_fallback_occurred=True)] * 3
+    report = build_local_llm_report(records)
+
+    assert report.cpu_fallback_rate == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Model metadata
+# ---------------------------------------------------------------------------
+
+
+def test_model_meta_none_by_default() -> None:
+    report = build_local_llm_report([LocalLLMRecord()])
+
+    assert report.model_meta is None
+
+
+def test_model_meta_all_fields_included() -> None:
+    meta = LocalLLMModelMeta(
+        model_size_b=7.0,
+        quantization="q4_0",
+        context_length=4096,
+        backend="llama.cpp",
+    )
+    report = build_local_llm_report([LocalLLMRecord()], model_meta=meta)
+
+    assert report.model_meta is not None
+    assert report.model_meta.model_size_b == 7.0
+    assert report.model_meta.quantization == "q4_0"
+    assert report.model_meta.context_length == 4096
+    assert report.model_meta.backend == "llama.cpp"
+
+
+def test_model_meta_partial_fields() -> None:
+    meta = LocalLLMModelMeta(backend="mlx")
+    report = build_local_llm_report([LocalLLMRecord()], model_meta=meta)
+
+    assert report.model_meta is not None
+    assert report.model_meta.backend == "mlx"
+    assert report.model_meta.model_size_b is None
+    assert report.model_meta.quantization is None
+    assert report.model_meta.context_length is None
+
+
+def test_model_meta_from_dict() -> None:
+    meta: dict[str, object] = {"model_size_b": 13.0, "backend": "ollama"}
+    report = build_local_llm_report([LocalLLMRecord()], model_meta=meta)
+
+    assert report.model_meta is not None
+    assert report.model_meta.model_size_b == 13.0
+    assert report.model_meta.backend == "ollama"
+
+
+def test_model_meta_extra_fields_ignored() -> None:
+    meta: dict[str, object] = {"backend": "transformers", "unknown_field": "value"}
+    report = build_local_llm_report([LocalLLMRecord()], model_meta=meta)
+
+    assert report.model_meta is not None
+    assert report.model_meta.backend == "transformers"
+
+
+# ---------------------------------------------------------------------------
+# Schema version and report shape
+# ---------------------------------------------------------------------------
+
+
+def test_schema_version_constant() -> None:
+    assert LOCAL_LLM_REPORT_SCHEMA == "local-llm-metrics.v1"
+
+
+def test_schema_version_in_report() -> None:
+    report = build_local_llm_report([])
+
+    assert report.schema_version == "local-llm-metrics.v1"
+
+
+def test_report_excludes_raw_fields() -> None:
+    report = build_local_llm_report([LocalLLMRecord(prompt_tokens_per_turn=100)])
+    payload = json.loads(report.model_dump_json())
+
+    assert "prompt" not in payload
+    assert "raw" not in payload
+    assert "records" not in payload
+    assert "cpu_fallback_occurred" not in payload
+
+
+def test_extra_record_fields_ignored() -> None:
+    raw: dict[str, object] = {
+        "prompt_tokens_per_turn": 50,
+        "raw_prompt": "secret prompt text",
+        "tool_output": "grep output here",
+    }
+    report = build_local_llm_report([raw])
+    payload = json.loads(report.model_dump_json())
+
+    assert report.total_prompt_tokens == 50
+    assert "raw_prompt" not in payload
+    assert "tool_output" not in payload
+
+
+def test_all_optional_metrics_absent_gives_none_percentiles() -> None:
+    records = [LocalLLMRecord(prompt_tokens_per_turn=100)] * 5
+    report = build_local_llm_report(records)
+
+    assert report.prefill_time_ms_p50 is None
+    assert report.decode_tokens_per_second_p50 is None
+    assert report.peak_vram_mb_p50 is None
+    assert report.context_length_used_p50 is None
+
+
+# ---------------------------------------------------------------------------
+# Runner integration
+# ---------------------------------------------------------------------------
+
+
+def test_runner_run_local_llm_returns_report() -> None:
+    records = [{"prompt_tokens_per_turn": 100, "context_pack_tokens": 50}]
+    report = run_local_llm(records)
+
+    assert isinstance(report, LocalLLMReport)
+    assert report.total_records == 1
+    assert report.total_prompt_tokens == 100
+
+
+def test_runner_writes_aggregate_json(tmp_path: Path) -> None:
+    output_path = tmp_path / "local_llm.json"
+    records = [
+        {"prompt_tokens_per_turn": 100, "context_pack_tokens": 50},
+        {"prompt_tokens_per_turn": 200, "cpu_fallback_occurred": True},
+    ]
+    report = run_local_llm(records, output_path=output_path)
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+
+    assert payload == report.model_dump(mode="json")
+    assert "total_records" in payload
+    assert "avg_prompt_tokens_per_turn" in payload
+    assert "cpu_fallback_rate" in payload
+    assert "records" not in payload
+    assert "prompt" not in payload
+    assert "cpu_fallback_occurred" not in payload
+
+
+def test_runner_loads_list_fixture(tmp_path: Path) -> None:
+    fixture = [
+        {"prompt_tokens_per_turn": 100, "cpu_fallback_occurred": True},
+        {"prompt_tokens_per_turn": 200, "cpu_fallback_occurred": False},
+    ]
+    fixture_path = tmp_path / "fixture.json"
+    fixture_path.write_text(json.dumps(fixture), encoding="utf-8")
+
+    report = run_local_llm_fixture(fixture_path)
+
+    assert report.total_records == 2
+    assert report.total_prompt_tokens == 300
+    assert report.cpu_fallback_rate == pytest.approx(0.5)
+
+
+def test_runner_loads_object_fixture(tmp_path: Path) -> None:
+    fixture = {
+        "records": [
+            {"prompt_tokens_per_turn": 80, "prefill_time_ms": 50.0},
+            {"prompt_tokens_per_turn": 120, "prefill_time_ms": 150.0},
+        ]
+    }
+    fixture_path = tmp_path / "fixture.json"
+    fixture_path.write_text(json.dumps(fixture), encoding="utf-8")
+
+    report = run_local_llm_fixture(fixture_path)
+
+    assert report.total_records == 2
+    assert report.total_prompt_tokens == 200
+    assert report.prefill_time_ms_p50 == 50.0
+    assert report.prefill_time_ms_p95 == 150.0
+
+
+def test_runner_passes_model_meta_to_fixture(tmp_path: Path) -> None:
+    fixture_path = tmp_path / "fixture.json"
+    fixture_path.write_text(json.dumps([{"prompt_tokens_per_turn": 100}]), encoding="utf-8")
+    meta = LocalLLMModelMeta(backend="mlx", quantization="q8_0")
+
+    report = run_local_llm_fixture(fixture_path, model_meta=meta)
+
+    assert report.model_meta is not None
+    assert report.model_meta.backend == "mlx"
+    assert report.model_meta.quantization == "q8_0"
+
+
+def test_write_local_llm_report_creates_parent_dirs(tmp_path: Path) -> None:
+    report = build_local_llm_report([LocalLLMRecord(prompt_tokens_per_turn=50)])
+    output_path = tmp_path / "nested" / "dir" / "report.json"
+
+    write_local_llm_report(report, output_path)
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "local-llm-metrics.v1"
+    assert payload["total_records"] == 1


### PR DESCRIPTION
## Summary
- Add aggregate-only local LLM metrics hooks for prompt/context tokens and optional runtime metrics.
- Record model metadata for size, quantization, context length, and backend without requiring metrics to be present.
- Add runner APIs and JSON writer for privacy-safe local LLM reports.
- Add focused tests and dev reports for issue #44.

## Verification
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m mypy photon_action_memory tests`
- `python -m pytest -q`

Closes #44