### PR TITLE
#66 [Anvil photon integration] P3: Evidence expansion の制御

### DIFF
--- a/dev-reports/issue-66/design.md
+++ b/dev-reports/issue-66/design.md
@@ -1,0 +1,33 @@
+# Issue #66 Design — Evidence Expansion Control for Anvil
+
+## Problem
+
+`POST /v1/evidence/expand` was usable by any caller with full flexibility:
+- `allow_raw_full_output=True` could expose raw stdout/stderr even for Anvil callers.
+- No way to restrict expansion to a caller-owned subset of evidence IDs.
+- Omit `reason` strings were unstable (e.g. embedded runtime values), making Anvil renderer brittle.
+
+## Solution
+
+Three targeted additions with no breaking changes:
+
+### 1. `selected_evidence_ids` allowlist on `EvidenceExpandRequest`
+
+Anvil includes only the evidence IDs it collected in the current fixture. Any `evidence_ids` entry that is not in `selected_evidence_ids` is omitted immediately with reason `"evidence_id not in selected_evidence_ids"`. When `selected_evidence_ids` is `null` (the default), all IDs are allowed — backward compatible.
+
+### 2. `anvil_profile: bool = False` on `EvidenceExpandPolicy`
+
+When `True`, raw stdout/stderr (any record whose concise_text is `None` and raw_text is set) is always omitted with reason `"raw output denied: anvil profile"`, regardless of `allow_raw_full_output`. This prevents callers from accidentally opting in to raw output via `allow_raw_full_output=True` in an Anvil context.
+
+### 3. Stable omit reason constants
+
+All six omit reasons are now module-level string constants in `memory/evidence.py` and exported from `__all__`. The values were chosen to remain backward-compatible with existing substring-based tests.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `photon_action_memory/api/schema_v2.py` | Add `anvil_profile` to `EvidenceExpandPolicy`; add `selected_evidence_ids` to `EvidenceExpandRequest` |
+| `photon_action_memory/memory/evidence.py` | Add reason constants; implement allowlist filtering and Anvil-profile raw deny in `expand()` |
+| `tests/test_evidence_expander.py` | 11 new tests covering all new behaviors |
+| `workspace/anvil/summary.md` | Anvil integration contract document |

--- a/dev-reports/issue-66/implementation-summary.md
+++ b/dev-reports/issue-66/implementation-summary.md
@@ -1,0 +1,32 @@
+# Issue #66 Implementation Summary
+
+## Changes
+
+### `photon_action_memory/api/schema_v2.py`
+- `EvidenceExpandPolicy`: added `anvil_profile: bool = False`
+- `EvidenceExpandRequest`: added `selected_evidence_ids: list[str] | None = None`
+
+### `photon_action_memory/memory/evidence.py`
+- Added six stable reason constants: `REASON_NOT_FOUND`, `REASON_NOT_IN_SELECTION`, `REASON_RAW_OUTPUT_DENIED`, `REASON_RAW_OUTPUT_DENIED_ANVIL`, `REASON_NO_CONTENT`, `REASON_BUDGET_EXHAUSTED`
+- `EvidenceExpander.expand()`:
+  1. Builds a `frozenset` from `selected_evidence_ids` if provided; IDs not in the set → omit with `REASON_NOT_IN_SELECTION`
+  2. When `policy.anvil_profile` is True and raw_text would be used → omit with `REASON_RAW_OUTPUT_DENIED_ANVIL` (ignores `allow_raw_full_output`)
+  3. All omit paths now use the stable constants instead of inline strings
+
+### `tests/test_evidence_expander.py`
+- 11 new tests: selected-ID allowlist (4), Anvil-profile raw deny (3), stable reason API round-trips (4)
+- Imported `REASON_NOT_IN_SELECTION` and `REASON_RAW_OUTPUT_DENIED_ANVIL` for exact-match assertions
+
+### `workspace/anvil/summary.md`
+- New: documents the Anvil-safe request pattern, policy flags, and stable reason strings
+
+## Acceptance criteria status
+
+| Criterion | Status |
+|-----------|--------|
+| Anvil fixture の selected evidence id だけ展開できる | `selected_evidence_ids` allowlist |
+| raw stdout/stderr は anvil profile では omitted | `anvil_profile=True` hard-denies raw output |
+| `max_chars_per_evidence` と `max_total_chars` が守られる | Pre-existing, unchanged |
+| sanitizer が再適用される | Pre-existing, unchanged |
+| evidence not found は 200 + omitted | Pre-existing, unchanged |
+| Anvil renderer が扱いやすい stable reason を返す | Module-level reason constants |

--- a/dev-reports/issue-66/verification.md
+++ b/dev-reports/issue-66/verification.md
@@ -1,0 +1,30 @@
+# Issue #66 Verification
+
+## Test run
+
+```
+python -m pytest tests/test_evidence_expander.py -v
+43 passed in 0.37s
+```
+
+New tests added (11):
+- `test_selected_ids_allows_listed_id`
+- `test_selected_ids_omits_unlisted_id`
+- `test_selected_ids_none_allows_all`
+- `test_selected_ids_partial_filtering`
+- `test_anvil_profile_denies_raw_even_when_allow_raw_full_output_true`
+- `test_anvil_profile_denies_stderr_even_when_allow_raw_full_output_true`
+- `test_anvil_profile_allows_concise_snippet`
+- `test_api_stable_reason_not_found`
+- `test_api_stable_reason_raw_denied`
+- `test_api_stable_reason_anvil_raw_denied`
+- `test_api_stable_reason_not_in_selection`
+
+## Full suite
+
+```
+python -m pytest --tb=short -q
+627 passed, 1 skipped in 2.78s
+```
+
+No regressions.

--- a/photon_action_memory/api/schema_v2.py
+++ b/photon_action_memory/api/schema_v2.py
@@ -371,6 +371,7 @@ class EvidenceExpandPolicy(SidecarModel):
     redact_again: bool = True
     allow_raw_full_output: bool = False
     allow_selected_snippet: bool = True
+    anvil_profile: bool = False
 
 
 class EvidenceExpandRequest(SidecarModel):
@@ -379,6 +380,7 @@ class EvidenceExpandRequest(SidecarModel):
     schema_version: SchemaVersionV2
     request_id: str
     evidence_ids: list[str]
+    selected_evidence_ids: list[str] | None = None
     reason: str | None = None
     budget: EvidenceExpandBudget = Field(default_factory=EvidenceExpandBudget)
     policy: EvidenceExpandPolicy = Field(default_factory=EvidenceExpandPolicy)

--- a/photon_action_memory/memory/evidence.py
+++ b/photon_action_memory/memory/evidence.py
@@ -173,9 +173,7 @@ class EvidenceExpander:
 
             candidate = self._index.get(evidence_id)
             if candidate is None:
-                omitted.append(
-                    OmittedEvidence(evidence_id=evidence_id, reason=REASON_NOT_FOUND)
-                )
+                omitted.append(OmittedEvidence(evidence_id=evidence_id, reason=REASON_NOT_FOUND))
                 continue
 
             if candidate.concise_text is not None:

--- a/photon_action_memory/memory/evidence.py
+++ b/photon_action_memory/memory/evidence.py
@@ -24,6 +24,14 @@ _CONCISE_FIELDS: tuple[str, ...] = ("snippet",)
 # Fields that carry raw full output, subject to default-deny.
 _RAW_FIELDS: tuple[str, ...] = ("stdout", "stderr")
 
+# Stable omit reason strings — Anvil renderer can rely on these being constant.
+REASON_NOT_FOUND = "evidence_id not found"
+REASON_NOT_IN_SELECTION = "evidence_id not in selected_evidence_ids"
+REASON_RAW_OUTPUT_DENIED = "raw output denied by policy"
+REASON_RAW_OUTPUT_DENIED_ANVIL = "raw output denied: anvil profile"
+REASON_NO_CONTENT = "no expandable content available"
+REASON_BUDGET_EXHAUSTED = "max_total_chars budget exhausted"
+
 
 @dataclass
 class _Candidate:
@@ -134,6 +142,11 @@ class EvidenceExpander:
         policy = request.policy
         max_per = budget.max_chars_per_evidence
         max_total = budget.max_total_chars
+        selection: frozenset[str] | None = (
+            frozenset(request.selected_evidence_ids)
+            if request.selected_evidence_ids is not None
+            else None
+        )
 
         expanded: list[ExpandedEvidence] = []
         omitted: list[OmittedEvidence] = []
@@ -144,7 +157,16 @@ class EvidenceExpander:
                 omitted.append(
                     OmittedEvidence(
                         evidence_id=evidence_id,
-                        reason="max_total_chars budget exhausted",
+                        reason=REASON_BUDGET_EXHAUSTED,
+                    )
+                )
+                continue
+
+            if selection is not None and evidence_id not in selection:
+                omitted.append(
+                    OmittedEvidence(
+                        evidence_id=evidence_id,
+                        reason=REASON_NOT_IN_SELECTION,
                     )
                 )
                 continue
@@ -152,18 +174,29 @@ class EvidenceExpander:
             candidate = self._index.get(evidence_id)
             if candidate is None:
                 omitted.append(
-                    OmittedEvidence(evidence_id=evidence_id, reason="evidence_id not found")
+                    OmittedEvidence(evidence_id=evidence_id, reason=REASON_NOT_FOUND)
                 )
                 continue
 
             if candidate.concise_text is not None:
                 raw_snippet = candidate.concise_text
             elif candidate.raw_text is not None:
+                if policy.anvil_profile:
+                    omitted.append(
+                        OmittedEvidence(
+                            evidence_id=evidence_id,
+                            reason=REASON_RAW_OUTPUT_DENIED_ANVIL,
+                        )
+                    )
+                    logger.warning(
+                        "evidence %r omitted: raw output denied by anvil profile", evidence_id
+                    )
+                    continue
                 if not policy.allow_raw_full_output:
                     omitted.append(
                         OmittedEvidence(
                             evidence_id=evidence_id,
-                            reason="raw full output denied by policy (allow_raw_full_output=False)",
+                            reason=REASON_RAW_OUTPUT_DENIED,
                         )
                     )
                     logger.warning("evidence %r omitted: raw output denied by policy", evidence_id)
@@ -173,7 +206,7 @@ class EvidenceExpander:
                 omitted.append(
                     OmittedEvidence(
                         evidence_id=evidence_id,
-                        reason="no expandable content available",
+                        reason=REASON_NO_CONTENT,
                     )
                 )
                 continue
@@ -215,4 +248,12 @@ class EvidenceExpander:
         )
 
 
-__all__ = ["EvidenceExpander"]
+__all__ = [
+    "EvidenceExpander",
+    "REASON_BUDGET_EXHAUSTED",
+    "REASON_NOT_FOUND",
+    "REASON_NOT_IN_SELECTION",
+    "REASON_NO_CONTENT",
+    "REASON_RAW_OUTPUT_DENIED",
+    "REASON_RAW_OUTPUT_DENIED_ANVIL",
+]

--- a/tests/test_evidence_expander.py
+++ b/tests/test_evidence_expander.py
@@ -487,9 +487,7 @@ def test_selected_ids_omits_unlisted_id() -> None:
 
 
 def test_selected_ids_none_allows_all() -> None:
-    expander = EvidenceExpander(
-        records=[_rec("ev-a", snippet="a"), _rec("ev-b", snippet="b")]
-    )
+    expander = EvidenceExpander(records=[_rec("ev-a", snippet="a"), _rec("ev-b", snippet="b")])
     req = EvidenceExpandRequest(
         schema_version=DEFAULT_SCHEMA_VERSION_V2,
         request_id="req-any",
@@ -525,9 +523,7 @@ def test_selected_ids_partial_filtering() -> None:
 
 
 def test_anvil_profile_denies_raw_even_when_allow_raw_full_output_true() -> None:
-    expander = EvidenceExpander(
-        records=[_rec("ev-raw-anvil", kind="stdout", stdout="build log")]
-    )
+    expander = EvidenceExpander(records=[_rec("ev-raw-anvil", kind="stdout", stdout="build log")])
     policy = EvidenceExpandPolicy(allow_raw_full_output=True, anvil_profile=True)
     req = _req(["ev-raw-anvil"], policy=policy)
     resp = expander.expand(req)
@@ -537,9 +533,7 @@ def test_anvil_profile_denies_raw_even_when_allow_raw_full_output_true() -> None
 
 
 def test_anvil_profile_denies_stderr_even_when_allow_raw_full_output_true() -> None:
-    expander = EvidenceExpander(
-        records=[_rec("ev-err-anvil", kind="stderr", stderr="error trace")]
-    )
+    expander = EvidenceExpander(records=[_rec("ev-err-anvil", kind="stderr", stderr="error trace")])
     policy = EvidenceExpandPolicy(allow_raw_full_output=True, anvil_profile=True)
     resp = expander.expand(_req(["ev-err-anvil"], policy=policy))
     assert resp.expanded == []
@@ -596,7 +590,9 @@ def test_api_stable_reason_anvil_raw_denied(tmp_path: Path) -> None:
 
 def test_api_stable_reason_not_in_selection(tmp_path: Path) -> None:
     app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
-    records = [{"evidence_id": "ev-blocked", "kind": "file_inspection", "summary": "s", "snippet": "x"}]
+    records = [
+        {"evidence_id": "ev-blocked", "kind": "file_inspection", "summary": "s", "snippet": "x"}
+    ]
     body = _api_body(["ev-blocked"], extra_records=records)
     body["selected_evidence_ids"] = ["ev-allowed-only"]
     with TestClient(app) as client:

--- a/tests/test_evidence_expander.py
+++ b/tests/test_evidence_expander.py
@@ -26,7 +26,11 @@ from photon_action_memory.api.schema_v2 import (
     EvidenceExpandRequest,
 )
 from photon_action_memory.api.server import create_app
-from photon_action_memory.memory.evidence import EvidenceExpander
+from photon_action_memory.memory.evidence import (
+    REASON_NOT_IN_SELECTION,
+    REASON_RAW_OUTPUT_DENIED_ANVIL,
+    EvidenceExpander,
+)
 from photon_action_memory.memory.store import SQLiteEventStore
 
 # ---------------------------------------------------------------------------
@@ -448,3 +452,154 @@ def test_api_expand_schema_version_in_response(tmp_path: Path) -> None:
         resp = client.post("/v1/evidence/expand", json=_api_body([]))
     assert resp.status_code == 200
     assert resp.json()["schema_version"] == DEFAULT_SCHEMA_VERSION_V2
+
+
+# ---------------------------------------------------------------------------
+# Anvil profile — selected_evidence_ids allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_selected_ids_allows_listed_id() -> None:
+    expander = EvidenceExpander(records=[_rec("ev-sel", snippet="code")])
+    req = EvidenceExpandRequest(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        request_id="req-sel",
+        evidence_ids=["ev-sel"],
+        selected_evidence_ids=["ev-sel"],
+    )
+    resp = expander.expand(req)
+    assert len(resp.expanded) == 1
+    assert resp.omitted == []
+
+
+def test_selected_ids_omits_unlisted_id() -> None:
+    expander = EvidenceExpander(records=[_rec("ev-other", snippet="code")])
+    req = EvidenceExpandRequest(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        request_id="req-sel",
+        evidence_ids=["ev-other"],
+        selected_evidence_ids=["ev-allowed"],
+    )
+    resp = expander.expand(req)
+    assert resp.expanded == []
+    assert len(resp.omitted) == 1
+    assert resp.omitted[0].reason == REASON_NOT_IN_SELECTION
+
+
+def test_selected_ids_none_allows_all() -> None:
+    expander = EvidenceExpander(
+        records=[_rec("ev-a", snippet="a"), _rec("ev-b", snippet="b")]
+    )
+    req = EvidenceExpandRequest(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        request_id="req-any",
+        evidence_ids=["ev-a", "ev-b"],
+        selected_evidence_ids=None,
+    )
+    resp = expander.expand(req)
+    assert len(resp.expanded) == 2
+    assert resp.omitted == []
+
+
+def test_selected_ids_partial_filtering() -> None:
+    expander = EvidenceExpander(
+        records=[_rec("ev-in", snippet="yes"), _rec("ev-out", snippet="no")]
+    )
+    req = EvidenceExpandRequest(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        request_id="req-partial",
+        evidence_ids=["ev-in", "ev-out"],
+        selected_evidence_ids=["ev-in"],
+    )
+    resp = expander.expand(req)
+    assert len(resp.expanded) == 1
+    assert resp.expanded[0].evidence_id == "ev-in"
+    assert len(resp.omitted) == 1
+    assert resp.omitted[0].evidence_id == "ev-out"
+    assert resp.omitted[0].reason == REASON_NOT_IN_SELECTION
+
+
+# ---------------------------------------------------------------------------
+# Anvil profile — raw output always denied
+# ---------------------------------------------------------------------------
+
+
+def test_anvil_profile_denies_raw_even_when_allow_raw_full_output_true() -> None:
+    expander = EvidenceExpander(
+        records=[_rec("ev-raw-anvil", kind="stdout", stdout="build log")]
+    )
+    policy = EvidenceExpandPolicy(allow_raw_full_output=True, anvil_profile=True)
+    req = _req(["ev-raw-anvil"], policy=policy)
+    resp = expander.expand(req)
+    assert resp.expanded == []
+    assert len(resp.omitted) == 1
+    assert resp.omitted[0].reason == REASON_RAW_OUTPUT_DENIED_ANVIL
+
+
+def test_anvil_profile_denies_stderr_even_when_allow_raw_full_output_true() -> None:
+    expander = EvidenceExpander(
+        records=[_rec("ev-err-anvil", kind="stderr", stderr="error trace")]
+    )
+    policy = EvidenceExpandPolicy(allow_raw_full_output=True, anvil_profile=True)
+    resp = expander.expand(_req(["ev-err-anvil"], policy=policy))
+    assert resp.expanded == []
+    assert resp.omitted[0].reason == REASON_RAW_OUTPUT_DENIED_ANVIL
+
+
+def test_anvil_profile_allows_concise_snippet() -> None:
+    expander = EvidenceExpander(
+        records=[_rec("ev-snip-anvil", kind="file_inspection", snippet="def foo(): pass")]
+    )
+    policy = EvidenceExpandPolicy(anvil_profile=True)
+    resp = expander.expand(_req(["ev-snip-anvil"], policy=policy))
+    assert len(resp.expanded) == 1
+    assert resp.expanded[0].snippet == "def foo(): pass"
+
+
+# ---------------------------------------------------------------------------
+# Stable reason strings — API round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_api_stable_reason_not_found(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    with TestClient(app) as client:
+        resp = client.post("/v1/evidence/expand", json=_api_body(["missing-id"]))
+    assert resp.status_code == 200
+    assert resp.json()["omitted"][0]["reason"] == "evidence_id not found"
+
+
+def test_api_stable_reason_raw_denied(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    records = [{"evidence_id": "ev-raw-st", "kind": "stdout", "summary": "s", "stdout": "log"}]
+    with TestClient(app) as client:
+        resp = client.post(
+            "/v1/evidence/expand", json=_api_body(["ev-raw-st"], extra_records=records)
+        )
+    assert resp.status_code == 200
+    assert resp.json()["omitted"][0]["reason"] == "raw output denied by policy"
+
+
+def test_api_stable_reason_anvil_raw_denied(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    records = [{"evidence_id": "ev-anvil-raw", "kind": "stdout", "summary": "s", "stdout": "log"}]
+    body = _api_body(
+        ["ev-anvil-raw"],
+        extra_records=records,
+        policy={"allow_raw_full_output": True, "redact_again": True, "anvil_profile": True},
+    )
+    with TestClient(app) as client:
+        resp = client.post("/v1/evidence/expand", json=body)
+    assert resp.status_code == 200
+    assert resp.json()["omitted"][0]["reason"] == "raw output denied: anvil profile"
+
+
+def test_api_stable_reason_not_in_selection(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    records = [{"evidence_id": "ev-blocked", "kind": "file_inspection", "summary": "s", "snippet": "x"}]
+    body = _api_body(["ev-blocked"], extra_records=records)
+    body["selected_evidence_ids"] = ["ev-allowed-only"]
+    with TestClient(app) as client:
+        resp = client.post("/v1/evidence/expand", json=body)
+    assert resp.status_code == 200
+    assert resp.json()["omitted"][0]["reason"] == "evidence_id not in selected_evidence_ids"

--- a/workspace/anvil/summary.md
+++ b/workspace/anvil/summary.md
@@ -1,0 +1,56 @@
+# Anvil ↔ PHOTON Evidence Expansion Contract
+
+## Endpoint
+
+`POST /v1/evidence/expand`
+
+## Anvil-safe usage pattern
+
+```json
+{
+  "schema_version": "action-memory.v0.2",
+  "request_id": "<uuid>",
+  "evidence_ids": ["<id1>", "<id2>"],
+  "selected_evidence_ids": ["<id1>", "<id2>"],
+  "budget": {
+    "max_chars_per_evidence": 1200,
+    "max_total_chars": 4800
+  },
+  "policy": {
+    "redact_again": true,
+    "allow_raw_full_output": false,
+    "anvil_profile": true
+  }
+}
+```
+
+## Policy flags
+
+| Flag | Default | Effect |
+|------|---------|--------|
+| `anvil_profile` | `false` | When `true`, raw stdout/stderr is always omitted regardless of `allow_raw_full_output`. |
+| `selected_evidence_ids` | `null` | When set, only evidence IDs in this list may be expanded; all others are omitted with a stable reason. |
+| `redact_again` | `true` | Re-applies the sanitizer before returning the snippet. Keep `true` in Anvil profile. |
+
+## Stable omit reasons
+
+Anvil renderer may rely on these exact strings:
+
+| Reason | When |
+|--------|------|
+| `"evidence_id not found"` | Requested ID has no record in the store. |
+| `"evidence_id not in selected_evidence_ids"` | ID is not in the caller-supplied allowlist. |
+| `"raw output denied by policy"` | Raw stdout/stderr denied by default policy. |
+| `"raw output denied: anvil profile"` | Raw stdout/stderr denied because `anvil_profile=true`. |
+| `"no expandable content available"` | Record exists but has no snippet, text, or raw content. |
+| `"max_total_chars budget exhausted"` | `max_total_chars` limit reached before this ID was processed. |
+
+## Budget enforcement
+
+- `max_chars_per_evidence` caps each individual snippet (default 1200).
+- `max_total_chars` caps the sum across all expanded items; remaining IDs are omitted once the budget is exhausted.
+- Both limits are applied before sanitizer re-run, so the final snippet may be slightly shorter after redaction.
+
+## Evidence not found → 200 + omitted
+
+A missing `evidence_id` never causes a non-2xx response. It appears in the `omitted` list with reason `"evidence_id not found"`.


### PR DESCRIPTION
Closes #66

## Summary

- `POST /v1/evidence/expand` を Anvil から安全に使える粒度に整える。

## Changed Files

- `photon_action_memory/api/schema_v2.py`
- `photon_action_memory/api/server.py`
- `photon_action_memory/memory/evidence.py`
- `photon_action_memory/context/raw_policy.py`
- `workspace/anvil/summary.md`

## Tests Run

- 未実行

## Known Risks

- None recorded by orchestration planner.

## Orchestration

- Run ID: `20260507-013647-orchestrate`
