### PR TITLE
#70 [Anvil photon integration] P7: photon-action-memory 側テスト

### DIFF
--- a/dev-reports/issue-70/design.md
+++ b/dev-reports/issue-70/design.md
@@ -1,0 +1,34 @@
+# Design Note — Issue #70: photon-action-memory Anvil Integration Tests
+
+## Objective
+Add photon-side Anvil integration tests covering all acceptance criteria.
+
+## Scope of new test files
+
+| File | Focus |
+|---|---|
+| `tests/test_anvil_contract.py` | Umbrella contract test: schema, raw log policy, shadow/canary aggregation, evidence expansion safety, full call sequence |
+| `tests/test_anvil_context_pack_api.py` | Context pack API with Anvil-specific patterns (raw evidence, upserted summaries) |
+| `tests/test_anvil_evaluate.py` | `/v1/evaluate` with Anvil shadow/canary statuses; store + aggregate |
+| `tests/test_anvil_evidence_expand.py` | Evidence expansion with `anvil_profile=True` safety profile |
+| `tests/test_anvil_feedback_scoring.py` | Summary upsert/retrieval via store; staleness filtering before context pack |
+
+## New fixtures under `tests/fixtures/photon/`
+
+| File | Contents |
+|---|---|
+| `anvil_raw_tool_log_request.json` | ContextPackRequest from Anvil carrying raw stdout/stderr evidence |
+| `anvil_action_summary.json` | ActionSummary Anvil would upsert into the summary store |
+| `anvil_shadow_evaluate_log.json` | Shadow/canary evaluate log (3 records: shadow_not_injected, adopted, not_available) |
+
+## Acceptance criteria mapping
+
+1. **`pytest tests/test_anvil_contract.py`** — tests in `test_anvil_contract.py` form the umbrella.
+2. **Anvil shared fixtures pass photon schema/API tests** — all new test files load and validate existing `fixtures/v0.2/` fixtures.
+3. **unsafe raw log fixture is not prompt-visible** — `test_anvil_contract.py` and `test_anvil_context_pack_api.py` both verify `context_pack.items == []` when raw evidence is present.
+4. **shadow/canary evaluate fixtures can be stored and aggregated** — `test_anvil_evaluate.py` posts shadow/canary fixtures to `/v1/evaluate` and verifies SQLite storage; `aggregate_context_pack_eval` is called on the stored records.
+5. **evidence expansion safety profile returns no raw output** — `test_anvil_evidence_expand.py` verifies `anvil_profile=True` always denies stdout/stderr.
+
+## Non-goals
+- No production code changes — all acceptance criteria are already implemented; only tests are missing.
+- Tests intentionally do not duplicate assertions already in existing test files.

--- a/dev-reports/issue-70/implementation-summary.md
+++ b/dev-reports/issue-70/implementation-summary.md
@@ -1,0 +1,29 @@
+# Implementation Summary — Issue #70: photon-action-memory Anvil Integration Tests
+
+## New files
+
+### Test files (5)
+| File | Tests | Focus |
+|---|---|---|
+| `tests/test_anvil_contract.py` | 16 | Umbrella contract: schema, raw log policy, shadow/canary aggregation, evidence expansion safety, call sequence |
+| `tests/test_anvil_context_pack_api.py` | 9 | `/v1/context/pack` with Anvil raw evidence and upserted summaries |
+| `tests/test_anvil_evaluate.py` | 7 | `/v1/evaluate` shadow/canary storage and aggregation |
+| `tests/test_anvil_evidence_expand.py` | 15 | Evidence expansion `anvil_profile=True` safety profile |
+| `tests/test_anvil_feedback_scoring.py` | 11 | Summary store upsert/retrieval/staleness filtering, adoption report aggregation |
+
+**Total new tests: 58**
+
+### Fixture files (3, under `tests/fixtures/photon/`)
+| File | Contents |
+|---|---|
+| `anvil_raw_tool_log_request.json` | ContextPackRequest from Anvil with stdout/stderr/build_log raw evidence |
+| `anvil_action_summary.json` | ActionSummary from Anvil (facts, avoid, valid status, token_cost) |
+| `anvil_shadow_evaluate_log.json` | 3-record shadow/canary evaluate log (shadow_not_injected, adopted, not_available) |
+
+### Report files
+- `dev-reports/issue-70/design.md`
+- `dev-reports/issue-70/implementation-summary.md`
+- `dev-reports/issue-70/verification.md`
+
+## No production code changes
+All acceptance criteria were already implemented in prior P-series issues. Only tests were missing.

--- a/dev-reports/issue-70/verification.md
+++ b/dev-reports/issue-70/verification.md
@@ -1,0 +1,35 @@
+# Verification — Issue #70
+
+## Test run results
+
+### Targeted test
+```
+pytest tests/test_anvil_contract.py -v
+# 16 passed
+```
+
+### All new Anvil test files
+```
+pytest tests/test_anvil_contract.py tests/test_anvil_context_pack_api.py \
+       tests/test_anvil_evaluate.py tests/test_anvil_evidence_expand.py \
+       tests/test_anvil_feedback_scoring.py -v
+# 58 passed
+```
+
+### Full suite (regression check)
+```
+pytest tests/ -q
+# 713 passed, 1 skipped (MLX smoke opt-in)
+# was 655 passed before this issue
+```
+
+## Acceptance criteria
+
+| Criterion | Status | Evidence |
+|---|---|---|
+| `pytest tests/test_anvil_contract.py` 相当が通る | PASS | 16/16 passed |
+| Anvil shared fixtures validate against photon schema/API | PASS | `test_anvil_evaluate_shadow_fixture_validates`, `test_anvil_adoption_log_fixture_validates_all_statuses`, etc. |
+| unsafe raw log fixture is not prompt-visible | PASS | `test_anvil_raw_log_fixture_not_in_context_pack_items`, `test_anvil_raw_evidence_all_denied`, `test_anvil_raw_evidence_deny_decisions_have_policy` |
+| shadow/canary evaluate fixtures can be stored and aggregated | PASS | `test_anvil_shadow_evaluate_fixture_stored_in_event_store`, `test_anvil_shadow_evaluate_multiple_fixtures_aggregate`, `test_anvil_shadow_evaluate_log_aggregates_correctly` |
+| evidence expansion safety profile returns no raw output | PASS | `test_anvil_profile_denies_stdout_with_allow_raw_true`, `test_api_anvil_profile_denies_stdout`, all `anvil_profile` tests |
+| 既存 test suite が regression しない | PASS | Full suite: 713 passed (no regressions) |

--- a/tests/fixtures/photon/anvil_action_summary.json
+++ b/tests/fixtures/photon/anvil_action_summary.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "action-memory.v0.2",
+  "summary_id": "anvil-sum-photon-001",
+  "session_id": "anvil-sess-photon-001",
+  "repo_id": "my-repo",
+  "task_signature": "fix-build-failure-type-mismatch",
+  "summary_level": "chunk",
+  "source_chunk_ids": ["anvil-chunk-001"],
+  "facts": [
+    {
+      "text": "Build fails at src/main.rs:42 due to type mismatch (expected u32, found i32).",
+      "evidence_ids": ["anvil-ev-001"],
+      "confidence": 0.95
+    },
+    {
+      "text": "The fix is to cast the value to u32 on line 42.",
+      "evidence_ids": ["anvil-ev-002"],
+      "confidence": 0.88
+    }
+  ],
+  "hypotheses": [
+    {
+      "text": "There may be additional type mismatches in related files.",
+      "evidence_ids": ["anvil-ev-001"],
+      "confidence": 0.4,
+      "status": "open"
+    }
+  ],
+  "failed_attempts": [],
+  "avoid": [
+    {
+      "action": "rerun cargo build without code changes",
+      "reason": "same type mismatch error will occur",
+      "evidence_ids": ["anvil-ev-001"]
+    }
+  ],
+  "validity": {"status": "valid"},
+  "token_cost": {
+    "estimated_summary_tokens": 120,
+    "estimated_raw_tokens": 2800,
+    "tokens_saved_vs_raw": 2680
+  }
+}

--- a/tests/fixtures/photon/anvil_raw_tool_log_request.json
+++ b/tests/fixtures/photon/anvil_raw_tool_log_request.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "action-memory.v0.2",
+  "request_id": "pack-anvil-raw-001",
+  "agent": {"name": "anvil", "version": "1.0.0"},
+  "repo": {"root": "/workspace/my-repo", "name": "my-repo"},
+  "task": {
+    "user_request": "fix the build failure",
+    "mode": "act",
+    "summary": "fixing build failure due to type mismatch"
+  },
+  "working_memory": {"touched_files": ["src/main.rs"]},
+  "recent_event_ids": [],
+  "candidate_summary_ids": [],
+  "budget": {"max_memory_tokens": 800, "max_evidence_chars": 1200},
+  "raw_evidence": [
+    {
+      "item_id": "anvil-stdout-001",
+      "kind": "stdout",
+      "content": "error[E0308]: mismatched types\n --> src/main.rs:42:10\n  = expected `u32`, found `i32`"
+    },
+    {
+      "item_id": "anvil-stderr-001",
+      "kind": "stderr",
+      "content": "warning: unused variable `x`\nwarning: unused import `std::io`"
+    },
+    {
+      "item_id": "anvil-build-001",
+      "kind": "build_log",
+      "content": "error: could not compile `my-repo` due to 1 previous error"
+    }
+  ]
+}

--- a/tests/fixtures/photon/anvil_shadow_evaluate_log.json
+++ b/tests/fixtures/photon/anvil_shadow_evaluate_log.json
@@ -1,0 +1,39 @@
+{
+  "schema": "context-pack-eval.v1",
+  "description": "Anvil shadow/canary evaluate log for photon-side aggregation tests.",
+  "records": [
+    {
+      "context_pack_request_id": "pack-photon-shadow-001",
+      "adoption_status": "shadow_not_injected",
+      "ignored_reason": "shadow_mode_no_injection",
+      "evidence_expand_requested": false,
+      "evidence_ids_expanded": [],
+      "items_adopted_count": 0,
+      "items_ignored_count": 0,
+      "outcome": null,
+      "latency_ms": 38.5
+    },
+    {
+      "context_pack_request_id": "pack-photon-shadow-002",
+      "adoption_status": "adopted",
+      "ignored_reason": null,
+      "evidence_expand_requested": false,
+      "evidence_ids_expanded": [],
+      "items_adopted_count": 2,
+      "items_ignored_count": 0,
+      "outcome": "success",
+      "latency_ms": 145.0
+    },
+    {
+      "context_pack_request_id": "pack-photon-shadow-003",
+      "adoption_status": "not_available",
+      "ignored_reason": "sidecar_timeout",
+      "evidence_expand_requested": false,
+      "evidence_ids_expanded": [],
+      "items_adopted_count": 0,
+      "items_ignored_count": 0,
+      "outcome": "partial",
+      "latency_ms": 5012.0
+    }
+  ]
+}

--- a/tests/test_anvil_context_pack_api.py
+++ b/tests/test_anvil_context_pack_api.py
@@ -1,0 +1,191 @@
+"""Anvil context pack API tests (Issue #70 P7).
+
+Tests the /v1/context/pack endpoint with Anvil-specific patterns:
+- Raw tool log evidence from Anvil is denied (not prompt-visible)
+- Anvil-upserted summaries resolve correctly through candidate_summary_ids
+- Canary context pack fixture round-trips through the schema
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    ActionSummary,
+    ContextPack,
+)
+from photon_action_memory.api.server import create_app
+from photon_action_memory.memory.store import SQLiteEventStore
+from photon_action_memory.memory.summary_store import SummaryStore
+
+FIXTURES_V2 = Path(__file__).parent / "fixtures" / "v0.2"
+FIXTURES_PHOTON = Path(__file__).parent / "fixtures" / "photon"
+
+
+def _load(directory: Path, name: str) -> object:
+    return json.loads((directory / name).read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Raw Anvil tool log evidence is denied — not prompt-visible
+# ---------------------------------------------------------------------------
+
+
+def test_anvil_raw_evidence_all_denied(tmp_path: Path) -> None:
+    raw_request = _load(FIXTURES_PHOTON, "anvil_raw_tool_log_request.json")
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    with TestClient(app) as client:
+        resp = client.post("/v1/context/pack", json=raw_request)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["context_pack"]["items"] == []
+    assert len(data["context_pack"]["omitted"]) == 3
+
+
+def test_anvil_raw_evidence_deny_decisions_have_policy(tmp_path: Path) -> None:
+    raw_request = _load(FIXTURES_PHOTON, "anvil_raw_tool_log_request.json")
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    with TestClient(app) as client:
+        resp = client.post("/v1/context/pack", json=raw_request)
+    decisions = resp.json()["admission_decisions"]
+    assert len(decisions) == 3
+    for dec in decisions:
+        assert dec["decision"] == "deny"
+        assert dec["policy"]["raw_evidence_policy"] == "raw_tool_log_default_deny"
+
+
+def test_anvil_raw_evidence_denied_item_ids_match_request(tmp_path: Path) -> None:
+    raw_request = _load(FIXTURES_PHOTON, "anvil_raw_tool_log_request.json")
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    with TestClient(app) as client:
+        resp = client.post("/v1/context/pack", json=raw_request)
+    omitted_ids = {o["id"] for o in resp.json()["context_pack"]["omitted"]}
+    assert omitted_ids == {"anvil-stdout-001", "anvil-stderr-001", "anvil-build-001"}
+
+
+# ---------------------------------------------------------------------------
+# Anvil summary upsert → candidate_summary_ids → context pack resolves
+# ---------------------------------------------------------------------------
+
+
+def test_anvil_summary_appears_in_context_pack_items(tmp_path: Path) -> None:
+    summary_store = SummaryStore(tmp_path / "summaries.sqlite")
+    event_store = SQLiteEventStore(tmp_path / "events.sqlite")
+    raw_summary = _load(FIXTURES_PHOTON, "anvil_action_summary.json")
+    summary = ActionSummary.model_validate(raw_summary)
+    summary_store.upsert(summary)
+
+    body = {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "pack-anvil-sum-001",
+        "agent": {"name": "anvil", "version": "1.0.0"},
+        "repo": {"root": "/workspace/my-repo", "name": "my-repo"},
+        "task": {
+            "user_request": "fix build",
+            "mode": "act",
+            "summary": "fixing build failure",
+        },
+        "working_memory": {"touched_files": []},
+        "recent_event_ids": [],
+        "candidate_summary_ids": ["anvil-sum-photon-001"],
+        "budget": {"max_memory_tokens": 800, "max_evidence_chars": 1200},
+    }
+    with TestClient(create_app(event_store, summary_store)) as client:
+        resp = client.post("/v1/context/pack", json=body)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["sidecar_status"] == "ok"
+    assert len(data["context_pack"]["items"]) >= 1
+
+
+def test_anvil_unknown_candidate_summary_id_is_skipped(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    body = {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "pack-anvil-unknown-001",
+        "agent": {"name": "anvil", "version": "1.0.0"},
+        "repo": {"root": "/workspace/my-repo", "name": "my-repo"},
+        "task": {
+            "user_request": "fix something",
+            "mode": "act",
+            "summary": "fixing",
+        },
+        "working_memory": {"touched_files": []},
+        "recent_event_ids": [],
+        "candidate_summary_ids": ["nonexistent-anvil-sum-999"],
+        "budget": {"max_memory_tokens": 800, "max_evidence_chars": 1200},
+    }
+    with TestClient(app) as client:
+        resp = client.post("/v1/context/pack", json=body)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["sidecar_status"] == "ok"
+    assert data["context_pack"]["items"] == []
+
+
+def test_anvil_stale_summary_not_in_context_pack(tmp_path: Path) -> None:
+    summary_store = SummaryStore(tmp_path / "summaries.sqlite")
+    event_store = SQLiteEventStore(tmp_path / "events.sqlite")
+    raw_summary = _load(FIXTURES_PHOTON, "anvil_action_summary.json")
+    summary = ActionSummary.model_validate(raw_summary)
+    # Mark stale before upsert
+    from photon_action_memory.api.schema_v2 import Validity
+
+    summary = summary.model_copy(update={"validity": Validity(status="stale", reason="outdated")})
+    summary_store.upsert(summary)
+
+    body = {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "pack-anvil-stale-001",
+        "agent": {"name": "anvil", "version": "1.0.0"},
+        "repo": {"root": "/workspace/my-repo", "name": "my-repo"},
+        "task": {
+            "user_request": "fix build",
+            "mode": "act",
+            "summary": "fixing",
+        },
+        "working_memory": {"touched_files": []},
+        "recent_event_ids": [],
+        "candidate_summary_ids": ["anvil-sum-photon-001"],
+        "budget": {"max_memory_tokens": 800, "max_evidence_chars": 1200},
+    }
+    with TestClient(create_app(event_store, summary_store)) as client:
+        resp = client.post("/v1/context/pack", json=body)
+    assert resp.status_code == 200
+    assert resp.json()["context_pack"]["items"] == []
+
+
+# ---------------------------------------------------------------------------
+# Canary context pack fixture round-trips
+# ---------------------------------------------------------------------------
+
+
+def test_canary_context_pack_fixture_validates_as_context_pack() -> None:
+    raw = _load(FIXTURES_V2, "canary_context_pack.json")
+    pack = ContextPack.model_validate(raw)
+    assert pack.schema_version == DEFAULT_SCHEMA_VERSION_V2
+    assert pack.mode == "summary_only"
+    assert len(pack.items) > 0
+    assert len(pack.omitted) > 0
+    assert pack.token_budget.estimated_tokens >= 0
+
+
+def test_canary_context_pack_raw_items_all_in_omitted() -> None:
+    raw = _load(FIXTURES_V2, "canary_context_pack.json")
+    pack = ContextPack.model_validate(raw)
+    item_ids = {item.id for item in pack.items}
+    omitted_ids = {o.id for o in pack.omitted}
+    # raw-stdout-1 must be in omitted, not items
+    assert "raw-stdout-1" in omitted_ids
+    assert "raw-stdout-1" not in item_ids
+
+
+def test_context_pack_omits_raw_fixture_validates() -> None:
+    raw = _load(FIXTURES_V2, "context_pack_omits_raw.json")
+    pack = ContextPack.model_validate(raw)
+    omitted_kinds = {o.kind for o in pack.omitted}
+    assert "raw_tool_output" in omitted_kinds

--- a/tests/test_anvil_contract.py
+++ b/tests/test_anvil_contract.py
@@ -1,0 +1,307 @@
+"""Anvil photon integration contract tests (Issue #70 P7).
+
+Umbrella test covering all photon-side acceptance criteria:
+- Anvil shared fixtures validate against photon schema/API
+- unsafe raw log fixture is not prompt-visible
+- shadow/canary evaluate fixtures can be stored and aggregated
+- evidence expansion safety profile (anvil_profile=True) returns no raw output
+- full Anvil call sequence is valid
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    ActionSummary,
+    ContextPack,
+    EvaluateRequest,
+    EvidenceExpandPolicy,
+    EvidenceExpandRequest,
+)
+from photon_action_memory.api.server import create_app
+from photon_action_memory.context.pack import build_context_pack
+from photon_action_memory.context.raw_policy import RawEvidenceItem
+from photon_action_memory.eval.context_pack_log import aggregate_context_pack_eval
+from photon_action_memory.integration.context_pack_contract import validate_call_sequence
+from photon_action_memory.memory.evidence import (
+    REASON_RAW_OUTPUT_DENIED_ANVIL,
+    EvidenceExpander,
+)
+from photon_action_memory.memory.store import SQLiteEventStore
+from photon_action_memory.memory.summary_store import SummaryStore
+
+FIXTURES_V2 = Path(__file__).parent / "fixtures" / "v0.2"
+FIXTURES_PHOTON = Path(__file__).parent / "fixtures" / "photon"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _client(tmp_path: Path) -> TestClient:
+    store = SQLiteEventStore(tmp_path / "events.sqlite")
+    return TestClient(create_app(store))
+
+
+def _load(directory: Path, name: str) -> object:
+    return json.loads((directory / name).read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# AC-2: Anvil shared fixtures validate against photon schema/API
+# ---------------------------------------------------------------------------
+
+
+def test_anvil_evaluate_shadow_fixture_validates() -> None:
+    raw = _load(FIXTURES_V2, "evaluate_anvil_shadow.json")
+    req = EvaluateRequest.model_validate(raw)
+    assert req.context_pack_event is not None
+    assert req.context_pack_event.adoption_status == "shadow_not_injected"
+    assert req.agent is not None
+    assert req.agent.name == "anvil"
+
+
+def test_anvil_adoption_log_fixture_validates_all_statuses() -> None:
+    raw = _load(FIXTURES_V2, "context_pack_adoption_log_anvil.json")
+    records = raw["records"]  # type: ignore[index]
+    report = aggregate_context_pack_eval(records)
+    assert report.total_turns == 5
+    assert report.shadow_not_injected_count == 1
+    assert report.not_available_count == 1
+    assert report.error_count == 1
+    assert report.adopted_count == 2
+
+
+def test_anvil_canary_context_pack_fixture_validates() -> None:
+    raw = _load(FIXTURES_V2, "canary_context_pack.json")
+    pack = ContextPack.model_validate(raw)
+    assert pack.mode == "summary_only"
+    # raw stdout item must be in omitted, not items
+    item_ids = {item.id for item in pack.items}
+    omitted_ids = {o.id for o in pack.omitted}
+    assert "raw-stdout-1" in omitted_ids
+    assert "raw-stdout-1" not in item_ids
+
+
+def test_anvil_photon_action_summary_fixture_validates() -> None:
+    raw = _load(FIXTURES_PHOTON, "anvil_action_summary.json")
+    summary = ActionSummary.model_validate(raw)
+    assert summary.summary_id == "anvil-sum-photon-001"
+    assert summary.repo_id == "my-repo"
+    assert len(summary.facts) == 2
+    assert summary.validity.status == "valid"
+
+
+def test_anvil_shadow_evaluate_log_fixture_validates() -> None:
+    raw = _load(FIXTURES_PHOTON, "anvil_shadow_evaluate_log.json")
+    records = raw["records"]  # type: ignore[index]
+    report = aggregate_context_pack_eval(records)
+    assert report.total_turns == 3
+    assert report.shadow_not_injected_count == 1
+    assert report.not_available_count == 1
+    assert report.adopted_count == 1
+
+
+# ---------------------------------------------------------------------------
+# AC-3: unsafe raw log fixture is not prompt-visible
+# ---------------------------------------------------------------------------
+
+
+def test_anvil_raw_log_fixture_not_in_context_pack_items() -> None:
+    raw_items = [
+        RawEvidenceItem(item_id="anvil-stdout-001", kind="stdout", content="build output"),
+        RawEvidenceItem(item_id="anvil-stderr-001", kind="stderr", content="warnings"),
+        RawEvidenceItem(item_id="anvil-build-001", kind="build_log", content="error: compile"),
+    ]
+    from photon_action_memory.api.schema_v2 import ContextPackBudget
+
+    pack, decisions = build_context_pack(
+        request_id="anvil-test-001",
+        session_id=None,
+        repo_id="my-repo",
+        summaries=[],
+        budget=ContextPackBudget(max_memory_tokens=800),
+        raw_items=raw_items,
+    )
+    assert pack.items == []
+    omitted_ids = {o.id for o in pack.omitted}
+    assert "anvil-stdout-001" in omitted_ids
+    assert "anvil-stderr-001" in omitted_ids
+    assert "anvil-build-001" in omitted_ids
+    assert all(d.decision == "deny" for d in decisions)
+
+
+def test_anvil_raw_log_fixture_api_returns_empty_items(tmp_path: Path) -> None:
+    raw = _load(FIXTURES_PHOTON, "anvil_raw_tool_log_request.json")
+    with _client(tmp_path) as client:
+        resp = client.post("/v1/context/pack", json=raw)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["context_pack"]["items"] == []
+    omitted_ids = {o["id"] for o in data["context_pack"]["omitted"]}
+    assert "anvil-stdout-001" in omitted_ids
+    assert "anvil-stderr-001" in omitted_ids
+    assert "anvil-build-001" in omitted_ids
+
+
+# ---------------------------------------------------------------------------
+# AC-4: shadow/canary evaluate fixtures can be stored and aggregated
+# ---------------------------------------------------------------------------
+
+
+def test_anvil_shadow_evaluate_fixture_stored_in_event_store(tmp_path: Path) -> None:
+    store = SQLiteEventStore(tmp_path / "events.sqlite")
+    with TestClient(create_app(store)) as client:
+        raw = _load(FIXTURES_V2, "evaluate_anvil_shadow.json")
+        resp = client.post("/v1/evaluate", json=raw)
+    assert resp.status_code == 200
+    assert resp.json()["logged"] == 1
+    assert store.count() == 1
+    stored = store.list_events()[0]
+    assert stored.payload["adoption_status"] == "shadow_not_injected"
+
+
+def test_anvil_shadow_evaluate_multiple_fixtures_aggregate(tmp_path: Path) -> None:
+    store = SQLiteEventStore(tmp_path / "events.sqlite")
+    photon_log = _load(FIXTURES_PHOTON, "anvil_shadow_evaluate_log.json")
+    records = photon_log["records"]  # type: ignore[index]
+    with TestClient(create_app(store)) as client:
+        for i, record in enumerate(records):
+            body = {
+                "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+                "request_id": f"anvil-eval-{i}",
+                "context_pack_event": record,
+            }
+            resp = client.post("/v1/evaluate", json=body)
+            assert resp.status_code == 200
+            assert resp.json()["logged"] == 1
+
+    assert store.count() == 3
+    payloads = [e.payload for e in store.list_events()]
+    statuses = {p["adoption_status"] for p in payloads}
+    assert "shadow_not_injected" in statuses
+    assert "adopted" in statuses
+    assert "not_available" in statuses
+
+    report = aggregate_context_pack_eval(payloads)
+    assert report.total_turns == 3
+    assert report.shadow_not_injected_count == 1
+    assert report.not_available_count == 1
+    assert report.adopted_count == 1
+
+
+# ---------------------------------------------------------------------------
+# AC-5: evidence expansion safety profile returns no raw output
+# ---------------------------------------------------------------------------
+
+
+def test_anvil_evidence_expand_safety_profile_denies_stdout() -> None:
+    expander = EvidenceExpander(
+        records=[
+            {"evidence_id": "ev-anvil-raw", "kind": "stdout", "summary": "s", "stdout": "build log"}
+        ]
+    )
+    policy = EvidenceExpandPolicy(allow_raw_full_output=True, anvil_profile=True)
+    req = EvidenceExpandRequest(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        request_id="req-anvil",
+        evidence_ids=["ev-anvil-raw"],
+        policy=policy,
+    )
+    resp = expander.expand(req)
+    assert resp.expanded == []
+    assert len(resp.omitted) == 1
+    assert resp.omitted[0].reason == REASON_RAW_OUTPUT_DENIED_ANVIL
+
+
+def test_anvil_evidence_expand_safety_profile_allows_safe_snippet() -> None:
+    expander = EvidenceExpander(
+        records=[
+            {
+                "evidence_id": "ev-anvil-safe",
+                "kind": "file_inspection",
+                "summary": "type mismatch on line 42",
+                "snippet": "let x: u32 = value as u32;",
+            }
+        ]
+    )
+    policy = EvidenceExpandPolicy(anvil_profile=True)
+    req = EvidenceExpandRequest(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        request_id="req-anvil-safe",
+        evidence_ids=["ev-anvil-safe"],
+        policy=policy,
+    )
+    resp = expander.expand(req)
+    assert len(resp.expanded) == 1
+    assert resp.expanded[0].snippet == "let x: u32 = value as u32;"
+    assert resp.omitted == []
+
+
+# ---------------------------------------------------------------------------
+# Full Anvil call sequence validation
+# ---------------------------------------------------------------------------
+
+
+def test_anvil_full_call_sequence_is_valid() -> None:
+    violations = validate_call_sequence(["context_pack", "evidence_expand", "evaluate"])
+    assert violations == []
+
+
+def test_anvil_minimal_call_sequence_is_valid() -> None:
+    violations = validate_call_sequence(["context_pack", "evaluate"])
+    assert violations == []
+
+
+def test_anvil_missing_evaluate_is_violation() -> None:
+    violations = validate_call_sequence(["context_pack"])
+    assert any("evaluate" in v for v in violations)
+
+
+def test_anvil_missing_context_pack_is_violation() -> None:
+    violations = validate_call_sequence(["evaluate"])
+    assert any("context_pack" in v for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# Summary store integration — Anvil upsert + context pack resolve
+# ---------------------------------------------------------------------------
+
+
+def test_anvil_summary_upsert_and_resolve_via_context_pack(tmp_path: Path) -> None:
+    summary_store = SummaryStore(tmp_path / "summaries.sqlite")
+    event_store = SQLiteEventStore(tmp_path / "events.sqlite")
+    raw_summary = _load(FIXTURES_PHOTON, "anvil_action_summary.json")
+    summary = ActionSummary.model_validate(raw_summary)
+    summary_store.upsert(summary)
+
+    with TestClient(create_app(event_store, summary_store)) as client:
+        body = {
+            "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+            "request_id": "pack-resolve-001",
+            "agent": {"name": "anvil", "version": "1.0.0"},
+            "repo": {"root": "/workspace/my-repo", "name": "my-repo"},
+            "task": {
+                "user_request": "fix build",
+                "mode": "act",
+                "summary": "fixing build",
+            },
+            "working_memory": {"touched_files": []},
+            "recent_event_ids": [],
+            "candidate_summary_ids": ["anvil-sum-photon-001"],
+            "budget": {"max_memory_tokens": 800, "max_evidence_chars": 1200},
+        }
+        resp = client.post("/v1/context/pack", json=body)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["sidecar_status"] == "ok"
+    assert len(data["context_pack"]["items"]) >= 1
+    item_texts = " ".join(i["text"] for i in data["context_pack"]["items"])
+    assert "type mismatch" in item_texts.lower() or "u32" in item_texts

--- a/tests/test_anvil_evaluate.py
+++ b/tests/test_anvil_evaluate.py
@@ -1,0 +1,147 @@
+"""Anvil evaluate endpoint tests (Issue #70 P7).
+
+Tests /v1/evaluate with Anvil-specific shadow/canary statuses:
+- Shadow evaluate fixture stores correctly in SQLite
+- Canary evaluate fixtures aggregate correctly
+- raw_stdout/raw_stderr in evaluate request body are not stored
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from photon_action_memory.api.schema_v2 import DEFAULT_SCHEMA_VERSION_V2
+from photon_action_memory.api.server import create_app
+from photon_action_memory.eval.context_pack_log import (
+    aggregate_context_pack_eval,
+)
+from photon_action_memory.memory.store import SQLiteEventStore
+
+FIXTURES_V2 = Path(__file__).parent / "fixtures" / "v0.2"
+FIXTURES_PHOTON = Path(__file__).parent / "fixtures" / "photon"
+
+
+def _load(directory: Path, name: str) -> object:
+    return json.loads((directory / name).read_text(encoding="utf-8"))
+
+
+def _make_client(tmp_path: Path) -> tuple[TestClient, SQLiteEventStore]:
+    store = SQLiteEventStore(tmp_path / "events.sqlite")
+    return TestClient(create_app(store)), store
+
+
+# ---------------------------------------------------------------------------
+# Shadow evaluate fixture — HTTP endpoint storage
+# ---------------------------------------------------------------------------
+
+
+def test_anvil_shadow_evaluate_fixture_logs_ok(tmp_path: Path) -> None:
+    client, _ = _make_client(tmp_path)
+    raw = _load(FIXTURES_V2, "evaluate_anvil_shadow.json")
+    resp = client.post("/v1/evaluate", json=raw)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["logged"] == 1
+    assert data["status"] == "ok"
+
+
+def test_anvil_shadow_evaluate_fixture_payload_stored(tmp_path: Path) -> None:
+    client, store = _make_client(tmp_path)
+    raw = _load(FIXTURES_V2, "evaluate_anvil_shadow.json")
+    client.post("/v1/evaluate", json=raw)
+    assert store.count() == 1
+    stored = store.list_events()[0]
+    assert stored.payload["adoption_status"] == "shadow_not_injected"
+    assert stored.payload["ignored_reason"] == "shadow_mode_no_injection"
+
+
+def test_anvil_shadow_evaluate_raw_stdout_not_stored(tmp_path: Path) -> None:
+    client, store = _make_client(tmp_path)
+    body = {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "anvil-eval-raw-001",
+        "context_pack_event": {
+            "context_pack_request_id": "pack-anvil-raw-001",
+            "adoption_status": "shadow_not_injected",
+            "items_adopted_count": 0,
+            "items_ignored_count": 0,
+            "raw_stdout": "huge build log line 1\nline 2\nline 3",
+            "raw_stderr": "warning: unused import",
+        },
+    }
+    resp = client.post("/v1/evaluate", json=body)
+    assert resp.status_code == 200
+    assert resp.json()["logged"] == 1
+    stored = store.list_events()[0]
+    assert "raw_stdout" not in stored.payload
+    assert "raw_stderr" not in stored.payload
+    assert stored.payload["adoption_status"] == "shadow_not_injected"
+
+
+# ---------------------------------------------------------------------------
+# Canary evaluate fixtures — aggregate shadow/canary statuses
+# ---------------------------------------------------------------------------
+
+
+def test_anvil_canary_evaluate_shadow_mode_fixture_aggregates(tmp_path: Path) -> None:
+    client, store = _make_client(tmp_path)
+    raw = _load(FIXTURES_V2, "canary_evaluate_shadow_mode.json")
+    resp = client.post("/v1/evaluate", json=raw)
+    assert resp.status_code == 200
+    assert resp.json()["logged"] == 1
+    payloads = [e.payload for e in store.list_events()]
+    report = aggregate_context_pack_eval(payloads)
+    assert report.total_turns == 1
+    assert report.partial_count == 1
+
+
+def test_anvil_shadow_evaluate_log_all_records_stored(tmp_path: Path) -> None:
+    client, store = _make_client(tmp_path)
+    photon_log = _load(FIXTURES_PHOTON, "anvil_shadow_evaluate_log.json")
+    records = photon_log["records"]  # type: ignore[index]
+    for i, record in enumerate(records):
+        body = {
+            "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+            "request_id": f"anvil-log-eval-{i}",
+            "context_pack_event": record,
+        }
+        resp = client.post("/v1/evaluate", json=body)
+        assert resp.status_code == 200
+        assert resp.json()["logged"] == 1
+    assert store.count() == 3
+
+
+def test_anvil_shadow_evaluate_log_aggregates_correctly(tmp_path: Path) -> None:
+    client, store = _make_client(tmp_path)
+    photon_log = _load(FIXTURES_PHOTON, "anvil_shadow_evaluate_log.json")
+    records = photon_log["records"]  # type: ignore[index]
+    for i, record in enumerate(records):
+        client.post(
+            "/v1/evaluate",
+            json={
+                "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+                "request_id": f"anvil-agg-eval-{i}",
+                "context_pack_event": record,
+            },
+        )
+    payloads = [e.payload for e in store.list_events()]
+    report = aggregate_context_pack_eval(payloads)
+    assert report.total_turns == 3
+    assert report.shadow_not_injected_count == 1
+    assert report.not_available_count == 1
+    assert report.adopted_count == 1
+    assert report.adoption_rate == pytest.approx(1 / 3)
+
+
+def test_anvil_evaluate_canary_context_pack_adopted_fixture_logs(tmp_path: Path) -> None:
+    client, store = _make_client(tmp_path)
+    raw = _load(FIXTURES_V2, "evaluate_context_pack_adopted.json")
+    resp = client.post("/v1/evaluate", json=raw)
+    assert resp.status_code == 200
+    assert resp.json()["logged"] == 1
+    stored = store.list_events()[0]
+    assert stored.payload["adoption_status"] == "adopted"

--- a/tests/test_anvil_evidence_expand.py
+++ b/tests/test_anvil_evidence_expand.py
@@ -1,0 +1,292 @@
+"""Anvil evidence expansion safety profile tests (Issue #70 P7).
+
+Tests /v1/evidence/expand with anvil_profile=True:
+- Raw stdout/stderr always denied regardless of allow_raw_full_output
+- Safe concise snippets are returned
+- selected_evidence_ids filtering works with Anvil profile
+- Stable reason strings are preserved
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    EvidenceExpandBudget,
+    EvidenceExpandPolicy,
+    EvidenceExpandRequest,
+)
+from photon_action_memory.api.server import create_app
+from photon_action_memory.memory.evidence import (
+    REASON_NOT_IN_SELECTION,
+    REASON_RAW_OUTPUT_DENIED_ANVIL,
+    EvidenceExpander,
+)
+from photon_action_memory.memory.store import SQLiteEventStore
+
+FIXTURES_V2 = Path(__file__).parent / "fixtures" / "v0.2"
+
+
+def _rec(evidence_id: str, **kwargs: Any) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "evidence_id": evidence_id,
+        "kind": kwargs.pop("kind", "file_inspection"),
+        "summary": kwargs.pop("summary", "test summary"),
+    }
+    record.update(kwargs)
+    return record
+
+
+def _req(
+    evidence_ids: list[str],
+    *,
+    policy: EvidenceExpandPolicy | None = None,
+    budget: EvidenceExpandBudget | None = None,
+    selected_ids: list[str] | None = None,
+) -> EvidenceExpandRequest:
+    return EvidenceExpandRequest(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        request_id="req-anvil-expand",
+        evidence_ids=evidence_ids,
+        selected_evidence_ids=selected_ids,
+        budget=budget or EvidenceExpandBudget(),
+        policy=policy or EvidenceExpandPolicy(anvil_profile=True),
+    )
+
+
+# ---------------------------------------------------------------------------
+# anvil_profile denies raw output regardless of allow_raw_full_output
+# ---------------------------------------------------------------------------
+
+
+def test_anvil_profile_denies_stdout_with_allow_raw_true() -> None:
+    expander = EvidenceExpander(
+        records=[_rec("ev-anvil-out", kind="stdout", stdout="cargo build output")]
+    )
+    resp = expander.expand(
+        _req(
+            ["ev-anvil-out"],
+            policy=EvidenceExpandPolicy(allow_raw_full_output=True, anvil_profile=True),
+        )
+    )
+    assert resp.expanded == []
+    assert len(resp.omitted) == 1
+    assert resp.omitted[0].reason == REASON_RAW_OUTPUT_DENIED_ANVIL
+
+
+def test_anvil_profile_denies_stderr_with_allow_raw_true() -> None:
+    expander = EvidenceExpander(records=[_rec("ev-anvil-err", kind="stderr", stderr="error trace")])
+    resp = expander.expand(
+        _req(
+            ["ev-anvil-err"],
+            policy=EvidenceExpandPolicy(allow_raw_full_output=True, anvil_profile=True),
+        )
+    )
+    assert resp.expanded == []
+    assert resp.omitted[0].reason == REASON_RAW_OUTPUT_DENIED_ANVIL
+
+
+def test_anvil_profile_denies_build_log() -> None:
+    expander = EvidenceExpander(
+        records=[_rec("ev-anvil-build", kind="build_log", content="BUILD FAILED")]
+    )
+    resp = expander.expand(_req(["ev-anvil-build"]))
+    assert resp.expanded == []
+    assert len(resp.omitted) == 1
+    assert resp.omitted[0].reason == REASON_RAW_OUTPUT_DENIED_ANVIL
+
+
+def test_anvil_profile_denies_grep_output() -> None:
+    expander = EvidenceExpander(
+        records=[_rec("ev-anvil-grep", kind="grep_output", content="src/main.rs:42: let x = 1;")]
+    )
+    resp = expander.expand(_req(["ev-anvil-grep"]))
+    assert resp.expanded == []
+    assert resp.omitted[0].reason == REASON_RAW_OUTPUT_DENIED_ANVIL
+
+
+def test_anvil_profile_denies_file_content() -> None:
+    expander = EvidenceExpander(
+        records=[_rec("ev-anvil-fc", kind="file_content", content="fn main() {}")]
+    )
+    resp = expander.expand(_req(["ev-anvil-fc"]))
+    assert resp.expanded == []
+    assert resp.omitted[0].reason == REASON_RAW_OUTPUT_DENIED_ANVIL
+
+
+# ---------------------------------------------------------------------------
+# anvil_profile allows safe concise snippets
+# ---------------------------------------------------------------------------
+
+
+def test_anvil_profile_allows_file_inspection_snippet() -> None:
+    expander = EvidenceExpander(
+        records=[
+            _rec("ev-anvil-snip", kind="file_inspection", snippet="let x: u32 = value as u32;")
+        ]
+    )
+    resp = expander.expand(_req(["ev-anvil-snip"]))
+    assert len(resp.expanded) == 1
+    assert resp.expanded[0].snippet == "let x: u32 = value as u32;"
+    assert resp.omitted == []
+
+
+def test_anvil_profile_allows_edit_attempt_snippet() -> None:
+    expander = EvidenceExpander(
+        records=[
+            _rec("ev-anvil-edit", kind="edit_attempt", snippet="Changed line 42 from i32 to u32")
+        ]
+    )
+    resp = expander.expand(_req(["ev-anvil-edit"]))
+    assert len(resp.expanded) == 1
+    assert resp.omitted == []
+
+
+def test_anvil_profile_snippet_is_sanitized() -> None:
+    secret = "token=sk-abc123def456ghi789jkl012"
+    expander = EvidenceExpander(records=[_rec("ev-anvil-sec", snippet=secret)])
+    resp = expander.expand(_req(["ev-anvil-sec"]))
+    assert len(resp.expanded) == 1
+    snippet = resp.expanded[0].snippet or ""
+    assert "sk-abc123" not in snippet
+    assert "[REDACTED" in snippet
+
+
+# ---------------------------------------------------------------------------
+# selected_evidence_ids + anvil_profile
+# ---------------------------------------------------------------------------
+
+
+def test_anvil_profile_selected_ids_allows_listed() -> None:
+    expander = EvidenceExpander(records=[_rec("ev-allowed", snippet="safe code")])
+    resp = expander.expand(_req(["ev-allowed"], selected_ids=["ev-allowed"]))
+    assert len(resp.expanded) == 1
+
+
+def test_anvil_profile_selected_ids_omits_unlisted() -> None:
+    expander = EvidenceExpander(records=[_rec("ev-blocked", snippet="safe code")])
+    resp = expander.expand(_req(["ev-blocked"], selected_ids=["ev-other"]))
+    assert resp.expanded == []
+    assert len(resp.omitted) == 1
+    assert resp.omitted[0].reason == REASON_NOT_IN_SELECTION
+
+
+def test_anvil_profile_selected_ids_with_raw_blocked_by_anvil() -> None:
+    expander = EvidenceExpander(records=[_rec("ev-raw-sel", kind="stdout", stdout="build log")])
+    resp = expander.expand(
+        _req(
+            ["ev-raw-sel"],
+            policy=EvidenceExpandPolicy(allow_raw_full_output=True, anvil_profile=True),
+            selected_ids=["ev-raw-sel"],
+        )
+    )
+    # selected_evidence_ids check passes (it's in the list), but anvil_profile blocks raw
+    assert resp.expanded == []
+    assert resp.omitted[0].reason == REASON_RAW_OUTPUT_DENIED_ANVIL
+
+
+# ---------------------------------------------------------------------------
+# API endpoint with anvil_profile policy
+# ---------------------------------------------------------------------------
+
+
+def _api_body(
+    evidence_ids: list[str],
+    *,
+    extra_records: list[dict[str, Any]] | None = None,
+    policy: dict[str, Any] | None = None,
+    selected_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "req-anvil-api",
+        "evidence_ids": evidence_ids,
+        "budget": {"max_chars_per_evidence": 1200},
+        "policy": policy or {"anvil_profile": True, "redact_again": True},
+    }
+    if extra_records is not None:
+        body["evidence_records"] = extra_records
+    if selected_ids is not None:
+        body["selected_evidence_ids"] = selected_ids
+    return body
+
+
+def test_api_anvil_profile_denies_stdout(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    records = [
+        {
+            "evidence_id": "ev-anvil-api-out",
+            "kind": "stdout",
+            "summary": "s",
+            "stdout": "build output",
+        }
+    ]
+    with TestClient(app) as client:
+        resp = client.post(
+            "/v1/evidence/expand", json=_api_body(["ev-anvil-api-out"], extra_records=records)
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["expanded"] == []
+    assert data["omitted"][0]["reason"] == REASON_RAW_OUTPUT_DENIED_ANVIL
+
+
+def test_api_anvil_profile_allows_safe_snippet(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    records = [
+        {
+            "evidence_id": "ev-anvil-api-safe",
+            "kind": "file_inspection",
+            "summary": "s",
+            "snippet": "def fix(): pass",
+        }
+    ]
+    with TestClient(app) as client:
+        resp = client.post(
+            "/v1/evidence/expand", json=_api_body(["ev-anvil-api-safe"], extra_records=records)
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["expanded"]) == 1
+    assert data["expanded"][0]["snippet"] == "def fix(): pass"
+
+
+def test_api_anvil_profile_stable_reason_raw_denied(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    records = [
+        {"evidence_id": "ev-anvil-stable", "kind": "stdout", "summary": "s", "stdout": "log"}
+    ]
+    body = _api_body(
+        ["ev-anvil-stable"],
+        extra_records=records,
+        policy={"allow_raw_full_output": True, "redact_again": True, "anvil_profile": True},
+    )
+    with TestClient(app) as client:
+        resp = client.post("/v1/evidence/expand", json=body)
+    assert resp.status_code == 200
+    assert resp.json()["omitted"][0]["reason"] == "raw output denied: anvil profile"
+
+
+def test_api_anvil_profile_selected_ids_filtering(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    records = [
+        {"evidence_id": "ev-anvil-in", "kind": "file_inspection", "summary": "s", "snippet": "yes"},
+        {"evidence_id": "ev-anvil-out", "kind": "file_inspection", "summary": "s", "snippet": "no"},
+    ]
+    body = _api_body(
+        ["ev-anvil-in", "ev-anvil-out"],
+        extra_records=records,
+        selected_ids=["ev-anvil-in"],
+    )
+    with TestClient(app) as client:
+        resp = client.post("/v1/evidence/expand", json=body)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["expanded"]) == 1
+    assert data["expanded"][0]["evidence_id"] == "ev-anvil-in"
+    assert len(data["omitted"]) == 1
+    assert data["omitted"][0]["reason"] == "evidence_id not in selected_evidence_ids"

--- a/tests/test_anvil_feedback_scoring.py
+++ b/tests/test_anvil_feedback_scoring.py
@@ -1,0 +1,209 @@
+"""Anvil feedback scoring tests (Issue #70 P7).
+
+Tests summary store integration with Anvil data:
+- Anvil summaries upserted via API are retrievable
+- Stale Anvil summaries are filtered before context pack
+- Shadow/canary evaluate records from Anvil aggregate into adoption reports
+- Summary upsert API endpoint works end-to-end
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    ActionSummary,
+    Fact,
+    Validity,
+)
+from photon_action_memory.api.server import create_app
+from photon_action_memory.eval.context_pack_log import aggregate_context_pack_eval
+from photon_action_memory.memory.retrieval import SummaryRetriever
+from photon_action_memory.memory.store import SQLiteEventStore
+from photon_action_memory.memory.summary_store import SummaryStore
+
+FIXTURES_PHOTON = Path(__file__).parent / "fixtures" / "photon"
+FIXTURES_V2 = Path(__file__).parent / "fixtures" / "v0.2"
+
+
+def _load(directory: Path, name: str) -> object:
+    return json.loads((directory / name).read_text(encoding="utf-8"))
+
+
+def _summary(
+    summary_id: str = "anvil-sum-001",
+    *,
+    repo_id: str = "my-repo",
+    task_signature: str = "fix-build",
+    validity_status: str = "valid",
+) -> ActionSummary:
+    return ActionSummary(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        summary_id=summary_id,
+        repo_id=repo_id,
+        task_signature=task_signature,
+        facts=[Fact(text="the build fix is in src/main.rs line 42", evidence_ids=["ev-1"])],
+        validity=Validity(status=validity_status),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Summary upsert API endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_anvil_summary_upsert_api_returns_stored(tmp_path: Path) -> None:
+    app = create_app(
+        SQLiteEventStore(tmp_path / "events.sqlite"),
+        SummaryStore(tmp_path / "summaries.sqlite"),
+    )
+    raw_summary = _load(FIXTURES_PHOTON, "anvil_action_summary.json")
+    body = {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "upsert-req-001",
+        "summary": raw_summary,
+    }
+    with TestClient(app) as client:
+        resp = client.post("/v1/summary/upsert", json=body)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["summary_id"] == "anvil-sum-photon-001"
+    assert data["status"] == "stored"
+
+
+def test_anvil_summary_upsert_api_twice_is_idempotent(tmp_path: Path) -> None:
+    summary_store = SummaryStore(tmp_path / "summaries.sqlite")
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"), summary_store)
+    raw_summary = _load(FIXTURES_PHOTON, "anvil_action_summary.json")
+    body = {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "upsert-req-002",
+        "summary": raw_summary,
+    }
+    with TestClient(app) as client:
+        client.post("/v1/summary/upsert", json=body)
+        client.post("/v1/summary/upsert", json=body)
+    assert summary_store.count() == 1
+
+
+# ---------------------------------------------------------------------------
+# SummaryStore — Anvil-specific upsert / retrieve / filter
+# ---------------------------------------------------------------------------
+
+
+def test_anvil_summary_store_upsert_and_get(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        raw = _load(FIXTURES_PHOTON, "anvil_action_summary.json")
+        s = ActionSummary.model_validate(raw)
+        store.upsert(s)
+        result = store.get("anvil-sum-photon-001")
+    assert result is not None
+    assert result.summary_id == "anvil-sum-photon-001"
+    assert result.repo_id == "my-repo"
+    assert len(result.facts) == 2
+
+
+def test_anvil_summary_store_search_by_repo(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        store.upsert(_summary("sum-a", repo_id="repo-anvil"))
+        store.upsert(_summary("sum-b", repo_id="repo-other"))
+        results = store.search(repo_id="repo-anvil")
+    assert len(results) == 1
+    assert results[0].summary_id == "sum-a"
+
+
+def test_anvil_summary_store_search_by_task_signature(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        store.upsert(_summary("sum-a", task_signature="fix-auth"))
+        store.upsert(_summary("sum-b", task_signature="fix-build"))
+        results = store.search(task_signature="fix-build")
+    assert len(results) == 1
+    assert results[0].summary_id == "sum-b"
+
+
+# ---------------------------------------------------------------------------
+# SummaryRetriever — Anvil stale filtering
+# ---------------------------------------------------------------------------
+
+
+def test_anvil_retriever_excludes_stale_summary(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        store.upsert(_summary("sum-stale", validity_status="stale"))
+        store.upsert(_summary("sum-valid", validity_status="valid"))
+        retriever = SummaryRetriever(store)
+        results = retriever.resolve_candidates(["sum-stale", "sum-valid"])
+    assert len(results) == 1
+    assert results[0].summary_id == "sum-valid"
+
+
+def test_anvil_retriever_excludes_contradicted_summary(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        store.upsert(_summary("sum-bad", validity_status="contradicted"))
+        retriever = SummaryRetriever(store)
+        results = retriever.resolve_candidates(["sum-bad"])
+    assert results == []
+
+
+def test_anvil_retriever_search_filters_stale(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        store.upsert(_summary("sum-ok", repo_id="repo-a", validity_status="valid"))
+        store.upsert(_summary("sum-stale", repo_id="repo-a", validity_status="stale"))
+        retriever = SummaryRetriever(store)
+        results = retriever.search(repo_id="repo-a")
+    ids = {r.summary_id for r in results}
+    assert "sum-ok" in ids
+    assert "sum-stale" not in ids
+
+
+# ---------------------------------------------------------------------------
+# Aggregate shadow/canary evaluate records from stored events
+# ---------------------------------------------------------------------------
+
+
+def test_anvil_shadow_evaluate_records_aggregate_after_store(tmp_path: Path) -> None:
+    store = SQLiteEventStore(tmp_path / "events.sqlite")
+    app = create_app(store)
+    photon_log = _load(FIXTURES_PHOTON, "anvil_shadow_evaluate_log.json")
+    records = photon_log["records"]  # type: ignore[index]
+
+    with TestClient(app) as client:
+        for i, record in enumerate(records):
+            body = {
+                "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+                "request_id": f"scoring-eval-{i}",
+                "context_pack_event": record,
+            }
+            client.post("/v1/evaluate", json=body)
+
+    payloads = [e.payload for e in store.list_events()]
+    report = aggregate_context_pack_eval(payloads)
+    assert report.total_turns == 3
+    assert report.shadow_not_injected_count == 1
+    assert report.not_available_count == 1
+    assert report.adopted_count == 1
+    assert report.adoption_rate == pytest.approx(1 / 3)
+
+
+def test_anvil_adoption_log_fixture_full_aggregate(tmp_path: Path) -> None:
+    raw = _load(FIXTURES_V2, "context_pack_adoption_log_anvil.json")
+    report = aggregate_context_pack_eval(raw["records"])  # type: ignore[index]
+    assert report.total_turns == 5
+    assert report.adopted_count == 2
+    assert report.shadow_not_injected_count == 1
+    assert report.not_available_count == 1
+    assert report.error_count == 1
+    # adoption_rate = (adopted + partial) / total = 2/5
+    assert report.adoption_rate == pytest.approx(2 / 5)
+
+
+def test_anvil_summary_fixture_validity_is_valid() -> None:
+    raw = _load(FIXTURES_PHOTON, "anvil_action_summary.json")
+    s = ActionSummary.model_validate(raw)
+    assert s.validity.status == "valid"
+    assert s.token_cost is not None
+    assert s.token_cost.tokens_saved_vs_raw > 0


### PR DESCRIPTION
Refs #70. Summary: add Anvil integration contract and regression tests using photon fixtures. Verification: worker reported targeted Anvil tests passed and full suite passed.