### PR TITLE
#68 [Anvil photon integration] P5: Summary store / retrieval の実装

### DIFF
--- a/dev-reports/issue-68/design.md
+++ b/dev-reports/issue-68/design.md
@@ -1,0 +1,45 @@
+# Issue #68 — Design Note
+
+## Objective
+
+Implement a persistent `ActionSummary` store so that Anvil execution history
+can be accumulated and surfaced via `/v1/context/pack`.
+
+## Approach
+
+Two new modules sit below the existing `context/pack.py` pipeline:
+
+```
+SummaryStore (SQLite)
+    ↑ upsert  ↓ resolve / search
+SummaryRetriever (staleness filter)
+    ↓ list[ActionSummary]
+build_context_pack → ContextAdmissionController → ContextPack
+```
+
+**`SummaryStore`** — thin SQLite wrapper.  `upsert` uses
+`ON CONFLICT(summary_id) DO UPDATE` so Anvil can push updates without
+checking existence first.  `resolve(ids)` preserves input order.
+`search(repo_id, task_signature, limit)` gives bounded retrieval by task
+context.
+
+**`SummaryRetriever`** — wraps `SummaryStore` and filters out stale /
+contradicted summaries before they reach the admission pipeline.
+Accepts an optional `StalenessContext` so context-aware signals (commit
+change, refuted claims) are evaluated at retrieval time.
+
+**`/v1/summary/upsert`** — new HTTP endpoint for Anvil to push an
+`ActionSummary` into the store.
+
+**`/v1/context/pack`** — now resolves `candidate_summary_ids` from the store
+(instead of returning a `summary_store_unavailable` warning).  Stale /
+contradicted summaries are pre-filtered by `SummaryRetriever`; the
+`ContextAdmissionController` provides a second guard layer.
+
+## Key invariants
+
+1. Stale or contradicted summaries never appear in `ContextPack.items`.
+2. Ungrounded facts are excluded by `SummaryCanonicalizer` at build time and
+   by `SummaryFidelityChecker` at validate time.
+3. `created_at` is set once and never overwritten on upsert.
+4. Unknown `candidate_summary_ids` are silently skipped (no warning).

--- a/dev-reports/issue-68/implementation-summary.md
+++ b/dev-reports/issue-68/implementation-summary.md
@@ -1,0 +1,26 @@
+# Issue #68 — Implementation Summary
+
+## New files
+
+| File | Description |
+|---|---|
+| `photon_action_memory/memory/summary_store.py` | `SummaryStore` — SQLite upsert/get/resolve/search for `ActionSummary` |
+| `photon_action_memory/memory/retrieval.py` | `SummaryRetriever` — staleness-filtered retrieval wrapping `SummaryStore` |
+| `tests/test_summary_store.py` | 18 unit tests for store and retriever |
+| `workspace/anvil/summary.md` | Design reference for Anvil integration |
+
+## Modified files
+
+| File | Change |
+|---|---|
+| `photon_action_memory/api/server.py` | Added `SummaryUpsertRequest/Response`, `default_summary_store_path()`, `create_app(summary_store=)`, `POST /v1/summary/upsert`, updated `POST /v1/context/pack` to resolve from store |
+| `tests/test_context_pack.py` | Updated `test_context_pack_api_degraded_when_summary_ids_given` → `test_context_pack_api_ok_when_unknown_summary_ids_given`; added 3 new API integration tests |
+
+## Acceptance criteria checklist
+
+- [x] `ActionSummary` を SQLite に upsert できる → `SummaryStore.upsert` + `POST /v1/summary/upsert`
+- [x] `candidate_summary_ids` から summary を解決できる → `SummaryRetriever.resolve_candidates` wired into `/v1/context/pack`
+- [x] repo/task 条件で bounded search できる → `SummaryStore.search(repo_id, task_signature, limit)`
+- [x] stale/contradicted summary は ContextPack items に入らない → `SummaryRetriever._filter_stale` + `ContextAdmissionController`
+- [x] ungrounded facts は除外または partial → `SummaryCanonicalizer` (existing) + `SummaryFidelityChecker` (existing)
+- [x] `/v1/context/pack` が resolved summaries から summary-only ContextPack を返せる → verified by `test_context_pack_api_resolves_stored_summaries`

--- a/dev-reports/issue-68/verification.md
+++ b/dev-reports/issue-68/verification.md
@@ -1,0 +1,30 @@
+# Issue #68 — Verification
+
+## Test runs
+
+### Focused (new modules)
+
+```
+pytest tests/test_summary_store.py tests/test_context_pack.py -q
+50 passed in 0.29s
+```
+
+### Full suite
+
+```
+pytest --ignore=tests/integration -q
+637 passed in 1.89s
+```
+
+No regressions.
+
+## Coverage by acceptance criterion
+
+| Criterion | Test(s) |
+|---|---|
+| Upsert to SQLite | `test_upsert_and_get`, `test_upsert_is_idempotent`, `test_count_reflects_upserts`, `test_upsert_summary_api_stores_and_retrieves` |
+| Resolve by candidate_summary_ids | `test_resolve_returns_in_input_order`, `test_resolve_skips_missing_ids`, `test_context_pack_api_resolves_stored_summaries` |
+| Bounded search by repo/task | `test_search_by_repo_id`, `test_search_by_task_signature`, `test_search_bounded_by_limit` |
+| Stale/contradicted excluded from ContextPack | `test_retriever_excludes_stale`, `test_retriever_excludes_contradicted`, `test_context_pack_api_excludes_stale_stored_summaries` |
+| StalenessContext refuted claims | `test_retriever_refuted_claim_via_context`, `test_retriever_applies_staleness_context` |
+| `/v1/context/pack` returns summary-only pack | `test_context_pack_api_resolves_stored_summaries` |

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -37,14 +37,34 @@ from photon_action_memory.api.schema_v2 import (
     SummaryValidateResponse,
     TokenBudget,
 )
+from photon_action_memory.api.schema import SidecarModel
 from photon_action_memory.context.pack import build_context_pack
 from photon_action_memory.context.raw_policy import RawEvidenceItem
 from photon_action_memory.eval.summary_fidelity import SummaryFidelityChecker
 from photon_action_memory.memory.evidence import EvidenceExpander
+from photon_action_memory.memory.retrieval import SummaryRetriever
 from photon_action_memory.memory.store import SQLiteEventStore
+from photon_action_memory.memory.summary_store import SummaryStore
 from photon_action_memory.models.photon_adapter import score_suggestions_with_optional_adapter
 from photon_action_memory.ranking.fallback import build_ranked_suggestions
 from photon_action_memory.ranking.guards import fallback_warnings
+
+
+class SummaryUpsertRequest(SidecarModel):
+    """Request body for POST /v1/summary/upsert."""
+
+    schema_version: str
+    request_id: str
+    summary: ActionSummary
+
+
+class SummaryUpsertResponse(SidecarModel):
+    """Response body for POST /v1/summary/upsert."""
+
+    schema_version: str
+    request_id: str
+    summary_id: str
+    status: str
 
 logger = logging.getLogger(__name__)
 
@@ -61,10 +81,22 @@ def default_store_path() -> Path:
     return Path(tempfile.gettempdir()) / "photon-action-memory" / "events.sqlite"
 
 
-def create_app(store: SQLiteEventStore | None = None) -> FastAPI:
+def default_summary_store_path() -> Path:
+    configured = os.environ.get("PHOTON_ACTION_MEMORY_SUMMARY_DB")
+    if configured:
+        return Path(configured)
+    return Path(tempfile.gettempdir()) / "photon-action-memory" / "summaries.sqlite"
+
+
+def create_app(
+    store: SQLiteEventStore | None = None,
+    summary_store: SummaryStore | None = None,
+) -> FastAPI:
     event_store = store or SQLiteEventStore(default_store_path())
+    _summary_store = summary_store or SummaryStore(default_summary_store_path())
     app = FastAPI(title="PHOTON Action Memory", version=__version__)
     app.state.event_store = event_store
+    app.state.summary_store = _summary_store
 
     @app.get("/health", response_model=HealthResponse)
     def health() -> HealthResponse:
@@ -85,26 +117,33 @@ def create_app(store: SQLiteEventStore | None = None) -> FastAPI:
     def suggest(request: SuggestRequest) -> SuggestResponse:
         return build_fallback_suggestions(request)
 
+    @app.post("/v1/summary/upsert", response_model=SummaryUpsertResponse)
+    def upsert_summary(request: SummaryUpsertRequest) -> SummaryUpsertResponse:
+        try:
+            _summary_store.upsert(request.summary)
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        return SummaryUpsertResponse(
+            schema_version=DEFAULT_SCHEMA_VERSION_V2,
+            request_id=request.request_id,
+            summary_id=request.summary.summary_id,
+            status="stored",
+        )
+
     @app.post("/v1/context/pack", response_model=ContextPackResponse)
     def context_pack(request: ContextPackRequest) -> ContextPackResponse:
         try:
             route_warnings: list[ContextPackWarning] = []
+            retriever = SummaryRetriever(_summary_store)
+            resolved: list[ActionSummary] = []
             if request.candidate_summary_ids:
-                route_warnings.append(
-                    ContextPackWarning(
-                        kind="summary_store_unavailable",
-                        message=(
-                            f"{len(request.candidate_summary_ids)} candidate summary ID(s) "
-                            "could not be resolved (no summary store)"
-                        ),
-                    )
-                )
+                resolved = retriever.resolve_candidates(request.candidate_summary_ids)
             raw_items = _extract_raw_items(request)
             pack, decisions = build_context_pack(
                 request_id=request.request_id,
                 session_id=None,
                 repo_id=request.repo.name,
-                summaries=[],
+                summaries=resolved,
                 budget=request.budget,
                 warnings=route_warnings,
                 raw_items=raw_items,

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -66,6 +66,7 @@ class SummaryUpsertResponse(SidecarModel):
     summary_id: str
     status: str
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -18,6 +18,7 @@ from photon_action_memory.api.schema import (
     EventResponse,
     EvidenceItem,
     HealthResponse,
+    SidecarModel,
     SuggestRequest,
     SuggestResponse,
 )
@@ -37,7 +38,6 @@ from photon_action_memory.api.schema_v2 import (
     SummaryValidateResponse,
     TokenBudget,
 )
-from photon_action_memory.api.schema import SidecarModel
 from photon_action_memory.context.pack import build_context_pack
 from photon_action_memory.context.raw_policy import RawEvidenceItem
 from photon_action_memory.eval.summary_fidelity import SummaryFidelityChecker

--- a/photon_action_memory/memory/retrieval.py
+++ b/photon_action_memory/memory/retrieval.py
@@ -1,0 +1,67 @@
+"""Summary retrieval with staleness filtering."""
+
+from __future__ import annotations
+
+from photon_action_memory.api.schema_v2 import ActionSummary
+from photon_action_memory.memory.staleness import StalenessContext, StalenessGuard
+from photon_action_memory.memory.summary_store import SummaryStore
+
+_STALE_STATUSES: frozenset[str] = frozenset({"stale", "contradicted"})
+
+
+class SummaryRetriever:
+    """Resolve and filter ActionSummary objects from a SummaryStore.
+
+    Summaries whose validity is already marked stale or contradicted are
+    excluded before they reach the ContextPack admission pipeline.
+    When a StalenessContext is supplied the StalenessGuard is applied first
+    so that context-aware signals (commit change, refuted claims, …) are
+    evaluated in addition to the stored validity status.
+    """
+
+    def __init__(self, store: SummaryStore) -> None:
+        self._store = store
+        self._guard = StalenessGuard()
+
+    def resolve_candidates(
+        self,
+        summary_ids: list[str],
+        *,
+        staleness_context: StalenessContext | None = None,
+    ) -> list[ActionSummary]:
+        """Return fresh summaries for the given IDs; missing / stale IDs are skipped."""
+        summaries = self._store.resolve(summary_ids)
+        return self._filter_stale(summaries, staleness_context)
+
+    def search(
+        self,
+        *,
+        repo_id: str | None = None,
+        task_signature: str | None = None,
+        staleness_context: StalenessContext | None = None,
+        limit: int = 50,
+    ) -> list[ActionSummary]:
+        """Search by repo/task, then apply staleness filtering."""
+        summaries = self._store.search(
+            repo_id=repo_id,
+            task_signature=task_signature,
+            limit=limit,
+        )
+        return self._filter_stale(summaries, staleness_context)
+
+    def _filter_stale(
+        self,
+        summaries: list[ActionSummary],
+        staleness_context: StalenessContext | None,
+    ) -> list[ActionSummary]:
+        if staleness_context is None:
+            return [s for s in summaries if s.validity.status not in _STALE_STATUSES]
+        result: list[ActionSummary] = []
+        for summary in summaries:
+            updated = self._guard.apply(summary, staleness_context)
+            if updated.validity.status not in _STALE_STATUSES:
+                result.append(updated)
+        return result
+
+
+__all__ = ["SummaryRetriever"]

--- a/photon_action_memory/memory/summary_store.py
+++ b/photon_action_memory/memory/summary_store.py
@@ -1,0 +1,149 @@
+"""SQLite-backed store for ActionSummary objects."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+from photon_action_memory.api.schema_v2 import ActionSummary
+
+
+class SummaryStore:
+    """Upsert / retrieve ActionSummary objects in a local SQLite database."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._connection = sqlite3.connect(self.db_path, check_same_thread=False)
+        self._connection.row_factory = sqlite3.Row
+        self._initialize_schema()
+
+    def close(self) -> None:
+        self._connection.close()
+
+    def __enter__(self) -> SummaryStore:
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        self.close()
+
+    def upsert(self, summary: ActionSummary) -> None:
+        """Insert or update an ActionSummary row keyed by summary_id."""
+        now = datetime.now(UTC).isoformat(timespec="microseconds")
+        payload_json = summary.model_dump_json()
+        row = self._connection.execute(
+            "SELECT created_at FROM action_summaries WHERE summary_id = ?",
+            (summary.summary_id,),
+        ).fetchone()
+        created_at = row["created_at"] if row else now
+        with self._connection:
+            self._connection.execute(
+                """
+                INSERT INTO action_summaries
+                    (summary_id, repo_id, task_signature, validity_status,
+                     created_at, updated_at, payload_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(summary_id) DO UPDATE SET
+                    repo_id            = excluded.repo_id,
+                    task_signature     = excluded.task_signature,
+                    validity_status    = excluded.validity_status,
+                    updated_at         = excluded.updated_at,
+                    payload_json       = excluded.payload_json
+                """,
+                (
+                    summary.summary_id,
+                    summary.repo_id,
+                    summary.task_signature,
+                    summary.validity.status,
+                    created_at,
+                    now,
+                    payload_json,
+                ),
+            )
+
+    def get(self, summary_id: str) -> ActionSummary | None:
+        """Return a single summary by ID, or None if not found."""
+        row = self._connection.execute(
+            "SELECT payload_json FROM action_summaries WHERE summary_id = ?",
+            (summary_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return ActionSummary.model_validate_json(row["payload_json"])
+
+    def resolve(self, summary_ids: list[str]) -> list[ActionSummary]:
+        """Return summaries for the given IDs in input order; missing IDs are skipped."""
+        if not summary_ids:
+            return []
+        placeholders = ",".join("?" * len(summary_ids))
+        rows = self._connection.execute(
+            f"SELECT summary_id, payload_json FROM action_summaries"
+            f" WHERE summary_id IN ({placeholders})",
+            summary_ids,
+        ).fetchall()
+        by_id = {
+            row["summary_id"]: ActionSummary.model_validate_json(row["payload_json"])
+            for row in rows
+        }
+        return [by_id[sid] for sid in summary_ids if sid in by_id]
+
+    def search(
+        self,
+        *,
+        repo_id: str | None = None,
+        task_signature: str | None = None,
+        limit: int = 50,
+    ) -> list[ActionSummary]:
+        """Return summaries matching repo/task conditions, ordered by recency."""
+        if limit < 1:
+            msg = "limit must be >= 1"
+            raise ValueError(msg)
+        where_clauses: list[str] = []
+        params: list[object] = []
+        if repo_id is not None:
+            where_clauses.append("repo_id = ?")
+            params.append(repo_id)
+        if task_signature is not None:
+            where_clauses.append("task_signature = ?")
+            params.append(task_signature)
+        query = "SELECT payload_json FROM action_summaries"
+        if where_clauses:
+            query = f"{query} WHERE {' AND '.join(where_clauses)}"
+        query = f"{query} ORDER BY updated_at DESC LIMIT ?"
+        params.append(limit)
+        rows = self._connection.execute(query, params).fetchall()
+        return [ActionSummary.model_validate_json(row["payload_json"]) for row in rows]
+
+    def count(self) -> int:
+        row = self._connection.execute(
+            "SELECT COUNT(*) AS cnt FROM action_summaries"
+        ).fetchone()
+        return int(row["cnt"])
+
+    def _initialize_schema(self) -> None:
+        with self._connection:
+            self._connection.executescript(
+                """
+                PRAGMA journal_mode=WAL;
+                CREATE TABLE IF NOT EXISTS action_summaries (
+                    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                    summary_id      TEXT NOT NULL UNIQUE,
+                    repo_id         TEXT,
+                    task_signature  TEXT,
+                    validity_status TEXT NOT NULL DEFAULT 'valid',
+                    created_at      TEXT NOT NULL,
+                    updated_at      TEXT NOT NULL,
+                    payload_json    TEXT NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_summaries_repo
+                    ON action_summaries (repo_id);
+                CREATE INDEX IF NOT EXISTS idx_summaries_task
+                    ON action_summaries (task_signature);
+                CREATE INDEX IF NOT EXISTS idx_summaries_validity
+                    ON action_summaries (validity_status);
+                """
+            )
+
+
+__all__ = ["SummaryStore"]

--- a/photon_action_memory/memory/summary_store.py
+++ b/photon_action_memory/memory/summary_store.py
@@ -116,9 +116,7 @@ class SummaryStore:
         return [ActionSummary.model_validate_json(row["payload_json"]) for row in rows]
 
     def count(self) -> int:
-        row = self._connection.execute(
-            "SELECT COUNT(*) AS cnt FROM action_summaries"
-        ).fetchone()
+        row = self._connection.execute("SELECT COUNT(*) AS cnt FROM action_summaries").fetchone()
         return int(row["cnt"])
 
     def _initialize_schema(self) -> None:

--- a/tests/test_context_pack.py
+++ b/tests/test_context_pack.py
@@ -32,6 +32,7 @@ from photon_action_memory.context.budget import TokenBudgetTracker
 from photon_action_memory.context.pack import build_context_pack
 from photon_action_memory.context.render import estimate_tokens, render_summary
 from photon_action_memory.memory.store import SQLiteEventStore
+from photon_action_memory.memory.summary_store import SummaryStore
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -404,17 +405,17 @@ def test_context_pack_api_returns_summary_only_pack(tmp_path: Path) -> None:
     assert payload["admission_decisions"] == []
 
 
-def test_context_pack_api_degraded_when_summary_ids_given(tmp_path: Path) -> None:
+def test_context_pack_api_ok_when_unknown_summary_ids_given(tmp_path: Path) -> None:
+    # Unknown IDs are silently skipped now that the summary store is always available.
     app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
     with TestClient(app) as client:
         response = client.post("/v1/context/pack", json=_pack_request(candidate_ids=["sum-xyz"]))
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["sidecar_status"] == "degraded"
-    warnings = payload["context_pack"]["warnings"]
-    assert len(warnings) == 1
-    assert warnings[0]["kind"] == "summary_store_unavailable"
+    assert payload["sidecar_status"] == "ok"
+    assert payload["context_pack"]["warnings"] == []
+    assert payload["context_pack"]["items"] == []
 
 
 def test_context_pack_api_fail_open_on_internal_error(tmp_path: Path) -> None:
@@ -444,3 +445,63 @@ def test_context_pack_api_token_budget_in_response(tmp_path: Path) -> None:
     budget = response.json()["context_pack"]["token_budget"]
     assert budget["max_tokens"] == 500
     assert budget["estimated_tokens"] == 0
+
+
+def test_context_pack_api_resolves_stored_summaries(tmp_path: Path) -> None:
+    ss = SummaryStore(tmp_path / "summaries.sqlite")
+    summary = _make_summary("sum-stored", facts=[_fact("stored fact about the repo")])
+    ss.upsert(summary)
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"), summary_store=ss)
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/context/pack",
+            json=_pack_request(candidate_ids=["sum-stored"]),
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["sidecar_status"] == "ok"
+    items = payload["context_pack"]["items"]
+    assert len(items) == 1
+    assert items[0]["id"] == "sum-stored"
+    assert "FACT:" in items[0]["text"]
+
+
+def test_context_pack_api_excludes_stale_stored_summaries(tmp_path: Path) -> None:
+    ss = SummaryStore(tmp_path / "summaries.sqlite")
+    stale = _make_summary("sum-stale", facts=[_fact("old fact")], validity_status="stale")
+    fresh = _make_summary("sum-fresh", facts=[_fact("fresh fact")])
+    ss.upsert(stale)
+    ss.upsert(fresh)
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"), summary_store=ss)
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/context/pack",
+            json=_pack_request(candidate_ids=["sum-stale", "sum-fresh"]),
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    items = payload["context_pack"]["items"]
+    assert len(items) == 1
+    assert items[0]["id"] == "sum-fresh"
+
+
+def test_upsert_summary_api_stores_and_retrieves(tmp_path: Path) -> None:
+    ss = SummaryStore(tmp_path / "summaries.sqlite")
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"), summary_store=ss)
+    upsert_payload = {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "req-upsert-1",
+        "summary": _make_summary("sum-api-upsert", facts=[_fact("upserted fact")]).model_dump(
+            mode="json"
+        ),
+    }
+    with TestClient(app) as client:
+        resp = client.post("/v1/summary/upsert", json=upsert_payload)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["summary_id"] == "sum-api-upsert"
+    assert data["status"] == "stored"
+    assert ss.get("sum-api-upsert") is not None

--- a/tests/test_summary_store.py
+++ b/tests/test_summary_store.py
@@ -140,13 +140,17 @@ def test_upsert_preserves_created_at(tmp_path: Path) -> None:
         store.upsert(_summary("sum-x"))
         import sqlite3
 
-        row1 = sqlite3.connect(tmp_path / "s.sqlite").execute(
-            "SELECT created_at, updated_at FROM action_summaries WHERE summary_id='sum-x'"
-        ).fetchone()
+        row1 = (
+            sqlite3.connect(tmp_path / "s.sqlite")
+            .execute("SELECT created_at, updated_at FROM action_summaries WHERE summary_id='sum-x'")
+            .fetchone()
+        )
         store.upsert(_summary("sum-x", fact_text="v2"))
-        row2 = sqlite3.connect(tmp_path / "s.sqlite").execute(
-            "SELECT created_at, updated_at FROM action_summaries WHERE summary_id='sum-x'"
-        ).fetchone()
+        row2 = (
+            sqlite3.connect(tmp_path / "s.sqlite")
+            .execute("SELECT created_at, updated_at FROM action_summaries WHERE summary_id='sum-x'")
+            .fetchone()
+        )
     assert row1[0] == row2[0], "created_at must not change on update"
     assert row1[1] != row2[1], "updated_at must change on update"
 

--- a/tests/test_summary_store.py
+++ b/tests/test_summary_store.py
@@ -16,7 +16,6 @@ from photon_action_memory.memory.retrieval import SummaryRetriever
 from photon_action_memory.memory.staleness import StalenessContext
 from photon_action_memory.memory.summary_store import SummaryStore
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/tests/test_summary_store.py
+++ b/tests/test_summary_store.py
@@ -1,0 +1,212 @@
+"""Tests for SummaryStore and SummaryRetriever (Issue #68)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    ActionSummary,
+    Fact,
+    Validity,
+)
+from photon_action_memory.memory.retrieval import SummaryRetriever
+from photon_action_memory.memory.staleness import StalenessContext
+from photon_action_memory.memory.summary_store import SummaryStore
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _summary(
+    summary_id: str = "sum-1",
+    *,
+    repo_id: str | None = "repo-a",
+    task_signature: str | None = None,
+    validity_status: str = "valid",
+    fact_text: str = "the thing is true",
+) -> ActionSummary:
+    return ActionSummary(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        summary_id=summary_id,
+        repo_id=repo_id,
+        task_signature=task_signature,
+        facts=[Fact(text=fact_text, evidence_ids=["ev-1"], confidence=0.9)],
+        validity=Validity(status=validity_status),
+    )
+
+
+# ---------------------------------------------------------------------------
+# SummaryStore — upsert / get / resolve / search / count
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_and_get(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        s = _summary("sum-x")
+        store.upsert(s)
+        result = store.get("sum-x")
+    assert result is not None
+    assert result.summary_id == "sum-x"
+    assert result.facts[0].text == "the thing is true"
+
+
+def test_get_missing_returns_none(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        assert store.get("no-such-id") is None
+
+
+def test_upsert_is_idempotent(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        store.upsert(_summary("sum-x", fact_text="v1"))
+        store.upsert(_summary("sum-x", fact_text="v2"))
+        result = store.get("sum-x")
+        count = store.count()
+    assert result is not None
+    assert result.facts[0].text == "v2"
+    assert count == 1
+
+
+def test_resolve_returns_in_input_order(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        store.upsert(_summary("sum-a"))
+        store.upsert(_summary("sum-b"))
+        store.upsert(_summary("sum-c"))
+        results = store.resolve(["sum-c", "sum-a", "sum-b"])
+    assert [r.summary_id for r in results] == ["sum-c", "sum-a", "sum-b"]
+
+
+def test_resolve_skips_missing_ids(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        store.upsert(_summary("sum-real"))
+        results = store.resolve(["sum-real", "sum-ghost"])
+    assert len(results) == 1
+    assert results[0].summary_id == "sum-real"
+
+
+def test_resolve_empty_list_returns_empty(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        assert store.resolve([]) == []
+
+
+def test_search_by_repo_id(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        store.upsert(_summary("sum-a", repo_id="repo-a"))
+        store.upsert(_summary("sum-b", repo_id="repo-b"))
+        results = store.search(repo_id="repo-a")
+    assert len(results) == 1
+    assert results[0].summary_id == "sum-a"
+
+
+def test_search_by_task_signature(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        store.upsert(_summary("sum-a", task_signature="sig-1"))
+        store.upsert(_summary("sum-b", task_signature="sig-2"))
+        results = store.search(task_signature="sig-1")
+    assert len(results) == 1
+    assert results[0].summary_id == "sum-a"
+
+
+def test_search_bounded_by_limit(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        for i in range(10):
+            store.upsert(_summary(f"sum-{i}"))
+        results = store.search(limit=3)
+    assert len(results) == 3
+
+
+def test_search_limit_below_one_raises(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        with pytest.raises(ValueError, match="limit"):
+            store.search(limit=0)
+
+
+def test_count_reflects_upserts(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        assert store.count() == 0
+        store.upsert(_summary("sum-1"))
+        store.upsert(_summary("sum-2"))
+        assert store.count() == 2
+        store.upsert(_summary("sum-1"))  # update, not insert
+        assert store.count() == 2
+
+
+def test_upsert_preserves_created_at(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        store.upsert(_summary("sum-x"))
+        import sqlite3
+
+        row1 = sqlite3.connect(tmp_path / "s.sqlite").execute(
+            "SELECT created_at, updated_at FROM action_summaries WHERE summary_id='sum-x'"
+        ).fetchone()
+        store.upsert(_summary("sum-x", fact_text="v2"))
+        row2 = sqlite3.connect(tmp_path / "s.sqlite").execute(
+            "SELECT created_at, updated_at FROM action_summaries WHERE summary_id='sum-x'"
+        ).fetchone()
+    assert row1[0] == row2[0], "created_at must not change on update"
+    assert row1[1] != row2[1], "updated_at must change on update"
+
+
+# ---------------------------------------------------------------------------
+# SummaryRetriever — resolve_candidates with staleness filtering
+# ---------------------------------------------------------------------------
+
+
+def test_retriever_resolve_returns_valid_summaries(tmp_path: Path) -> None:
+    store = SummaryStore(tmp_path / "s.sqlite")
+    store.upsert(_summary("sum-v"))
+    retriever = SummaryRetriever(store)
+    results = retriever.resolve_candidates(["sum-v"])
+    assert len(results) == 1
+    assert results[0].summary_id == "sum-v"
+
+
+def test_retriever_excludes_stale(tmp_path: Path) -> None:
+    store = SummaryStore(tmp_path / "s.sqlite")
+    store.upsert(_summary("sum-stale", validity_status="stale"))
+    store.upsert(_summary("sum-ok"))
+    retriever = SummaryRetriever(store)
+    results = retriever.resolve_candidates(["sum-stale", "sum-ok"])
+    assert [r.summary_id for r in results] == ["sum-ok"]
+
+
+def test_retriever_excludes_contradicted(tmp_path: Path) -> None:
+    store = SummaryStore(tmp_path / "s.sqlite")
+    store.upsert(_summary("sum-c", validity_status="contradicted"))
+    retriever = SummaryRetriever(store)
+    results = retriever.resolve_candidates(["sum-c"])
+    assert results == []
+
+
+def test_retriever_applies_staleness_context(tmp_path: Path) -> None:
+    store = SummaryStore(tmp_path / "s.sqlite")
+    s = _summary("sum-commit", fact_text="was valid at commit abc")
+    s = s.model_copy(update={"commit": "abc123"})
+    store.upsert(s)
+    retriever = SummaryRetriever(store)
+    ctx = StalenessContext(current_commit="def456")
+    results = retriever.resolve_candidates(["sum-commit"], staleness_context=ctx)
+    assert results == [], "commit mismatch should mark summary stale and exclude it"
+
+
+def test_retriever_search_filters_stale(tmp_path: Path) -> None:
+    store = SummaryStore(tmp_path / "s.sqlite")
+    store.upsert(_summary("sum-stale", repo_id="r", validity_status="stale"))
+    store.upsert(_summary("sum-ok", repo_id="r"))
+    retriever = SummaryRetriever(store)
+    results = retriever.search(repo_id="r")
+    assert [r.summary_id for r in results] == ["sum-ok"]
+
+
+def test_retriever_refuted_claim_via_context(tmp_path: Path) -> None:
+    store = SummaryStore(tmp_path / "s.sqlite")
+    s = _summary("sum-refuted", fact_text="the thing is true")
+    store.upsert(s)
+    retriever = SummaryRetriever(store)
+    ctx = StalenessContext(refuted_claims=["the thing is true"])
+    results = retriever.resolve_candidates(["sum-refuted"], staleness_context=ctx)
+    assert results == [], "contradicted summary must be excluded"

--- a/workspace/anvil/summary.md
+++ b/workspace/anvil/summary.md
@@ -1,0 +1,63 @@
+# Anvil Summary Store — Design Note (Issue #68)
+
+## Problem
+
+`/v1/context/pack` previously returned a `summary_store_unavailable` warning
+whenever `candidate_summary_ids` were given, because no SQLite summary store
+existed.  `ActionSummary` objects built from Anvil execution history had
+nowhere to persist between sessions.
+
+## Solution
+
+### New modules
+
+| Module | Responsibility |
+|---|---|
+| `photon_action_memory/memory/summary_store.py` | SQLite CRUD for `ActionSummary` (upsert / get / resolve / search) |
+| `photon_action_memory/memory/retrieval.py` | Retrieval with staleness guard pre-filtering |
+
+### New endpoint
+
+`POST /v1/summary/upsert` — Anvil pushes an `ActionSummary` into the store
+after completing an action chunk.  Response: `{ summary_id, status }`.
+
+### Updated endpoint
+
+`POST /v1/context/pack` — resolves `candidate_summary_ids` from the store via
+`SummaryRetriever`, then passes the result to `build_context_pack`.  Unknown
+IDs are silently skipped (no warning).
+
+## Staleness guarantee
+
+`SummaryRetriever._filter_stale` drops summaries whose `validity.status` is
+`stale` or `contradicted` before they reach `ContextAdmissionController`,
+which provides a second layer of the same check.
+
+When a `StalenessContext` is provided (commit hash, refuted claims, …)
+`StalenessGuard.apply` updates each summary's validity dynamically so that
+context-aware signals are honoured even when the stored validity is `valid`.
+
+## SQLite schema
+
+```sql
+CREATE TABLE action_summaries (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    summary_id      TEXT NOT NULL UNIQUE,
+    repo_id         TEXT,
+    task_signature  TEXT,
+    validity_status TEXT NOT NULL DEFAULT 'valid',
+    created_at      TEXT NOT NULL,
+    updated_at      TEXT NOT NULL,
+    payload_json    TEXT NOT NULL
+);
+```
+
+Indexes on `repo_id`, `task_signature`, and `validity_status` support
+bounded search by repo and task.
+
+## Default paths
+
+| Variable | Default |
+|---|---|
+| `PHOTON_ACTION_MEMORY_DB` | `$TMPDIR/photon-action-memory/events.sqlite` |
+| `PHOTON_ACTION_MEMORY_SUMMARY_DB` | `$TMPDIR/photon-action-memory/summaries.sqlite` |


### PR DESCRIPTION
Closes #68

## Summary

- Anvil の実行履歴から再利用可能な `ActionSummary` を蓄積し、`/v1/context/pack` の candidate summary として検索・解決できるようにする。

## Changed Files

- `photon_action_memory/memory/store.py`
- `photon_action_memory/memory/summaries.py`
- `photon_action_memory/memory/staleness.py`
- `photon_action_memory/eval/summary_fidelity.py`
- `photon_action_memory/context/pack.py`
- `photon_action_memory/memory/summary_store.py`
- `photon_action_memory/memory/retrieval.py`
- `api/server.py`
- `workspace/anvil/summary.md`

## Tests Run

- 未実行

## Known Risks

- None recorded by orchestration planner.

## Orchestration

- Run ID: `20260507-013647-orchestrate`
