### PR TITLE
#69 [Anvil photon integration] P6: PHOTON scoring の Anvil ログ対応

### DIFF
--- a/dev-reports/issue-69/design.md
+++ b/dev-reports/issue-69/design.md
@@ -1,0 +1,74 @@
+# Issue #69 — Design Note
+
+## Objective
+
+Apply Anvil evaluate log data to the PHOTON Context Firewall scoring system.
+Derive quality signals from `ContextPackEvalRecord` sequences and use them to
+boost `FallbackContextScorer` scores, while guaranteeing that stale/contradicted
+items cannot recover to valid-item score ranges.
+
+## Approach
+
+Two new modules:
+
+```
+ContextPackEvalRecord (from /v1/evaluate logs)
+    ↓
+aggregate_anvil_feedback()   [eval/anvil_feedback.py]
+    → PackFeedback (aggregate counts + rates, no raw content)
+    → EvidenceFeedback (per-evidence expansion × outcome correlation)
+         ↓
+FeedbackAdjustedContextScorer.score_*()  [ranking/feedback.py]
+    → boosted AdmissionScore / EvidenceExpansionScore / SummaryUsefulnessScore
+    → unchanged StalenessRiskScore (never adjusted)
+```
+
+### `eval/anvil_feedback.py`
+
+Aggregates `ContextPackEvalRecord` sequences into `PackFeedback`.
+
+**Excluded statuses** (`EXCLUDED_QUALITY_STATUSES`): `error`, `not_available`,
+`shadow_not_injected`. These records are counted in `total_turns` but excluded
+from `quality_turns` and `quality_score` to prevent infrastructure noise from
+diluting the quality signal.
+
+`quality_score = success_count / quality_turns` where success outcomes are
+`{success, accepted, completed}`.
+
+Per-evidence `EvidenceFeedback` is derived from which `evidence_ids_expanded`
+correlated with success outcomes across quality turns.
+
+`PackFeedback` stores only aggregate counts and rates — no raw prompts, tool
+outputs, or user text — making it safe to persist for future model training.
+
+### `ranking/feedback.py`
+
+Provides `apply_feedback_boost(base_score, status, quality_score)` and
+`FeedbackAdjustedContextScorer`.
+
+**Hard caps** (enforced regardless of feedback magnitude):
+
+| Status | Max score |
+|---|---|
+| `stale` | 0.25 |
+| `contradicted` | 0.15 |
+| `unsafe` | 0.15 |
+| others | 1.0 (no cap) |
+
+The 0.25 cap for stale sits above the natural deterministic max for stale items
+(≈ 0.20) but well below feedback-boosted valid items, so the ranking order is
+preserved.
+
+**Staleness risk**: `score_staleness_risk` delegates entirely to
+`FallbackContextScorer` with no feedback adjustment. Stale always stays stale.
+
+**Evidence expansion**: uses per-evidence `quality_score` when the evidence ID
+has been seen before; falls back to the pack-level `quality_score` for unseen IDs.
+
+## Key invariants
+
+1. stale/contradicted/unsafe items never exceed their hard cap, even at maximum feedback.
+2. Staleness risk scores are not modified by any feedback signal.
+3. `PackFeedback` / `EvidenceFeedback` contain only aggregate-safe features.
+4. fail-open/error/not_available/shadow_not_injected turns are excluded from quality_score.
+5. `FeedbackAdjustedContextScorer` satisfies `ContextScorerProtocol` and is injectable.

--- a/dev-reports/issue-69/implementation-summary.md
+++ b/dev-reports/issue-69/implementation-summary.md
@@ -1,0 +1,41 @@
+# Issue #69 — Implementation Summary
+
+## New files
+
+### `photon_action_memory/eval/anvil_feedback.py`
+
+- `EXCLUDED_QUALITY_STATUSES` — frozenset of statuses excluded from quality signal.
+- `EvidenceFeedback` — per-evidence aggregate: `expansion_count`, `success_count`, `quality_score`.
+- `PackFeedback` — pack-level aggregate: turn counts, adoption/success counts, `quality_score`, `evidence_feedback` dict.
+- `aggregate_anvil_feedback(records)` — builds `PackFeedback` from `ContextPackEvalRecord` sequence, excluding fail-open/error turns.
+
+### `photon_action_memory/ranking/feedback.py`
+
+- `STALE_MAX_SCORE = 0.25` / `CONTRADICTED_MAX_SCORE = 0.15` / `MAX_QUALITY_BOOST = 0.2` — tunable constants.
+- `apply_feedback_boost(base_score, status, quality_score)` — bounded boost with hard cap per status.
+- `FeedbackAdjustedContextScorer` — wraps `FallbackContextScorer`, applies `PackFeedback` signals. Implements `ContextScorerProtocol`.
+
+### `tests/fixtures/v0.2/anvil_evaluate_feedback.json`
+
+Anvil evaluate fixture with 5 records: 2 adopted/success, 1 ignored/failure, 1 error (excluded), 1 shadow_not_injected (excluded). Used to test `aggregate_anvil_feedback` with the exclusion invariant.
+
+### `tests/test_anvil_feedback.py`
+
+43 tests covering all 6 acceptance criteria.
+
+## Modified files
+
+### `photon_action_memory/eval/__init__.py`
+
+Added imports and `__all__` entries for `EXCLUDED_QUALITY_STATUSES`, `EvidenceFeedback`, `PackFeedback`, `aggregate_anvil_feedback`.
+
+## Acceptance criteria mapping
+
+| Criterion | Test(s) |
+|---|---|
+| Anvil evaluate fixture → aggregate feedback | `test_feedback_fixture_validates_and_aggregates`, `test_feedback_fixture_evidence_feedback` |
+| `FallbackContextScorer` に feedback adjustment | `test_feedback_scorer_admission_boosts_valid_item`, `test_feedback_scorer_expansion_*`, `test_feedback_scorer_usefulness_*` |
+| stale/contradicted は score で復活しない | `test_feedback_scorer_admission_stale_cannot_recover`, `test_feedback_scorer_admission_contradicted_cannot_recover`, `test_feedback_scorer_stale_scores_below_valid_always` |
+| fail-open/error turn は quality signal から除外 | `test_error_turns_excluded_from_quality_turns`, `test_shadow_not_injected_excluded_from_quality_turns`, `test_not_available_excluded_from_quality_turns`, `test_all_excluded_turns_yields_zero_quality_score` |
+| learned model なしで deterministic ranking 改善 | `test_feedback_improves_ranking_of_valid_over_stale`, `test_feedback_ranking_is_deterministic` |
+| aggregate-safe feature が保存される | `test_pack_feedback_contains_only_aggregate_fields`, `test_evidence_feedback_contains_only_aggregate_fields` |

--- a/dev-reports/issue-69/verification.md
+++ b/dev-reports/issue-69/verification.md
@@ -1,0 +1,29 @@
+# Issue #69 — Verification
+
+## Test run
+
+```
+python -m pytest tests/test_anvil_feedback.py -v
+```
+
+Result: **43 passed** in 0.09 s.
+
+## Broad regression check
+
+```
+python -m pytest --tb=short -q
+```
+
+Result: **698 passed, 1 skipped** in 2.03 s.
+(Skipped: MLX smoke — opt-in on macOS workflow only.)
+
+## Acceptance criteria verification
+
+| Criterion | Status |
+|---|---|
+| Anvil evaluate fixture → aggregate feedback | PASS — `test_feedback_fixture_validates_and_aggregates` reads `anvil_evaluate_feedback.json`, asserts total_turns=5, quality_turns=3, quality_score≈0.667 |
+| `FallbackContextScorer` に feedback adjustment | PASS — boosted scores exceed base for valid items (admission, expansion, usefulness) |
+| stale/contradicted は score で復活しない | PASS — rich stale ≤ 0.25, rich contradicted ≤ 0.15 even at quality_score=1.0 |
+| fail-open/error turn は quality signal から除外 | PASS — error/shadow_not_injected/not_available excluded from quality_turns |
+| learned model なしで deterministic ranking 改善 | PASS — `test_feedback_improves_ranking_of_valid_over_stale`, `test_feedback_ranking_is_deterministic` |
+| aggregate-safe feature が保存される | PASS — `PackFeedback`/`EvidenceFeedback` contain only counts and rates, no raw content fields |

--- a/photon_action_memory/eval/__init__.py
+++ b/photon_action_memory/eval/__init__.py
@@ -1,5 +1,11 @@
 """Offline and shadow evaluation utilities."""
 
+from photon_action_memory.eval.anvil_feedback import (
+    EXCLUDED_QUALITY_STATUSES,
+    EvidenceFeedback,
+    PackFeedback,
+    aggregate_anvil_feedback,
+)
 from photon_action_memory.eval.comparison import (
     COMPARISON_REPORT_SCHEMA,
     EVAL_CONDITIONS,
@@ -45,6 +51,10 @@ from photon_action_memory.eval.summary_fidelity import SummaryFidelityChecker
 
 __all__ = [
     "COMPARISON_REPORT_SCHEMA",
+    "EXCLUDED_QUALITY_STATUSES",
+    "EvidenceFeedback",
+    "PackFeedback",
+    "aggregate_anvil_feedback",
     "EVAL_CONDITIONS",
     "LOCAL_LLM_REPORT_SCHEMA",
     "EvalAction",

--- a/photon_action_memory/eval/anvil_feedback.py
+++ b/photon_action_memory/eval/anvil_feedback.py
@@ -1,0 +1,130 @@
+"""Aggregate feedback from Anvil evaluate logs for PHOTON scoring.
+
+Derives quality signals from ContextPackEvalRecord sequences.  fail-open,
+error, not_available, and shadow_not_injected turns are excluded from the
+quality computation so that infrastructure noise does not pollute signals.
+
+The resulting PackFeedback contains only aggregate counts and rates — no raw
+prompts, tool outputs, or user text — making it safe to persist for future
+model training feature extraction.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from photon_action_memory.eval.context_pack_log import (
+    ContextPackEvalRecord,
+    RawContextPackEvalRecord,
+)
+
+# Statuses that indicate fail-open or infrastructure-error turns.
+# These contribute to total_turns but not to quality_turns or quality_score.
+EXCLUDED_QUALITY_STATUSES: frozenset[str] = frozenset(
+    {
+        "error",
+        "not_available",
+        "shadow_not_injected",
+    }
+)
+
+_SUCCESS_OUTCOMES: frozenset[str] = frozenset({"success", "accepted", "completed"})
+
+
+@dataclass(frozen=True)
+class EvidenceFeedback:
+    """Per-evidence aggregate feedback derived from Anvil evaluate logs.
+
+    expansion_count: total quality-turn expansions of this evidence_id.
+    success_count:   expansions that correlated with a success outcome.
+    quality_score:   success_count / expansion_count (0.0 if never expanded).
+
+    This is an aggregate-safe feature: it never stores raw event content.
+    """
+
+    evidence_id: str
+    expansion_count: int
+    success_count: int
+    quality_score: float
+
+
+@dataclass(frozen=True)
+class PackFeedback:
+    """Aggregate pack-level quality signal from Anvil evaluate logs.
+
+    Aggregate-safe features suitable for future model training:
+    - total_turns, quality_turns: turncount breakdown (no raw content).
+    - adoption_count, success_count, quality_score: adoption/outcome rates.
+    - evidence_feedback: per-evidence expansion × outcome correlation.
+
+    fail-open/error/not_available/shadow_not_injected records are counted in
+    total_turns but excluded from quality_turns and quality_score.
+    """
+
+    total_turns: int
+    quality_turns: int
+    adoption_count: int
+    success_count: int
+    quality_score: float
+    evidence_feedback: dict[str, EvidenceFeedback]
+
+
+def aggregate_anvil_feedback(
+    records: Sequence[RawContextPackEvalRecord],
+) -> PackFeedback:
+    """Build aggregate feedback from a sequence of Anvil evaluate log records.
+
+    Records with adoption_status in EXCLUDED_QUALITY_STATUSES are counted in
+    total_turns but excluded from quality_turns, adoption_count, success_count,
+    and quality_score.  This prevents fail-open / infrastructure errors from
+    diluting the quality signal.
+    """
+    parsed = [_coerce(r) for r in records]
+    total_turns = len(parsed)
+
+    quality_records = [r for r in parsed if r.adoption_status not in EXCLUDED_QUALITY_STATUSES]
+    quality_turns = len(quality_records)
+
+    adoption_count = sum(1 for r in quality_records if r.adoption_status in {"adopted", "partial"})
+    success_count = sum(1 for r in quality_records if r.outcome in _SUCCESS_OUTCOMES)
+    quality_score = success_count / quality_turns if quality_turns > 0 else 0.0
+
+    evidence_expansions: dict[str, list[bool]] = {}
+    for r in quality_records:
+        for ev_id in r.evidence_ids_expanded:
+            evidence_expansions.setdefault(ev_id, []).append(r.outcome in _SUCCESS_OUTCOMES)
+
+    evidence_feedback: dict[str, EvidenceFeedback] = {}
+    for ev_id, successes in evidence_expansions.items():
+        exp_count = len(successes)
+        succ_count = sum(successes)
+        evidence_feedback[ev_id] = EvidenceFeedback(
+            evidence_id=ev_id,
+            expansion_count=exp_count,
+            success_count=succ_count,
+            quality_score=succ_count / exp_count,
+        )
+
+    return PackFeedback(
+        total_turns=total_turns,
+        quality_turns=quality_turns,
+        adoption_count=adoption_count,
+        success_count=success_count,
+        quality_score=quality_score,
+        evidence_feedback=evidence_feedback,
+    )
+
+
+def _coerce(record: RawContextPackEvalRecord) -> ContextPackEvalRecord:
+    if isinstance(record, ContextPackEvalRecord):
+        return record
+    return ContextPackEvalRecord.model_validate(record)
+
+
+__all__ = [
+    "EXCLUDED_QUALITY_STATUSES",
+    "EvidenceFeedback",
+    "PackFeedback",
+    "aggregate_anvil_feedback",
+]

--- a/photon_action_memory/ranking/feedback.py
+++ b/photon_action_memory/ranking/feedback.py
@@ -1,0 +1,197 @@
+"""Feedback-adjusted context scoring for PHOTON Context Firewall.
+
+Provides apply_feedback_boost() and FeedbackAdjustedContextScorer, which
+wraps FallbackContextScorer and applies quality signals from PackFeedback.
+
+Hard invariants (never relaxed by positive feedback):
+- stale items: admission/usefulness score capped at STALE_MAX_SCORE.
+- contradicted items: admission/usefulness score capped at CONTRADICTED_MAX_SCORE.
+- unsafe items: treated identically to contradicted.
+- Staleness risk scores are NEVER adjusted — stale stays stale.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from photon_action_memory.api.schema_v2 import ActionSummary, EvidenceRef
+from photon_action_memory.eval.anvil_feedback import PackFeedback
+from photon_action_memory.models.context_scorer import (
+    AdmissionScore,
+    ContextScorerHook,
+    EvidenceExpansionScore,
+    FallbackContextScorer,
+    ScoringEvent,
+    StalenessRiskScore,
+    SummaryUsefulnessScore,
+)
+
+# Hard caps on scores for items that must not recover via feedback.
+# These sit above the natural deterministic max for stale/contradicted items
+# (stale max ≈ 0.20, contradicted max ≈ 0.10) but well below valid item scores,
+# so feedback cannot cause a stale item to rank above a valid one.
+STALE_MAX_SCORE: float = 0.25
+CONTRADICTED_MAX_SCORE: float = 0.15
+
+# Maximum additive boost from a quality_score of 1.0 (as a fraction of [0,1]).
+# Keeps the boost bounded so structural signals dominate.
+MAX_QUALITY_BOOST: float = 0.2
+
+_BLOCKED_STATUSES: frozenset[str] = frozenset({"stale", "contradicted", "unsafe"})
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def _score_cap(status: str) -> float:
+    """Hard cap on adjusted score for unsafe validity/staleness statuses."""
+    if status in {"contradicted", "unsafe"}:
+        return CONTRADICTED_MAX_SCORE
+    if status == "stale":
+        return STALE_MAX_SCORE
+    return 1.0
+
+
+def apply_feedback_boost(
+    base_score: float,
+    status: str,
+    quality_score: float,
+    *,
+    max_boost: float = MAX_QUALITY_BOOST,
+) -> float:
+    """Apply a bounded feedback quality boost to a base score.
+
+    quality_score * max_boost is added to base_score, then clamped to [0,1].
+    The result is then hard-capped by _score_cap(status) to prevent stale or
+    contradicted items from recovering to valid-item score ranges.
+    """
+    boosted = _clamp(base_score + quality_score * max_boost)
+    return _clamp(min(boosted, _score_cap(status)))
+
+
+class FeedbackAdjustedContextScorer:
+    """FallbackContextScorer with Anvil evaluate feedback adjustment.
+
+    Applies aggregate quality signals from PackFeedback:
+
+    - score_admission: base score boosted by pack quality_score, hard-capped
+      for stale/contradicted/unsafe summaries.
+    - score_evidence_expansion: base score boosted by per-evidence
+      quality_score (falls back to pack quality_score if not seen before),
+      hard-capped for stale evidence.
+    - score_summary_usefulness: same boost logic as admission.
+    - score_staleness_risk: NEVER adjusted — stale/contradicted stay stale.
+
+    Satisfies ContextScorerProtocol so it can be injected wherever
+    FallbackContextScorer is accepted.
+    """
+
+    def __init__(
+        self,
+        feedback: PackFeedback,
+        *,
+        eval_hook: ContextScorerHook | None = None,
+    ) -> None:
+        self._feedback = feedback
+        self._base = FallbackContextScorer()
+        self._hook = eval_hook
+
+    def score_admission(
+        self,
+        summaries: Sequence[ActionSummary],
+        *,
+        task_text: str = "",
+    ) -> list[AdmissionScore]:
+        base_results = self._base.score_admission(summaries, task_text=task_text)
+        adjusted: list[AdmissionScore] = []
+        for summary, base in zip(summaries, base_results, strict=False):
+            new_score = apply_feedback_boost(
+                base.score,
+                summary.validity.status,
+                self._feedback.quality_score,
+            )
+            reason = f"{base.reason} feedback_boost={self._feedback.quality_score:.2f}"
+            result = AdmissionScore(
+                summary_id=summary.summary_id,
+                score=new_score,
+                reason=reason,
+            )
+            adjusted.append(result)
+            if self._hook is not None:
+                self._hook(ScoringEvent("admission", summary.summary_id, new_score, reason))
+        return adjusted
+
+    def score_evidence_expansion(
+        self,
+        evidence_refs: Sequence[EvidenceRef],
+        *,
+        task_text: str = "",
+    ) -> list[EvidenceExpansionScore]:
+        base_results = self._base.score_evidence_expansion(evidence_refs, task_text=task_text)
+        adjusted: list[EvidenceExpansionScore] = []
+        for ref, base in zip(evidence_refs, base_results, strict=False):
+            ev_feedback = self._feedback.evidence_feedback.get(ref.evidence_id)
+            quality = (
+                ev_feedback.quality_score
+                if ev_feedback is not None
+                else self._feedback.quality_score
+            )
+            new_score = apply_feedback_boost(
+                base.score,
+                ref.staleness.status,
+                quality,
+            )
+            reason = f"{base.reason} feedback_boost={quality:.2f}"
+            result = EvidenceExpansionScore(
+                evidence_id=ref.evidence_id,
+                score=new_score,
+                reason=reason,
+            )
+            adjusted.append(result)
+            if self._hook is not None:
+                self._hook(ScoringEvent("evidence_expansion", ref.evidence_id, new_score, reason))
+        return adjusted
+
+    def score_summary_usefulness(
+        self,
+        summaries: Sequence[ActionSummary],
+        *,
+        task_text: str = "",
+    ) -> list[SummaryUsefulnessScore]:
+        base_results = self._base.score_summary_usefulness(summaries, task_text=task_text)
+        adjusted: list[SummaryUsefulnessScore] = []
+        for summary, base in zip(summaries, base_results, strict=False):
+            new_score = apply_feedback_boost(
+                base.score,
+                summary.validity.status,
+                self._feedback.quality_score,
+            )
+            reason = f"{base.reason} feedback_boost={self._feedback.quality_score:.2f}"
+            result = SummaryUsefulnessScore(
+                summary_id=summary.summary_id,
+                score=new_score,
+                reason=reason,
+            )
+            adjusted.append(result)
+            if self._hook is not None:
+                self._hook(
+                    ScoringEvent("summary_usefulness", summary.summary_id, new_score, reason)
+                )
+        return adjusted
+
+    def score_staleness_risk(
+        self,
+        summaries: Sequence[ActionSummary],
+    ) -> list[StalenessRiskScore]:
+        # Staleness risk is structural; positive feedback cannot reduce it.
+        return self._base.score_staleness_risk(summaries)
+
+
+__all__ = [
+    "CONTRADICTED_MAX_SCORE",
+    "MAX_QUALITY_BOOST",
+    "STALE_MAX_SCORE",
+    "FeedbackAdjustedContextScorer",
+    "apply_feedback_boost",
+]

--- a/tests/fixtures/v0.2/anvil_evaluate_feedback.json
+++ b/tests/fixtures/v0.2/anvil_evaluate_feedback.json
@@ -1,0 +1,61 @@
+{
+  "schema": "context-pack-eval.v1",
+  "description": "Anvil evaluate feedback fixture: 3 quality turns (2 success, 1 failure), 2 excluded (error, shadow_not_injected). Used to test aggregate_anvil_feedback and FeedbackAdjustedContextScorer.",
+  "records": [
+    {
+      "context_pack_request_id": "pack-fb-001",
+      "adoption_status": "adopted",
+      "ignored_reason": null,
+      "evidence_expand_requested": true,
+      "evidence_ids_expanded": ["ev-useful-001"],
+      "items_adopted_count": 2,
+      "items_ignored_count": 0,
+      "outcome": "success",
+      "latency_ms": 120.0
+    },
+    {
+      "context_pack_request_id": "pack-fb-002",
+      "adoption_status": "adopted",
+      "ignored_reason": null,
+      "evidence_expand_requested": true,
+      "evidence_ids_expanded": ["ev-useful-001", "ev-useful-002"],
+      "items_adopted_count": 1,
+      "items_ignored_count": 1,
+      "outcome": "success",
+      "latency_ms": 95.0
+    },
+    {
+      "context_pack_request_id": "pack-fb-003",
+      "adoption_status": "ignored",
+      "ignored_reason": "context_pack_empty",
+      "evidence_expand_requested": false,
+      "evidence_ids_expanded": [],
+      "items_adopted_count": 0,
+      "items_ignored_count": 0,
+      "outcome": "failure",
+      "latency_ms": 30.0
+    },
+    {
+      "context_pack_request_id": "pack-fb-004",
+      "adoption_status": "error",
+      "ignored_reason": "sidecar_error",
+      "evidence_expand_requested": false,
+      "evidence_ids_expanded": [],
+      "items_adopted_count": 0,
+      "items_ignored_count": 0,
+      "outcome": null,
+      "latency_ms": 8.0
+    },
+    {
+      "context_pack_request_id": "pack-fb-005",
+      "adoption_status": "shadow_not_injected",
+      "ignored_reason": "shadow_mode_no_injection",
+      "evidence_expand_requested": false,
+      "evidence_ids_expanded": [],
+      "items_adopted_count": 0,
+      "items_ignored_count": 0,
+      "outcome": null,
+      "latency_ms": 20.0
+    }
+  ]
+}

--- a/tests/test_anvil_feedback.py
+++ b/tests/test_anvil_feedback.py
@@ -1,0 +1,573 @@
+"""Tests for Anvil evaluate feedback aggregation and FeedbackAdjustedContextScorer.
+
+Acceptance criteria covered:
+- aggregate_anvil_feedback builds correct quality signal from Anvil evaluate fixture.
+- fail-open/error/shadow_not_injected/not_available turns excluded from quality signal.
+- FeedbackAdjustedContextScorer boosts valid-item scores via positive feedback.
+- stale/contradicted items are hard-capped and never score-recover via feedback.
+- Staleness risk is never adjusted by feedback.
+- Deterministic ranking improvement: feedback scorer ranks valid items higher.
+- PackFeedback stores aggregate-safe features (counts + rates, no raw content).
+- Per-evidence quality signals are derived from expansion × outcome correlation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    ActionSummary,
+    AvoidGuidance,
+    EvidenceRef,
+    Fact,
+    FailedAttempt,
+    Hypothesis,
+    StalenessStatus,
+    Validity,
+)
+from photon_action_memory.eval.anvil_feedback import (
+    EXCLUDED_QUALITY_STATUSES,
+    EvidenceFeedback,
+    PackFeedback,
+    aggregate_anvil_feedback,
+)
+from photon_action_memory.eval.context_pack_log import ContextPackEvalRecord
+from photon_action_memory.models.context_scorer import (
+    ContextScorerProtocol,
+    FallbackContextScorer,
+    ScoringEvent,
+)
+from photon_action_memory.ranking.feedback import (
+    CONTRADICTED_MAX_SCORE,
+    STALE_MAX_SCORE,
+    FeedbackAdjustedContextScorer,
+    apply_feedback_boost,
+)
+
+FIXTURES_V2 = Path(__file__).parent / "fixtures" / "v0.2"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _summary(
+    summary_id: str = "sum-001",
+    *,
+    facts: list[Fact] | None = None,
+    hypotheses: list[Hypothesis] | None = None,
+    failed_attempts: list[FailedAttempt] | None = None,
+    avoid: list[AvoidGuidance] | None = None,
+    validity_status: str = "valid",
+) -> ActionSummary:
+    return ActionSummary(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        summary_id=summary_id,
+        session_id="sess-1",
+        facts=facts or [],
+        hypotheses=hypotheses or [],
+        failed_attempts=failed_attempts or [],
+        avoid=avoid or [],
+        validity=Validity(status=validity_status),
+    )
+
+
+def _fact(text: str = "a fact") -> Fact:
+    return Fact(text=text, evidence_ids=["ev-1"])
+
+
+def _hypothesis(text: str = "a hypothesis") -> Hypothesis:
+    return Hypothesis(text=text, confidence=0.5)
+
+
+def _evidence_ref(
+    evidence_id: str = "evd-001",
+    *,
+    expand_policy: str = "on_demand_only",
+    staleness_status: str = "unknown",
+) -> EvidenceRef:
+    return EvidenceRef(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        evidence_id=evidence_id,
+        kind="tool_result",
+        summary="some evidence",
+        expand_policy=expand_policy,
+        staleness=StalenessStatus(status=staleness_status),
+    )
+
+
+def _record(
+    status: str = "adopted",
+    outcome: str | None = "success",
+    evidence_ids: list[str] | None = None,
+) -> ContextPackEvalRecord:
+    return ContextPackEvalRecord(
+        context_pack_request_id=f"pack-{status}",
+        adoption_status=status,
+        outcome=outcome,
+        evidence_expand_requested=bool(evidence_ids),
+        evidence_ids_expanded=evidence_ids or [],
+    )
+
+
+def _high_quality_feedback() -> PackFeedback:
+    return aggregate_anvil_feedback([_record("adopted", "success"), _record("adopted", "success")])
+
+
+def _zero_quality_feedback() -> PackFeedback:
+    return aggregate_anvil_feedback([_record("ignored", "failure")])
+
+
+# ---------------------------------------------------------------------------
+# aggregate_anvil_feedback — basic correctness
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_empty_returns_zero_feedback() -> None:
+    fb = aggregate_anvil_feedback([])
+    assert fb.total_turns == 0
+    assert fb.quality_turns == 0
+    assert fb.quality_score == 0.0
+    assert fb.evidence_feedback == {}
+
+
+def test_aggregate_all_success_returns_quality_score_one() -> None:
+    fb = aggregate_anvil_feedback([_record("adopted", "success"), _record("adopted", "success")])
+    assert fb.total_turns == 2
+    assert fb.quality_turns == 2
+    assert fb.quality_score == pytest.approx(1.0)
+    assert fb.adoption_count == 2
+    assert fb.success_count == 2
+
+
+def test_aggregate_mixed_computes_correct_quality_score() -> None:
+    records = [
+        _record("adopted", "success"),
+        _record("adopted", "success"),
+        _record("ignored", "failure"),
+    ]
+    fb = aggregate_anvil_feedback(records)
+    assert fb.total_turns == 3
+    assert fb.quality_turns == 3
+    assert fb.success_count == 2
+    assert fb.quality_score == pytest.approx(2 / 3)
+
+
+def test_aggregate_partial_counts_as_adoption() -> None:
+    fb = aggregate_anvil_feedback([_record("partial", "success")])
+    assert fb.adoption_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Excluded quality statuses (acceptance criterion: fail-open excluded)
+# ---------------------------------------------------------------------------
+
+
+def test_excluded_quality_statuses_set_contains_expected() -> None:
+    assert "error" in EXCLUDED_QUALITY_STATUSES
+    assert "not_available" in EXCLUDED_QUALITY_STATUSES
+    assert "shadow_not_injected" in EXCLUDED_QUALITY_STATUSES
+
+
+def test_error_turns_excluded_from_quality_turns() -> None:
+    records = [
+        _record("adopted", "success"),
+        _record("error", None),
+    ]
+    fb = aggregate_anvil_feedback(records)
+    assert fb.total_turns == 2
+    assert fb.quality_turns == 1
+    assert fb.quality_score == pytest.approx(1.0)
+
+
+def test_shadow_not_injected_excluded_from_quality_turns() -> None:
+    records = [
+        _record("adopted", "success"),
+        _record("shadow_not_injected", None),
+        _record("shadow_not_injected", None),
+    ]
+    fb = aggregate_anvil_feedback(records)
+    assert fb.total_turns == 3
+    assert fb.quality_turns == 1
+    assert fb.success_count == 1
+
+
+def test_not_available_excluded_from_quality_turns() -> None:
+    records = [
+        _record("not_available", None),
+        _record("adopted", "success"),
+    ]
+    fb = aggregate_anvil_feedback(records)
+    assert fb.quality_turns == 1
+
+
+def test_all_excluded_turns_yields_zero_quality_score() -> None:
+    records = [_record("error", None), _record("not_available", None)]
+    fb = aggregate_anvil_feedback(records)
+    assert fb.total_turns == 2
+    assert fb.quality_turns == 0
+    assert fb.quality_score == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Evidence feedback
+# ---------------------------------------------------------------------------
+
+
+def test_evidence_feedback_tracks_expansion_count() -> None:
+    records = [
+        _record("adopted", "success", ["ev-001"]),
+        _record("adopted", "success", ["ev-001"]),
+    ]
+    fb = aggregate_anvil_feedback(records)
+    assert "ev-001" in fb.evidence_feedback
+    assert fb.evidence_feedback["ev-001"].expansion_count == 2
+    assert fb.evidence_feedback["ev-001"].success_count == 2
+    assert fb.evidence_feedback["ev-001"].quality_score == pytest.approx(1.0)
+
+
+def test_evidence_feedback_mixed_outcomes() -> None:
+    records = [
+        _record("adopted", "success", ["ev-001"]),
+        _record("adopted", "failure", ["ev-001"]),
+    ]
+    fb = aggregate_anvil_feedback(records)
+    ev = fb.evidence_feedback["ev-001"]
+    assert ev.expansion_count == 2
+    assert ev.success_count == 1
+    assert ev.quality_score == pytest.approx(0.5)
+
+
+def test_evidence_feedback_excludes_error_turn_expansions() -> None:
+    records = [
+        _record("adopted", "success", ["ev-001"]),
+        _record("error", None, ["ev-001"]),
+    ]
+    fb = aggregate_anvil_feedback(records)
+    # error turn is excluded from quality — evidence_feedback only counts quality turns
+    assert fb.evidence_feedback["ev-001"].expansion_count == 1
+
+
+def test_evidence_feedback_multiple_ids_per_turn() -> None:
+    records = [_record("adopted", "success", ["ev-a", "ev-b"])]
+    fb = aggregate_anvil_feedback(records)
+    assert "ev-a" in fb.evidence_feedback
+    assert "ev-b" in fb.evidence_feedback
+
+
+def test_evidence_not_expanded_has_no_feedback_entry() -> None:
+    fb = aggregate_anvil_feedback([_record("adopted", "success")])
+    assert fb.evidence_feedback == {}
+
+
+# ---------------------------------------------------------------------------
+# Fixture validation
+# ---------------------------------------------------------------------------
+
+
+def test_feedback_fixture_validates_and_aggregates() -> None:
+    raw = json.loads((FIXTURES_V2 / "anvil_evaluate_feedback.json").read_text())
+    fb = aggregate_anvil_feedback(raw["records"])
+    # 5 total, 2 excluded (error + shadow_not_injected) → 3 quality turns
+    assert fb.total_turns == 5
+    assert fb.quality_turns == 3
+    assert fb.success_count == 2
+    assert fb.quality_score == pytest.approx(2 / 3)
+
+
+def test_feedback_fixture_evidence_feedback() -> None:
+    raw = json.loads((FIXTURES_V2 / "anvil_evaluate_feedback.json").read_text())
+    fb = aggregate_anvil_feedback(raw["records"])
+    # ev-useful-001 expanded twice (both success), ev-useful-002 once (success)
+    assert fb.evidence_feedback["ev-useful-001"].expansion_count == 2
+    assert fb.evidence_feedback["ev-useful-001"].quality_score == pytest.approx(1.0)
+    assert fb.evidence_feedback["ev-useful-002"].quality_score == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# apply_feedback_boost
+# ---------------------------------------------------------------------------
+
+
+def test_boost_increases_score_for_valid_item() -> None:
+    boosted = apply_feedback_boost(0.3, "valid", 1.0)
+    assert boosted > 0.3
+
+
+def test_boost_clamped_to_one() -> None:
+    boosted = apply_feedback_boost(0.95, "valid", 1.0)
+    assert boosted <= 1.0
+
+
+def test_boost_zero_quality_score_returns_base() -> None:
+    base = 0.4
+    assert apply_feedback_boost(base, "valid", 0.0) == pytest.approx(base)
+
+
+def test_boost_stale_capped_at_stale_max() -> None:
+    # Even maximum boost cannot push a stale item above STALE_MAX_SCORE
+    boosted = apply_feedback_boost(0.20, "stale", 1.0)
+    assert boosted <= STALE_MAX_SCORE
+
+
+def test_boost_contradicted_capped_at_contradicted_max() -> None:
+    boosted = apply_feedback_boost(0.10, "contradicted", 1.0)
+    assert boosted <= CONTRADICTED_MAX_SCORE
+
+
+def test_boost_unsafe_capped_at_contradicted_max() -> None:
+    boosted = apply_feedback_boost(0.12, "unsafe", 1.0)
+    assert boosted <= CONTRADICTED_MAX_SCORE
+
+
+def test_boost_valid_and_unknown_uncapped() -> None:
+    for status in ("valid", "partial", "unknown"):
+        boosted = apply_feedback_boost(0.5, status, 1.0)
+        assert boosted > STALE_MAX_SCORE, f"status={status} should be uncapped"
+
+
+# ---------------------------------------------------------------------------
+# FeedbackAdjustedContextScorer — admission
+# ---------------------------------------------------------------------------
+
+
+def test_feedback_scorer_satisfies_protocol() -> None:
+    fb = _high_quality_feedback()
+    scorer = FeedbackAdjustedContextScorer(fb)
+    assert isinstance(scorer, ContextScorerProtocol)
+
+
+def test_feedback_scorer_admission_boosts_valid_item() -> None:
+    fb = _high_quality_feedback()
+    base_scorer = FallbackContextScorer()
+    adj_scorer = FeedbackAdjustedContextScorer(fb)
+    s = _summary(facts=[_fact()])
+    base_score = base_scorer.score_admission([s])[0].score
+    adj_score = adj_scorer.score_admission([s])[0].score
+    assert adj_score >= base_score
+
+
+def test_feedback_scorer_admission_stale_cannot_recover() -> None:
+    fb = _high_quality_feedback()
+    adj_scorer = FeedbackAdjustedContextScorer(fb)
+    # Rich stale summary — even with maximum feedback it must stay ≤ STALE_MAX_SCORE
+    rich_stale = _summary(
+        "stale-rich",
+        facts=[_fact()] * 4,
+        hypotheses=[_hypothesis()] * 4,
+        validity_status="stale",
+    )
+    score = adj_scorer.score_admission([rich_stale])[0].score
+    assert score <= STALE_MAX_SCORE
+
+
+def test_feedback_scorer_admission_contradicted_cannot_recover() -> None:
+    fb = _high_quality_feedback()
+    adj_scorer = FeedbackAdjustedContextScorer(fb)
+    rich_contradicted = _summary(
+        "contr-rich",
+        facts=[_fact()] * 4,
+        validity_status="contradicted",
+    )
+    score = adj_scorer.score_admission([rich_contradicted])[0].score
+    assert score <= CONTRADICTED_MAX_SCORE
+
+
+def test_feedback_scorer_stale_scores_below_valid_always() -> None:
+    fb = _high_quality_feedback()
+    adj_scorer = FeedbackAdjustedContextScorer(fb)
+    valid_s = _summary("v", facts=[_fact(), _fact()], validity_status="valid")
+    stale_s = _summary("s", facts=[_fact(), _fact()], validity_status="stale")
+    valid_score = adj_scorer.score_admission([valid_s])[0].score
+    stale_score = adj_scorer.score_admission([stale_s])[0].score
+    assert stale_score < valid_score
+
+
+def test_feedback_scorer_zero_quality_does_not_boost() -> None:
+    fb = _zero_quality_feedback()
+    base_scorer = FallbackContextScorer()
+    adj_scorer = FeedbackAdjustedContextScorer(fb)
+    s = _summary(facts=[_fact()])
+    base_score = base_scorer.score_admission([s])[0].score
+    adj_score = adj_scorer.score_admission([s])[0].score
+    assert adj_score == pytest.approx(base_score)
+
+
+# ---------------------------------------------------------------------------
+# FeedbackAdjustedContextScorer — evidence expansion
+# ---------------------------------------------------------------------------
+
+
+def test_feedback_scorer_expansion_uses_per_evidence_quality() -> None:
+    records = [_record("adopted", "success", ["ev-seen"])]
+    fb = aggregate_anvil_feedback(records)
+    adj_scorer = FeedbackAdjustedContextScorer(fb)
+    base_scorer = FallbackContextScorer()
+    ref = _evidence_ref("ev-seen", staleness_status="valid")
+    base_score = base_scorer.score_evidence_expansion([ref])[0].score
+    adj_score = adj_scorer.score_evidence_expansion([ref])[0].score
+    assert adj_score >= base_score
+
+
+def test_feedback_scorer_expansion_stale_cannot_recover() -> None:
+    fb = _high_quality_feedback()
+    adj_scorer = FeedbackAdjustedContextScorer(fb)
+    stale_ref = _evidence_ref("ev-stale", expand_policy="always", staleness_status="stale")
+    score = adj_scorer.score_evidence_expansion([stale_ref])[0].score
+    assert score <= STALE_MAX_SCORE
+
+
+def test_feedback_scorer_expansion_unseen_evidence_uses_pack_quality() -> None:
+    fb = _high_quality_feedback()
+    adj_scorer = FeedbackAdjustedContextScorer(fb)
+    base_scorer = FallbackContextScorer()
+    ref = _evidence_ref("ev-never-seen", staleness_status="valid")
+    base_score = base_scorer.score_evidence_expansion([ref])[0].score
+    adj_score = adj_scorer.score_evidence_expansion([ref])[0].score
+    # With positive pack quality_score, unseen evidence should also receive a boost
+    assert adj_score >= base_score
+
+
+# ---------------------------------------------------------------------------
+# FeedbackAdjustedContextScorer — summary usefulness
+# ---------------------------------------------------------------------------
+
+
+def test_feedback_scorer_usefulness_boosted_by_feedback() -> None:
+    fb = _high_quality_feedback()
+    adj_scorer = FeedbackAdjustedContextScorer(fb)
+    base_scorer = FallbackContextScorer()
+    s = _summary(facts=[_fact("fix failing test")])
+    task = "fix failing test"
+    base_score = base_scorer.score_summary_usefulness([s], task_text=task)[0].score
+    adj_score = adj_scorer.score_summary_usefulness([s], task_text=task)[0].score
+    assert adj_score >= base_score
+
+
+def test_feedback_scorer_usefulness_stale_capped() -> None:
+    fb = _high_quality_feedback()
+    adj_scorer = FeedbackAdjustedContextScorer(fb)
+    stale_s = _summary(facts=[_fact()] * 4, validity_status="stale")
+    score = adj_scorer.score_summary_usefulness([stale_s])[0].score
+    assert score <= STALE_MAX_SCORE
+
+
+# ---------------------------------------------------------------------------
+# FeedbackAdjustedContextScorer — staleness risk (never adjusted)
+# ---------------------------------------------------------------------------
+
+
+def test_staleness_risk_not_adjusted_by_positive_feedback() -> None:
+    fb = _high_quality_feedback()
+    adj_scorer = FeedbackAdjustedContextScorer(fb)
+    base_scorer = FallbackContextScorer()
+    for status in ("valid", "partial", "stale", "contradicted"):
+        s = _summary(validity_status=status)
+        base_risk = base_scorer.score_staleness_risk([s])[0].risk
+        adj_risk = adj_scorer.score_staleness_risk([s])[0].risk
+        assert adj_risk == pytest.approx(base_risk), f"staleness_risk changed for {status}"
+
+
+def test_staleness_risk_stale_stays_high_regardless_of_feedback() -> None:
+    fb = _high_quality_feedback()
+    adj_scorer = FeedbackAdjustedContextScorer(fb)
+    stale = _summary(validity_status="stale")
+    risk = adj_scorer.score_staleness_risk([stale])[0].risk
+    assert risk > 0.5
+
+
+def test_staleness_risk_contradicted_stays_max() -> None:
+    fb = _high_quality_feedback()
+    adj_scorer = FeedbackAdjustedContextScorer(fb)
+    contradicted = _summary(validity_status="contradicted")
+    risk = adj_scorer.score_staleness_risk([contradicted])[0].risk
+    assert risk == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Deterministic ranking improvement (no learned model)
+# ---------------------------------------------------------------------------
+
+
+def test_feedback_improves_ranking_of_valid_over_stale() -> None:
+    """Feedback scorer ranks a valid-rich summary above stale-rich — deterministically."""
+    fb = _high_quality_feedback()
+    adj_scorer = FeedbackAdjustedContextScorer(fb)
+
+    valid_rich = _summary("v", facts=[_fact()] * 3, validity_status="valid")
+    stale_rich = _summary("s", facts=[_fact()] * 4, validity_status="stale")
+
+    scores = {r.summary_id: r.score for r in adj_scorer.score_admission([valid_rich, stale_rich])}
+    assert scores["v"] > scores["s"]
+
+
+def test_feedback_ranking_is_deterministic() -> None:
+    fb = _high_quality_feedback()
+    adj_scorer = FeedbackAdjustedContextScorer(fb)
+    s = _summary(facts=[_fact()])
+    r1 = adj_scorer.score_admission([s])[0].score
+    r2 = adj_scorer.score_admission([s])[0].score
+    assert r1 == pytest.approx(r2)
+
+
+# ---------------------------------------------------------------------------
+# Eval hook integration
+# ---------------------------------------------------------------------------
+
+
+def test_eval_hook_called_for_feedback_scored_items() -> None:
+    events: list[ScoringEvent] = []
+    fb = _high_quality_feedback()
+    scorer = FeedbackAdjustedContextScorer(fb, eval_hook=events.append)
+    summaries = [_summary(f"sum-{i}", facts=[_fact()]) for i in range(3)]
+    scorer.score_admission(summaries)
+    assert len(events) == 3
+    assert all(e.scorer_kind == "admission" for e in events)
+
+
+def test_eval_hook_receives_adjusted_score() -> None:
+    events: list[ScoringEvent] = []
+    fb = _high_quality_feedback()
+    scorer = FeedbackAdjustedContextScorer(fb, eval_hook=events.append)
+    base_scorer = FallbackContextScorer()
+    s = _summary(facts=[_fact()])
+    base_score = base_scorer.score_admission([s])[0].score
+    scorer.score_admission([s])
+    assert events[0].score >= base_score
+
+
+# ---------------------------------------------------------------------------
+# Aggregate-safe features (no raw content)
+# ---------------------------------------------------------------------------
+
+
+def test_pack_feedback_contains_only_aggregate_fields() -> None:
+    """PackFeedback must not store raw prompts, tool output, or user text."""
+    fb = _high_quality_feedback()
+    # Only structural/numeric fields exist
+    assert hasattr(fb, "total_turns")
+    assert hasattr(fb, "quality_turns")
+    assert hasattr(fb, "adoption_count")
+    assert hasattr(fb, "success_count")
+    assert hasattr(fb, "quality_score")
+    assert hasattr(fb, "evidence_feedback")
+    # No raw text fields
+    assert not hasattr(fb, "raw_stdout")
+    assert not hasattr(fb, "prompt_text")
+    assert not hasattr(fb, "tool_output")
+
+
+def test_evidence_feedback_contains_only_aggregate_fields() -> None:
+    records = [_record("adopted", "success", ["ev-001"])]
+    fb = aggregate_anvil_feedback(records)
+    ev = fb.evidence_feedback["ev-001"]
+    assert isinstance(ev, EvidenceFeedback)
+    assert hasattr(ev, "evidence_id")
+    assert hasattr(ev, "expansion_count")
+    assert hasattr(ev, "success_count")
+    assert hasattr(ev, "quality_score")


### PR DESCRIPTION
Refs #69. Summary: add Anvil feedback/scoring support and verification reports. Verification: worker reported tests/test_anvil_feedback.py -v passed and full suite passed.