### PR TITLE
#46 Add Context Firewall canary config

### DIFF
--- a/dev-reports/issue-46/implementation-summary.md
+++ b/dev-reports/issue-46/implementation-summary.md
@@ -1,0 +1,36 @@
+# Issue #46 Implementation Summary
+
+## Scope
+
+Added Context Firewall canary-mode configuration and policy evaluation for low-risk context injection.
+
+## Changes
+
+- Added `photon_action_memory/context/canary.py`.
+- Exported canary policy helpers from `photon_action_memory/context/__init__.py`.
+- Added canary fixtures:
+  - `tests/fixtures/v0.2/canary_context_pack.json`
+  - `tests/fixtures/v0.2/canary_evaluate_shadow_mode.json`
+- Added `tests/test_canary_policy.py`.
+
+## Policy Behavior
+
+- Allowed in canary:
+  - `read_candidate`
+  - `search_query_candidate`
+  - `test_command_candidate`
+  - `repeat_search_warning`
+  - `repeat_read_warning`
+  - `summary_only_memory`
+- Denied in canary:
+  - `destructive_shell_command`
+  - `edit_auto_approval`
+  - `security_sensitive_operation`
+  - `raw_full_stdout_injection`
+  - `raw_full_stderr_injection`
+
+Unknown or malformed candidates return `defer` instead of raising, preserving fail-open behavior without injecting risky context.
+
+## Privacy
+
+Fixtures and reports contain only aggregate or summary-only context. Raw full stdout/stderr is represented as an omitted item and is not prompt-visible.

--- a/dev-reports/issue-46/verification.md
+++ b/dev-reports/issue-46/verification.md
@@ -1,0 +1,20 @@
+# Issue #46 Verification
+
+## Commands
+
+- `python -m ruff format --check .`
+  - Result: `75 files already formatted`
+- `python -m ruff check .`
+  - Result: `All checks passed!`
+- `python -m mypy photon_action_memory tests`
+  - Result: `Success: no issues found in 73 source files`
+- `python -m pytest -q`
+  - Result: `616 passed, 1 skipped in 1.35s`
+
+## Coverage
+
+- Low-risk canary classes are admitted.
+- Destructive, edit auto-approval, security-sensitive, and raw full stdout/stderr classes are denied.
+- Unknown and malformed candidates defer instead of raising.
+- Canary ContextPack fixture validates as `ContextPack` and remains summary-only.
+- Shadow-mode evaluate fixture validates as `EvaluateRequest` and aggregates through `aggregate_context_pack_eval`.

--- a/photon_action_memory/context/__init__.py
+++ b/photon_action_memory/context/__init__.py
@@ -1,1 +1,23 @@
 """Context packing and admission control for v0.2."""
+
+from photon_action_memory.context.canary import (
+    CANARY_ALLOWED_CLASSES,
+    CANARY_DENIED_CLASSES,
+    CANARY_MODE_CONFIG,
+    CANARY_POLICY_NAME,
+    CanaryCandidate,
+    CanaryModeConfig,
+    evaluate_canary_candidate,
+    evaluate_canary_candidates,
+)
+
+__all__ = [
+    "CANARY_ALLOWED_CLASSES",
+    "CANARY_DENIED_CLASSES",
+    "CANARY_MODE_CONFIG",
+    "CANARY_POLICY_NAME",
+    "CanaryCandidate",
+    "CanaryModeConfig",
+    "evaluate_canary_candidate",
+    "evaluate_canary_candidates",
+]

--- a/photon_action_memory/context/canary.py
+++ b/photon_action_memory/context/canary.py
@@ -1,0 +1,200 @@
+"""Canary-mode policy for low-risk Context Firewall injection.
+
+The canary preset is intentionally conservative: only read/search/test
+candidate hints, repeated exploration warnings, and summary-only memory are
+eligible for prompt injection. Destructive, edit-approving, security-sensitive,
+and raw stdout/stderr injection classes are denied.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    AdmissionPolicy,
+    ContextAdmissionDecision,
+)
+
+CANARY_POLICY_NAME = "context_firewall_canary.v1"
+
+AllowedCanaryClass = Literal[
+    "read_candidate",
+    "search_query_candidate",
+    "test_command_candidate",
+    "repeat_search_warning",
+    "repeat_read_warning",
+    "summary_only_memory",
+]
+
+DeniedCanaryClass = Literal[
+    "destructive_shell_command",
+    "edit_auto_approval",
+    "security_sensitive_operation",
+    "raw_full_stdout_injection",
+    "raw_full_stderr_injection",
+]
+
+CANARY_ALLOWED_CLASSES: frozenset[str] = frozenset(
+    {
+        "read_candidate",
+        "search_query_candidate",
+        "test_command_candidate",
+        "repeat_search_warning",
+        "repeat_read_warning",
+        "summary_only_memory",
+    }
+)
+
+CANARY_DENIED_CLASSES: frozenset[str] = frozenset(
+    {
+        "destructive_shell_command",
+        "edit_auto_approval",
+        "security_sensitive_operation",
+        "raw_full_stdout_injection",
+        "raw_full_stderr_injection",
+    }
+)
+
+
+class CanaryModeConfig(BaseModel):
+    """Policy preset for low-risk Context Firewall canary mode."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    policy_name: str = CANARY_POLICY_NAME
+    enabled: bool = True
+    shadow_mode: bool = True
+    fail_open: bool = True
+    mode: str = "summary_only"
+    allowed_action_classes: set[str] = Field(default_factory=lambda: set(CANARY_ALLOWED_CLASSES))
+    denied_action_classes: set[str] = Field(default_factory=lambda: set(CANARY_DENIED_CLASSES))
+
+
+class CanaryCandidate(BaseModel):
+    """One candidate context injection evaluated by canary mode."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    candidate_id: str
+    action_class: str
+    item_kind: str = "warning"
+    estimated_tokens: int | None = Field(default=None, ge=0)
+
+
+CANARY_MODE_CONFIG = CanaryModeConfig()
+
+
+def evaluate_canary_candidate(
+    candidate: CanaryCandidate | Mapping[str, Any],
+    *,
+    config: CanaryModeConfig = CANARY_MODE_CONFIG,
+) -> ContextAdmissionDecision:
+    """Evaluate one candidate under the canary preset.
+
+    The helper is fail-open for malformed or unknown classes: it returns a
+    `defer` decision instead of raising so the caller can continue without
+    injecting risky context.
+    """
+    try:
+        parsed = (
+            candidate
+            if isinstance(candidate, CanaryCandidate)
+            else CanaryCandidate.model_validate(candidate)
+        )
+    except Exception as exc:
+        return _decision(
+            item_id="unknown",
+            item_kind="unknown",
+            decision="defer",
+            reason=f"canary fail-open: invalid candidate ({exc.__class__.__name__})",
+            estimated_tokens=None,
+            config=config,
+        )
+
+    if not config.enabled:
+        return _decision(
+            item_id=parsed.candidate_id,
+            item_kind=parsed.item_kind,
+            decision="defer",
+            reason="canary policy disabled",
+            estimated_tokens=parsed.estimated_tokens,
+            config=config,
+        )
+
+    if parsed.action_class in config.denied_action_classes:
+        return _decision(
+            item_id=parsed.candidate_id,
+            item_kind=parsed.item_kind,
+            decision="deny",
+            reason=f"canary denied action class: {parsed.action_class}",
+            estimated_tokens=parsed.estimated_tokens,
+            config=config,
+        )
+
+    if parsed.action_class in config.allowed_action_classes:
+        return _decision(
+            item_id=parsed.candidate_id,
+            item_kind=parsed.item_kind,
+            decision="admit",
+            reason=f"canary allowed low-risk action class: {parsed.action_class}",
+            estimated_tokens=parsed.estimated_tokens,
+            config=config,
+        )
+
+    return _decision(
+        item_id=parsed.candidate_id,
+        item_kind=parsed.item_kind,
+        decision="defer",
+        reason=f"canary fail-open: unknown action class: {parsed.action_class}",
+        estimated_tokens=parsed.estimated_tokens,
+        config=config,
+    )
+
+
+def evaluate_canary_candidates(
+    candidates: list[CanaryCandidate | Mapping[str, Any]],
+    *,
+    config: CanaryModeConfig = CANARY_MODE_CONFIG,
+) -> list[ContextAdmissionDecision]:
+    """Evaluate candidates in order under the canary preset."""
+    return [evaluate_canary_candidate(candidate, config=config) for candidate in candidates]
+
+
+def _decision(
+    *,
+    item_id: str,
+    item_kind: str,
+    decision: str,
+    reason: str,
+    estimated_tokens: int | None,
+    config: CanaryModeConfig,
+) -> ContextAdmissionDecision:
+    return ContextAdmissionDecision(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        decision_id=f"canary-{item_id}",
+        item_id=item_id,
+        item_kind=item_kind,
+        decision=decision,
+        reason=reason,
+        estimated_tokens=estimated_tokens,
+        policy=AdmissionPolicy(
+            raw_evidence_policy="raw_tool_log_default_deny",
+            detail_level=config.policy_name,
+        ),
+    )
+
+
+__all__ = [
+    "CANARY_ALLOWED_CLASSES",
+    "CANARY_DENIED_CLASSES",
+    "CANARY_MODE_CONFIG",
+    "CANARY_POLICY_NAME",
+    "CanaryCandidate",
+    "CanaryModeConfig",
+    "evaluate_canary_candidate",
+    "evaluate_canary_candidates",
+]

--- a/tests/fixtures/v0.2/canary_context_pack.json
+++ b/tests/fixtures/v0.2/canary_context_pack.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": "action-memory.v0.2",
+  "request_id": "pack-canary-001",
+  "session_id": "sess-canary",
+  "repo_id": "repo-neutral",
+  "mode": "summary_only",
+  "items": [
+    {
+      "kind": "action_summary",
+      "id": "summary-only-1",
+      "text": "Previously read photon_action_memory/context/pack.py and confirmed summary-only ContextPack behavior.",
+      "evidence_ids": ["ev-read-1"],
+      "admission_reason": "canary allowed low-risk action class: summary_only_memory"
+    },
+    {
+      "kind": "warning",
+      "id": "repeat-search-warning-1",
+      "text": "Avoid repeating the same search query; prior search already covered ContextPack admission policy.",
+      "evidence_ids": [],
+      "admission_reason": "canary allowed low-risk action class: repeat_search_warning"
+    },
+    {
+      "kind": "warning",
+      "id": "test-command-candidate-1",
+      "text": "Low-risk verification candidate: python -m pytest tests/test_context_pack.py -q",
+      "evidence_ids": [],
+      "admission_reason": "canary allowed low-risk action class: test_command_candidate"
+    }
+  ],
+  "omitted": [
+    {
+      "kind": "shell_command",
+      "id": "rm-command-1",
+      "reason": "canary denied action class: destructive_shell_command"
+    },
+    {
+      "kind": "edit_approval",
+      "id": "auto-edit-1",
+      "reason": "canary denied action class: edit_auto_approval"
+    },
+    {
+      "kind": "stdout",
+      "id": "raw-stdout-1",
+      "reason": "raw tool log default deny policy: kind 'stdout' is always denied"
+    }
+  ],
+  "warnings": [
+    {
+      "kind": "canary_shadow_mode",
+      "message": "Canary mode admitted low-risk summary-only context and recorded denied classes for shadow-mode evaluation."
+    }
+  ],
+  "token_budget": {
+    "max_tokens": 512,
+    "estimated_tokens": 42,
+    "tokens_saved_vs_raw": 958
+  }
+}

--- a/tests/fixtures/v0.2/canary_evaluate_shadow_mode.json
+++ b/tests/fixtures/v0.2/canary_evaluate_shadow_mode.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "action-memory.v0.2",
+  "request_id": "eval-canary-001",
+  "session_id": "sess-canary",
+  "agent": {
+    "name": "neutral-agent",
+    "version": "canary-shadow"
+  },
+  "context_pack_event": {
+    "context_pack_request_id": "pack-canary-001",
+    "adoption_status": "partial",
+    "ignored_reason": null,
+    "evidence_expand_requested": false,
+    "evidence_ids_expanded": [],
+    "items_adopted_count": 2,
+    "items_ignored_count": 1,
+    "outcome": "success",
+    "outcome_detail": "Canary shadow-mode tracked partial adoption of low-risk summary-only context.",
+    "latency_ms": 64.2
+  }
+}

--- a/tests/test_canary_policy.py
+++ b/tests/test_canary_policy.py
@@ -1,0 +1,117 @@
+"""Tests for Context Firewall canary-mode admission policy."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from photon_action_memory.api.schema_v2 import ContextPack, EvaluateRequest
+from photon_action_memory.context.canary import (
+    CANARY_ALLOWED_CLASSES,
+    CANARY_DENIED_CLASSES,
+    CANARY_MODE_CONFIG,
+    CanaryCandidate,
+    CanaryModeConfig,
+    evaluate_canary_candidate,
+    evaluate_canary_candidates,
+)
+from photon_action_memory.eval.context_pack_log import aggregate_context_pack_eval
+
+
+def test_canary_allows_only_low_risk_classes() -> None:
+    decisions = evaluate_canary_candidates(
+        [
+            {"candidate_id": f"allowed-{kind}", "action_class": kind}
+            for kind in sorted(CANARY_ALLOWED_CLASSES)
+        ]
+    )
+
+    assert {decision.decision for decision in decisions} == {"admit"}
+    assert all("low-risk" in str(decision.reason) for decision in decisions)
+
+
+def test_canary_denies_risky_classes() -> None:
+    decisions = evaluate_canary_candidates(
+        [
+            {"candidate_id": f"denied-{kind}", "action_class": kind}
+            for kind in sorted(CANARY_DENIED_CLASSES)
+        ]
+    )
+
+    assert {decision.decision for decision in decisions} == {"deny"}
+    assert all("canary denied" in str(decision.reason) for decision in decisions)
+
+
+def test_canary_defer_unknown_class_to_preserve_fail_open() -> None:
+    decision = evaluate_canary_candidate(
+        CanaryCandidate(candidate_id="unknown-1", action_class="unknown_experimental_tool")
+    )
+
+    assert decision.decision == "defer"
+    assert decision.reason == "canary fail-open: unknown action class: unknown_experimental_tool"
+
+
+def test_canary_defer_invalid_candidate_to_preserve_fail_open() -> None:
+    decision = evaluate_canary_candidate({"action_class": "read_candidate"})
+
+    assert decision.decision == "defer"
+    assert decision.item_id == "unknown"
+    assert "invalid candidate" in str(decision.reason)
+
+
+def test_canary_disabled_defer_without_denial() -> None:
+    decision = evaluate_canary_candidate(
+        CanaryCandidate(candidate_id="read-1", action_class="read_candidate"),
+        config=CanaryModeConfig(enabled=False),
+    )
+
+    assert decision.decision == "defer"
+    assert decision.reason == "canary policy disabled"
+
+
+def test_canary_decision_records_policy_metadata() -> None:
+    decision = evaluate_canary_candidate(
+        CanaryCandidate(
+            candidate_id="summary-1",
+            action_class="summary_only_memory",
+            item_kind="action_summary",
+            estimated_tokens=42,
+        )
+    )
+
+    assert decision.policy is not None
+    assert decision.policy.raw_evidence_policy == "raw_tool_log_default_deny"
+    assert decision.policy.detail_level == CANARY_MODE_CONFIG.policy_name
+    assert decision.estimated_tokens == 42
+
+
+def test_canary_context_pack_fixture_is_summary_only_and_low_risk() -> None:
+    fixture = _load_fixture("canary_context_pack.json")
+    pack = ContextPack.model_validate(fixture)
+
+    assert pack.mode == "summary_only"
+    assert [item.kind for item in pack.items] == ["action_summary", "warning", "warning"]
+    assert {omitted.reason for omitted in pack.omitted} == {
+        "canary denied action class: destructive_shell_command",
+        "canary denied action class: edit_auto_approval",
+        "raw tool log default deny policy: kind 'stdout' is always denied",
+    }
+
+
+def test_canary_shadow_mode_evaluate_fixture_is_aggregate_safe() -> None:
+    fixture = _load_fixture("canary_evaluate_shadow_mode.json")
+    request = EvaluateRequest.model_validate(fixture)
+    assert request.context_pack_event is not None
+
+    report = aggregate_context_pack_eval([request.context_pack_event.model_dump()])
+
+    assert report.total_turns == 1
+    assert report.adopted_count == 0
+    assert report.ignored_count == 0
+    assert report.partial_count == 1
+    assert report.task_success_rate == 1.0
+
+
+def _load_fixture(name: str) -> object:
+    path = Path("tests/fixtures/v0.2") / name
+    return json.loads(path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- Add Context Firewall canary-mode config for low-risk summary-only injection.
- Admit read/search/test candidates, repeated exploration warnings, and summary-only memory.
- Deny destructive commands, edit auto-approval, security-sensitive operations, and raw full stdout/stderr injection.
- Add canary ContextPack and shadow-mode evaluate fixtures plus policy tests.

## Verification
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m mypy photon_action_memory tests`
- `python -m pytest -q`

Closes #46