### PR TITLE
#45 Add PHOTON context scorer interfaces

### DIFF
--- a/dev-reports/issue-45/implementation-summary.md
+++ b/dev-reports/issue-45/implementation-summary.md
@@ -1,0 +1,85 @@
+# Issue #45 — PHOTON Context Scorer Interfaces
+
+## What was added
+
+### `photon_action_memory/models/context_scorer.py`
+
+New module providing the Context Firewall scoring layer so PHOTON can plug into
+the four admission-pipeline decisions:
+
+| Dimension | Scorer method | Returns |
+|-----------|--------------|---------|
+| Context admission priority | `score_admission` | `list[AdmissionScore]` |
+| Evidence expansion priority | `score_evidence_expansion` | `list[EvidenceExpansionScore]` |
+| Summary usefulness for task | `score_summary_usefulness` | `list[SummaryUsefulnessScore]` |
+| Staleness risk | `score_staleness_risk` | `list[StalenessRiskScore]` |
+
+#### Public types
+
+- **Score result dataclasses** — `AdmissionScore`, `EvidenceExpansionScore`,
+  `SummaryUsefulnessScore`, `StalenessRiskScore` — each frozen, carrying
+  `item_id`, `score`/`risk` (float in [0,1]), and `reason` string.
+- **`ScoringEvent`** — frozen dataclass emitted to the optional eval hook after
+  each scored item.  Fields: `scorer_kind`, `item_id`, `score`, `reason`.
+- **`ContextScorerHook`** — type alias `Callable[[ScoringEvent], None]`; passed
+  to `FallbackContextScorer(eval_hook=...)`.
+- **`ContextScorerProtocol`** — `@runtime_checkable Protocol` defining the four
+  scoring methods.  Any class exposing these methods satisfies it.
+- **`FallbackContextScorer`** — deterministic implementation requiring no model.
+
+#### FallbackContextScorer scoring logic
+
+**Admission** (`score_admission`):
+- Weighted richness: `facts×3 + hypotheses×2 + failed_attempts + avoid`
+- Normalised by ceiling of 12, then multiplied by a validity factor
+  (`valid=1.0`, `partial=0.7`, `unknown=0.5`, `stale=0.2`, `contradicted=0.1`).
+- Empty summaries (richness=0) always score 0.0.
+
+**Evidence expansion** (`score_evidence_expansion`):
+- Base score from `expand_policy` (`always=0.9`, `on_demand_only=0.5`, `deny=0.0`).
+- `deny` short-circuits to 0.0.  Otherwise penalised by staleness risk×0.5.
+
+**Summary usefulness** (`score_summary_usefulness`):
+- Task-text word overlap (70 %) + content richness (30 %).
+- Falls back to half-richness score when `task_text` is empty.
+
+**Staleness risk** (`score_staleness_risk`):
+- Direct table lookup: `valid→0.0`, `partial→0.3`, `unknown→0.5`,
+  `stale→0.8`, `contradicted→1.0`; unknown status defaults to 0.5.
+
+#### Eval comparison hooks
+
+Passing `eval_hook=fn` to `FallbackContextScorer` causes `fn(ScoringEvent(…))`
+to be called after every scored item.  Callers can aggregate these events into
+`ComparisonRecord` fields (e.g. `total_summaries_evaluated`) for the eval
+comparison framework in `eval/comparison.py`.
+
+#### MLX-free guarantee
+
+The module imports only:
+- `collections.abc.{Callable,Sequence}`
+- `dataclasses.dataclass`
+- `typing.{Protocol,runtime_checkable}`
+- `photon_action_memory.api.schema_v2.{ActionSummary,EvidenceRef}`
+
+`mlx.core` is never imported at module level or by the fallback scorer.
+
+### `tests/test_context_scorer.py`
+
+40 smoke tests grouped by scorer dimension:
+
+- **Admission** (9 tests) — empty input, no-content zero score, positive score,
+  stale < valid, contradicted < stale, clamp to [0,1], determinism, ID
+  preservation, correct list length.
+- **Evidence expansion** (6 tests) — deny=0, always>0.5, on_demand mid range,
+  stale penalty, ID preservation, empty list.
+- **Summary usefulness** (5 tests) — empty list, low score with no task text,
+  matching task text raises score, no-overlap fallback, determinism.
+- **Staleness risk** (7 tests) — empty list, valid=0.0, contradicted=1.0,
+  stale>0.5, partial ordering, unknown mid-range, ID preservation.
+- **Eval hook** (8 tests) — hook called per item, correct `scorer_kind` for all
+  four dimensions, event carries item_id + score, no-hook does not raise, hook
+  not called for empty input.
+- **Injectable scorer / Protocol** (5 tests) — `FallbackContextScorer`
+  satisfies protocol, `_FixedScorer` satisfies protocol, fixed scores returned,
+  callable through Protocol-typed parameter.

--- a/dev-reports/issue-45/verification.md
+++ b/dev-reports/issue-45/verification.md
@@ -1,0 +1,41 @@
+# Issue #45 — Verification
+
+## Commands run
+
+```
+python -m ruff format photon_action_memory/models/context_scorer.py tests/test_context_scorer.py
+python -m ruff check  photon_action_memory/models/context_scorer.py tests/test_context_scorer.py
+python -m mypy photon_action_memory/
+python -m pytest tests/test_context_scorer.py -v
+python -m pytest --tb=short -q
+```
+
+## Results
+
+| Check | Result |
+|-------|--------|
+| `ruff format` | 2 files reformatted (style-only changes) |
+| `ruff check` | All checks passed |
+| `mypy photon_action_memory/` | Success: no issues found in 40 source files |
+| `pytest tests/test_context_scorer.py` | **40 passed** in 0.06 s |
+| `pytest` (full suite) | **549 passed**, 1 skipped (MLX smoke opt-in) |
+
+No regressions in existing tests.
+
+## Acceptance criteria
+
+| Criterion | Status |
+|-----------|--------|
+| `photon_action_memory/models/context_scorer.py` added | ✓ |
+| Context admission scoring interface | ✓ `score_admission` |
+| Evidence expansion scoring interface | ✓ `score_evidence_expansion` |
+| Summary usefulness scoring interface | ✓ `score_summary_usefulness` |
+| Staleness risk scoring interface | ✓ `score_staleness_risk` |
+| Deterministic fallback when model unavailable | ✓ `FallbackContextScorer` |
+| Normal imports are MLX-free | ✓ verified by import path analysis |
+| Eval comparison hooks | ✓ `ContextScorerHook` / `ScoringEvent` |
+| Runtime-checkable Protocol | ✓ `ContextScorerProtocol` |
+| Smoke tests: fallback scorer | ✓ 35 tests |
+| Smoke tests: injectable scorer | ✓ 5 tests |
+| `dev-reports/issue-45/implementation-summary.md` | ✓ |
+| `dev-reports/issue-45/verification.md` | ✓ |

--- a/photon_action_memory/models/context_scorer.py
+++ b/photon_action_memory/models/context_scorer.py
@@ -1,0 +1,323 @@
+"""Context Firewall scoring interfaces for PHOTON.
+
+Provides score result types, a runtime-checkable Protocol, and a deterministic
+FallbackContextScorer that requires no trained model.
+
+This module is MLX-free at import time; normal imports never touch mlx.core.
+An optional eval_hook callable receives a ScoringEvent after each scored item,
+enabling integration with the eval comparison framework (eval/comparison.py).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from photon_action_memory.api.schema_v2 import ActionSummary, EvidenceRef
+
+# ---------------------------------------------------------------------------
+# Score result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AdmissionScore:
+    """Admission priority score for an ActionSummary."""
+
+    summary_id: str
+    score: float  # 0.0 = low priority, 1.0 = high priority
+    reason: str
+
+
+@dataclass(frozen=True)
+class EvidenceExpansionScore:
+    """Expansion priority score for an EvidenceRef."""
+
+    evidence_id: str
+    score: float  # 0.0 = skip, 1.0 = expand first
+    reason: str
+
+
+@dataclass(frozen=True)
+class SummaryUsefulnessScore:
+    """Usefulness score for an ActionSummary relative to the current task."""
+
+    summary_id: str
+    score: float  # 0.0 = not useful, 1.0 = highly useful
+    reason: str
+
+
+@dataclass(frozen=True)
+class StalenessRiskScore:
+    """Staleness risk score for an ActionSummary."""
+
+    summary_id: str
+    risk: float  # 0.0 = fresh, 1.0 = highly stale
+    reason: str
+
+
+# ---------------------------------------------------------------------------
+# Eval hook support
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScoringEvent:
+    """Emitted to the optional eval_hook after each scored item.
+
+    scorer_kind is one of: "admission", "evidence_expansion",
+    "summary_usefulness", "staleness_risk".  Callers may aggregate these
+    events into ComparisonRecord fields for the eval/comparison framework.
+    """
+
+    scorer_kind: str
+    item_id: str
+    score: float
+    reason: str
+
+
+ContextScorerHook = Callable[[ScoringEvent], None]
+
+
+# ---------------------------------------------------------------------------
+# ContextScorerProtocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class ContextScorerProtocol(Protocol):
+    """Runtime-checkable Protocol for PHOTON Context Firewall scorers.
+
+    Implementations must remain importable without MLX. Use
+    FallbackContextScorer when no model is configured.
+    """
+
+    def score_admission(
+        self,
+        summaries: Sequence[ActionSummary],
+        *,
+        task_text: str = "",
+    ) -> list[AdmissionScore]: ...
+
+    def score_evidence_expansion(
+        self,
+        evidence_refs: Sequence[EvidenceRef],
+        *,
+        task_text: str = "",
+    ) -> list[EvidenceExpansionScore]: ...
+
+    def score_summary_usefulness(
+        self,
+        summaries: Sequence[ActionSummary],
+        *,
+        task_text: str = "",
+    ) -> list[SummaryUsefulnessScore]: ...
+
+    def score_staleness_risk(
+        self,
+        summaries: Sequence[ActionSummary],
+    ) -> list[StalenessRiskScore]: ...
+
+
+# ---------------------------------------------------------------------------
+# Scoring constants
+# ---------------------------------------------------------------------------
+
+# Staleness risk mapped from validity.status
+_STALENESS_RISK: dict[str, float] = {
+    "valid": 0.0,
+    "partial": 0.3,
+    "unknown": 0.5,
+    "stale": 0.8,
+    "contradicted": 1.0,
+}
+
+# Admission multiplier per validity status
+_VALIDITY_ADMISSION_FACTOR: dict[str, float] = {
+    "valid": 1.0,
+    "partial": 0.7,
+    "unknown": 0.5,
+    "stale": 0.2,
+    "contradicted": 0.1,
+}
+
+# Base expansion score per expand_policy
+_EXPAND_POLICY_BASE: dict[str, float] = {
+    "always": 0.9,
+    "on_demand_only": 0.5,
+    "deny": 0.0,
+}
+
+# Weighted content count that maps to a raw admission score of 1.0
+_RICHNESS_CEILING = 12
+
+
+# ---------------------------------------------------------------------------
+# FallbackContextScorer
+# ---------------------------------------------------------------------------
+
+
+class FallbackContextScorer:
+    """Deterministic context scorer that requires no trained model.
+
+    Scores derive entirely from structural properties of the summaries:
+
+    - Admission: weighted content count × validity factor.
+    - Evidence expansion: expand_policy base × staleness adjustment.
+    - Summary usefulness: task-text word overlap + content richness.
+    - Staleness risk: direct mapping from validity.status.
+
+    All scores are clamped to [0.0, 1.0].  Calling the same scorer with the
+    same inputs always returns the same result (no randomness).
+    """
+
+    def __init__(self, *, eval_hook: ContextScorerHook | None = None) -> None:
+        self._hook = eval_hook
+
+    def score_admission(
+        self,
+        summaries: Sequence[ActionSummary],
+        *,
+        task_text: str = "",
+    ) -> list[AdmissionScore]:
+        """Score summaries for context admission priority."""
+        results: list[AdmissionScore] = []
+        for summary in summaries:
+            score, reason = _admission_score(summary)
+            result = AdmissionScore(summary_id=summary.summary_id, score=score, reason=reason)
+            results.append(result)
+            if self._hook is not None:
+                self._hook(ScoringEvent("admission", summary.summary_id, score, reason))
+        return results
+
+    def score_evidence_expansion(
+        self,
+        evidence_refs: Sequence[EvidenceRef],
+        *,
+        task_text: str = "",
+    ) -> list[EvidenceExpansionScore]:
+        """Score evidence refs for expansion priority."""
+        results: list[EvidenceExpansionScore] = []
+        for ref in evidence_refs:
+            score, reason = _expansion_score(ref)
+            result = EvidenceExpansionScore(evidence_id=ref.evidence_id, score=score, reason=reason)
+            results.append(result)
+            if self._hook is not None:
+                self._hook(ScoringEvent("evidence_expansion", ref.evidence_id, score, reason))
+        return results
+
+    def score_summary_usefulness(
+        self,
+        summaries: Sequence[ActionSummary],
+        *,
+        task_text: str = "",
+    ) -> list[SummaryUsefulnessScore]:
+        """Score summaries by usefulness for the current task."""
+        results: list[SummaryUsefulnessScore] = []
+        for summary in summaries:
+            score, reason = _usefulness_score(summary, task_text)
+            result = SummaryUsefulnessScore(
+                summary_id=summary.summary_id, score=score, reason=reason
+            )
+            results.append(result)
+            if self._hook is not None:
+                self._hook(ScoringEvent("summary_usefulness", summary.summary_id, score, reason))
+        return results
+
+    def score_staleness_risk(
+        self,
+        summaries: Sequence[ActionSummary],
+    ) -> list[StalenessRiskScore]:
+        """Score summaries for staleness risk."""
+        results: list[StalenessRiskScore] = []
+        for summary in summaries:
+            risk, reason = _staleness_risk(summary)
+            result = StalenessRiskScore(summary_id=summary.summary_id, risk=risk, reason=reason)
+            results.append(result)
+            if self._hook is not None:
+                self._hook(ScoringEvent("staleness_risk", summary.summary_id, risk, reason))
+        return results
+
+
+# ---------------------------------------------------------------------------
+# Internal scoring helpers
+# ---------------------------------------------------------------------------
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def _content_richness(summary: ActionSummary) -> int:
+    """Weighted count of content items; higher = richer summary."""
+    return (
+        len(summary.facts) * 3
+        + len(summary.hypotheses) * 2
+        + len(summary.failed_attempts)
+        + len(summary.avoid)
+    )
+
+
+def _task_overlap(summary: ActionSummary, task_text: str) -> float:
+    """Word-level overlap between task_text and summary fact/hypothesis texts."""
+    if not task_text:
+        return 0.0
+    task_words = set(task_text.lower().split())
+    if not task_words:
+        return 0.0
+    content_parts: list[str] = [f.text for f in summary.facts]
+    content_parts.extend(h.text for h in summary.hypotheses)
+    content_text = " ".join(content_parts)
+    content_words = set(content_text.lower().split())
+    if not content_words:
+        return 0.0
+    return _clamp(len(task_words & content_words) / len(task_words))
+
+
+def _admission_score(summary: ActionSummary) -> tuple[float, str]:
+    richness = _content_richness(summary)
+    if richness == 0:
+        return 0.0, "fallback: no admissible content"
+    validity_factor = _VALIDITY_ADMISSION_FACTOR.get(summary.validity.status, 0.5)
+    raw = _clamp(richness / _RICHNESS_CEILING)
+    score = _clamp(raw * validity_factor)
+    return score, f"fallback: richness={richness} validity={summary.validity.status}"
+
+
+def _expansion_score(ref: EvidenceRef) -> tuple[float, str]:
+    base = _EXPAND_POLICY_BASE.get(ref.expand_policy, 0.5)
+    if base == 0.0:
+        return 0.0, "fallback: expand_policy=deny"
+    staleness_penalty = _STALENESS_RISK.get(ref.staleness.status, 0.5)
+    score = _clamp(base * (1.0 - staleness_penalty * 0.5))
+    return score, f"fallback: policy={ref.expand_policy} staleness={ref.staleness.status}"
+
+
+def _usefulness_score(summary: ActionSummary, task_text: str) -> tuple[float, str]:
+    richness = _content_richness(summary)
+    richness_score = _clamp(richness / _RICHNESS_CEILING)
+    if not task_text:
+        score = _clamp(richness_score * 0.5)
+        return score, "fallback: no task context"
+    overlap = _task_overlap(summary, task_text)
+    score = _clamp(overlap * 0.7 + richness_score * 0.3)
+    return score, f"fallback: overlap={overlap:.2f} richness={richness}"
+
+
+def _staleness_risk(summary: ActionSummary) -> tuple[float, str]:
+    status = summary.validity.status
+    risk = _STALENESS_RISK.get(status, 0.5)
+    return risk, f"fallback: validity.status={status}"
+
+
+__all__ = [
+    "AdmissionScore",
+    "ContextScorerHook",
+    "ContextScorerProtocol",
+    "EvidenceExpansionScore",
+    "FallbackContextScorer",
+    "ScoringEvent",
+    "StalenessRiskScore",
+    "SummaryUsefulnessScore",
+]

--- a/tests/test_context_scorer.py
+++ b/tests/test_context_scorer.py
@@ -1,0 +1,421 @@
+"""Smoke tests for context_scorer: FallbackContextScorer and injectable scorer."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    ActionSummary,
+    AvoidGuidance,
+    EvidenceRef,
+    Fact,
+    FailedAttempt,
+    Hypothesis,
+    StalenessStatus,
+    Validity,
+)
+from photon_action_memory.models.context_scorer import (
+    AdmissionScore,
+    ContextScorerProtocol,
+    EvidenceExpansionScore,
+    FallbackContextScorer,
+    ScoringEvent,
+    StalenessRiskScore,
+    SummaryUsefulnessScore,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _summary(
+    summary_id: str = "sum-001",
+    *,
+    facts: list[Fact] | None = None,
+    hypotheses: list[Hypothesis] | None = None,
+    failed_attempts: list[FailedAttempt] | None = None,
+    avoid: list[AvoidGuidance] | None = None,
+    validity_status: str = "valid",
+) -> ActionSummary:
+    return ActionSummary(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        summary_id=summary_id,
+        session_id="sess-1",
+        facts=facts or [],
+        hypotheses=hypotheses or [],
+        failed_attempts=failed_attempts or [],
+        avoid=avoid or [],
+        validity=Validity(status=validity_status),
+    )
+
+
+def _fact(text: str = "a fact") -> Fact:
+    return Fact(text=text, evidence_ids=["ev-1"])
+
+
+def _hypothesis(text: str = "a hypothesis") -> Hypothesis:
+    return Hypothesis(text=text, confidence=0.5)
+
+
+def _failed(action: str = "grep foo") -> FailedAttempt:
+    return FailedAttempt(action=action, outcome="error", evidence_ids=[])
+
+
+def _avoid(action: str = "open large_file") -> AvoidGuidance:
+    return AvoidGuidance(action=action, reason="too expensive")
+
+
+def _evidence_ref(
+    evidence_id: str = "evd-001",
+    *,
+    expand_policy: str = "on_demand_only",
+    staleness_status: str = "unknown",
+) -> EvidenceRef:
+    return EvidenceRef(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        evidence_id=evidence_id,
+        kind="tool_result",
+        summary="some evidence",
+        expand_policy=expand_policy,
+        staleness=StalenessStatus(status=staleness_status),
+    )
+
+
+# ---------------------------------------------------------------------------
+# FallbackContextScorer — score_admission
+# ---------------------------------------------------------------------------
+
+
+def test_admission_empty_input_returns_empty_list() -> None:
+    scorer = FallbackContextScorer()
+    assert scorer.score_admission([]) == []
+
+
+def test_admission_no_content_returns_zero_score() -> None:
+    scorer = FallbackContextScorer()
+    results = scorer.score_admission([_summary()])
+    assert len(results) == 1
+    assert results[0].score == pytest.approx(0.0)
+
+
+def test_admission_with_facts_returns_positive_score() -> None:
+    scorer = FallbackContextScorer()
+    results = scorer.score_admission([_summary(facts=[_fact(), _fact()])])
+    assert results[0].score > 0.0
+
+
+def test_admission_stale_summary_scores_lower_than_valid() -> None:
+    scorer = FallbackContextScorer()
+    valid = _summary("sum-v", facts=[_fact(), _fact()], validity_status="valid")
+    stale = _summary("sum-s", facts=[_fact(), _fact()], validity_status="stale")
+    valid_score = scorer.score_admission([valid])[0].score
+    stale_score = scorer.score_admission([stale])[0].score
+    assert stale_score < valid_score
+
+
+def test_admission_contradicted_summary_scores_lower_than_stale() -> None:
+    scorer = FallbackContextScorer()
+    stale = _summary("sum-s", facts=[_fact()], validity_status="stale")
+    contradicted = _summary("sum-c", facts=[_fact()], validity_status="contradicted")
+    assert (
+        scorer.score_admission([contradicted])[0].score < scorer.score_admission([stale])[0].score
+    )
+
+
+def test_admission_scores_clamped_to_unit_interval() -> None:
+    scorer = FallbackContextScorer()
+    rich = _summary(
+        facts=[_fact()] * 10,
+        hypotheses=[_hypothesis()] * 10,
+        failed_attempts=[_failed()] * 10,
+    )
+    result = scorer.score_admission([rich])[0]
+    assert 0.0 <= result.score <= 1.0
+
+
+def test_admission_is_deterministic() -> None:
+    scorer = FallbackContextScorer()
+    s = _summary(facts=[_fact()])
+    assert scorer.score_admission([s])[0].score == scorer.score_admission([s])[0].score
+
+
+def test_admission_preserves_summary_id() -> None:
+    scorer = FallbackContextScorer()
+    results = scorer.score_admission([_summary("my-id", facts=[_fact()])])
+    assert results[0].summary_id == "my-id"
+
+
+def test_admission_returns_one_result_per_summary() -> None:
+    scorer = FallbackContextScorer()
+    summaries = [_summary(f"sum-{i}", facts=[_fact()]) for i in range(4)]
+    assert len(scorer.score_admission(summaries)) == 4
+
+
+# ---------------------------------------------------------------------------
+# FallbackContextScorer — score_evidence_expansion
+# ---------------------------------------------------------------------------
+
+
+def test_expansion_empty_input_returns_empty_list() -> None:
+    scorer = FallbackContextScorer()
+    assert scorer.score_evidence_expansion([]) == []
+
+
+def test_expansion_deny_policy_returns_zero() -> None:
+    scorer = FallbackContextScorer()
+    result = scorer.score_evidence_expansion([_evidence_ref(expand_policy="deny")])[0]
+    assert result.score == pytest.approx(0.0)
+
+
+def test_expansion_always_policy_returns_high_score() -> None:
+    scorer = FallbackContextScorer()
+    result = scorer.score_evidence_expansion(
+        [_evidence_ref(expand_policy="always", staleness_status="valid")]
+    )[0]
+    assert result.score > 0.5
+
+
+def test_expansion_on_demand_policy_returns_mid_score() -> None:
+    scorer = FallbackContextScorer()
+    result = scorer.score_evidence_expansion(
+        [_evidence_ref(expand_policy="on_demand_only", staleness_status="valid")]
+    )[0]
+    assert 0.0 < result.score <= 1.0
+
+
+def test_expansion_stale_evidence_penalises_score() -> None:
+    scorer = FallbackContextScorer()
+    fresh = _evidence_ref("evd-f", expand_policy="on_demand_only", staleness_status="valid")
+    stale = _evidence_ref("evd-s", expand_policy="on_demand_only", staleness_status="stale")
+    fresh_score = scorer.score_evidence_expansion([fresh])[0].score
+    stale_score = scorer.score_evidence_expansion([stale])[0].score
+    assert stale_score < fresh_score
+
+
+def test_expansion_preserves_evidence_id() -> None:
+    scorer = FallbackContextScorer()
+    results = scorer.score_evidence_expansion([_evidence_ref("my-evd")])
+    assert results[0].evidence_id == "my-evd"
+
+
+# ---------------------------------------------------------------------------
+# FallbackContextScorer — score_summary_usefulness
+# ---------------------------------------------------------------------------
+
+
+def test_usefulness_empty_input_returns_empty_list() -> None:
+    scorer = FallbackContextScorer()
+    assert scorer.score_summary_usefulness([]) == []
+
+
+def test_usefulness_no_task_text_returns_low_score() -> None:
+    scorer = FallbackContextScorer()
+    result = scorer.score_summary_usefulness([_summary(facts=[_fact()])], task_text="")[0]
+    # With no task context richness is halved
+    assert result.score < 0.5
+
+
+def test_usefulness_matching_task_text_raises_score() -> None:
+    scorer = FallbackContextScorer()
+    s = _summary(facts=[_fact("fix the failing test")])
+    low = scorer.score_summary_usefulness([s], task_text="")[0].score
+    high = scorer.score_summary_usefulness([s], task_text="fix the failing test")[0].score
+    assert high > low
+
+
+def test_usefulness_no_overlap_falls_back_to_richness() -> None:
+    scorer = FallbackContextScorer()
+    s = _summary(facts=[_fact("xyz abc")])
+    result = scorer.score_summary_usefulness([s], task_text="unrelated topic words")[0]
+    assert result.score >= 0.0
+
+
+def test_usefulness_is_deterministic() -> None:
+    scorer = FallbackContextScorer()
+    s = _summary(facts=[_fact("read file")])
+    r1 = scorer.score_summary_usefulness([s], task_text="read the file")[0].score
+    r2 = scorer.score_summary_usefulness([s], task_text="read the file")[0].score
+    assert r1 == pytest.approx(r2)
+
+
+# ---------------------------------------------------------------------------
+# FallbackContextScorer — score_staleness_risk
+# ---------------------------------------------------------------------------
+
+
+def test_staleness_risk_empty_input_returns_empty_list() -> None:
+    scorer = FallbackContextScorer()
+    assert scorer.score_staleness_risk([]) == []
+
+
+def test_staleness_risk_valid_returns_zero() -> None:
+    scorer = FallbackContextScorer()
+    result = scorer.score_staleness_risk([_summary(validity_status="valid")])[0]
+    assert result.risk == pytest.approx(0.0)
+
+
+def test_staleness_risk_contradicted_returns_one() -> None:
+    scorer = FallbackContextScorer()
+    result = scorer.score_staleness_risk([_summary(validity_status="contradicted")])[0]
+    assert result.risk == pytest.approx(1.0)
+
+
+def test_staleness_risk_stale_returns_high_risk() -> None:
+    scorer = FallbackContextScorer()
+    result = scorer.score_staleness_risk([_summary(validity_status="stale")])[0]
+    assert result.risk > 0.5
+
+
+def test_staleness_risk_partial_between_valid_and_stale() -> None:
+    scorer = FallbackContextScorer()
+    valid_risk = scorer.score_staleness_risk([_summary(validity_status="valid")])[0].risk
+    partial_risk = scorer.score_staleness_risk([_summary(validity_status="partial")])[0].risk
+    stale_risk = scorer.score_staleness_risk([_summary(validity_status="stale")])[0].risk
+    assert valid_risk < partial_risk < stale_risk
+
+
+def test_staleness_risk_unknown_status_returns_mid_risk() -> None:
+    scorer = FallbackContextScorer()
+    result = scorer.score_staleness_risk([_summary(validity_status="unknown")])[0]
+    assert 0.0 < result.risk < 1.0
+
+
+def test_staleness_risk_preserves_summary_id() -> None:
+    scorer = FallbackContextScorer()
+    results = scorer.score_staleness_risk([_summary("id-xyz")])
+    assert results[0].summary_id == "id-xyz"
+
+
+# ---------------------------------------------------------------------------
+# Eval hook
+# ---------------------------------------------------------------------------
+
+
+def test_eval_hook_called_for_each_scored_item() -> None:
+    events: list[ScoringEvent] = []
+    scorer = FallbackContextScorer(eval_hook=events.append)
+    summaries = [_summary(f"sum-{i}", facts=[_fact()]) for i in range(3)]
+    scorer.score_admission(summaries)
+    assert len(events) == 3
+
+
+def test_eval_hook_receives_correct_scorer_kind_admission() -> None:
+    events: list[ScoringEvent] = []
+    scorer = FallbackContextScorer(eval_hook=events.append)
+    scorer.score_admission([_summary(facts=[_fact()])])
+    assert events[0].scorer_kind == "admission"
+
+
+def test_eval_hook_receives_correct_scorer_kind_evidence_expansion() -> None:
+    events: list[ScoringEvent] = []
+    scorer = FallbackContextScorer(eval_hook=events.append)
+    scorer.score_evidence_expansion([_evidence_ref()])
+    assert events[0].scorer_kind == "evidence_expansion"
+
+
+def test_eval_hook_receives_correct_scorer_kind_summary_usefulness() -> None:
+    events: list[ScoringEvent] = []
+    scorer = FallbackContextScorer(eval_hook=events.append)
+    scorer.score_summary_usefulness([_summary(facts=[_fact()])], task_text="task")
+    assert events[0].scorer_kind == "summary_usefulness"
+
+
+def test_eval_hook_receives_correct_scorer_kind_staleness_risk() -> None:
+    events: list[ScoringEvent] = []
+    scorer = FallbackContextScorer(eval_hook=events.append)
+    scorer.score_staleness_risk([_summary()])
+    assert events[0].scorer_kind == "staleness_risk"
+
+
+def test_eval_hook_event_carries_item_id_and_score() -> None:
+    events: list[ScoringEvent] = []
+    scorer = FallbackContextScorer(eval_hook=events.append)
+    scorer.score_staleness_risk([_summary("sum-track", validity_status="stale")])
+    assert events[0].item_id == "sum-track"
+    assert events[0].score == pytest.approx(0.8)
+
+
+def test_no_eval_hook_does_not_raise() -> None:
+    scorer = FallbackContextScorer()
+    scorer.score_admission([_summary(facts=[_fact()])])
+
+
+def test_eval_hook_not_called_for_empty_input() -> None:
+    events: list[ScoringEvent] = []
+    scorer = FallbackContextScorer(eval_hook=events.append)
+    scorer.score_admission([])
+    scorer.score_evidence_expansion([])
+    scorer.score_summary_usefulness([])
+    scorer.score_staleness_risk([])
+    assert events == []
+
+
+# ---------------------------------------------------------------------------
+# ContextScorerProtocol — injectable scorer
+# ---------------------------------------------------------------------------
+
+
+class _FixedScorer:
+    """Injectable scorer that always returns a fixed score; satisfies Protocol."""
+
+    def score_admission(
+        self,
+        summaries: Sequence[ActionSummary],
+        *,
+        task_text: str = "",
+    ) -> list[AdmissionScore]:
+        return [AdmissionScore(s.summary_id, 0.9, "fixed") for s in summaries]
+
+    def score_evidence_expansion(
+        self,
+        evidence_refs: Sequence[EvidenceRef],
+        *,
+        task_text: str = "",
+    ) -> list[EvidenceExpansionScore]:
+        return [EvidenceExpansionScore(r.evidence_id, 0.8, "fixed") for r in evidence_refs]
+
+    def score_summary_usefulness(
+        self,
+        summaries: Sequence[ActionSummary],
+        *,
+        task_text: str = "",
+    ) -> list[SummaryUsefulnessScore]:
+        return [SummaryUsefulnessScore(s.summary_id, 0.7, "fixed") for s in summaries]
+
+    def score_staleness_risk(
+        self,
+        summaries: Sequence[ActionSummary],
+    ) -> list[StalenessRiskScore]:
+        return [StalenessRiskScore(s.summary_id, 0.1, "fixed") for s in summaries]
+
+
+def test_fallback_scorer_satisfies_protocol() -> None:
+    assert isinstance(FallbackContextScorer(), ContextScorerProtocol)
+
+
+def test_injectable_scorer_satisfies_protocol() -> None:
+    assert isinstance(_FixedScorer(), ContextScorerProtocol)
+
+
+def test_injectable_scorer_returns_fixed_admission_score() -> None:
+    scorer: ContextScorerProtocol = _FixedScorer()
+    results = scorer.score_admission([_summary(facts=[_fact()])])
+    assert results[0].score == pytest.approx(0.9)
+
+
+def test_injectable_scorer_returns_fixed_staleness_risk() -> None:
+    scorer: ContextScorerProtocol = _FixedScorer()
+    results = scorer.score_staleness_risk([_summary(validity_status="stale")])
+    assert results[0].risk == pytest.approx(0.1)
+
+
+def test_injectable_scorer_can_be_called_through_protocol_type() -> None:
+    def _run(scorer: ContextScorerProtocol, s: ActionSummary) -> float:
+        return scorer.score_admission([s])[0].score
+
+    assert _run(_FixedScorer(), _summary(facts=[_fact()])) == pytest.approx(0.9)
+    assert _run(FallbackContextScorer(), _summary()) == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- Add MLX-free Context Firewall scorer protocol and result DTOs for PHOTON plug-in scoring.
- Add deterministic fallback scoring for context admission, evidence expansion, summary usefulness, and staleness risk.
- Add optional scoring event hook for eval comparison integration.
- Add smoke tests and dev reports for issue #45.

## Verification
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m mypy photon_action_memory tests`
- `python -m pytest -q`

Closes #45