### PR TITLE
#72 [Anvil photon integration] C2: Rollout policy の整理

### DIFF
--- a/dev-reports/issue-72/design.md
+++ b/dev-reports/issue-72/design.md
@@ -1,0 +1,59 @@
+# Design Note — Issue #72: C2 Rollout Policy
+
+## Problem
+
+The Anvil ↔ photon-action-memory integration has been running in shadow mode
+(context pack built, never injected). Before promoting to canary (live injection
+for a fraction of sessions), three safety gates must be verified:
+
+1. **Turn count** — shadow data must cover enough turns to be statistically meaningful.
+2. **Raw tool token cleanliness** — no raw stdout/stderr may appear in the injected prompt.
+3. **Sidecar stability** — error/timeout rate must be below an acceptable threshold.
+
+There was no code or documentation formalizing these gates.
+
+## Approach
+
+### `context/canary.py` — eligibility predicate
+
+Add `CanaryRolloutPolicy` (Pydantic model with `min_turns_for_canary` and
+`max_fail_open_rate`) and `is_canary_eligible(turn_count, raw_tool_tokens,
+fail_open_rate, policy)` returning `(bool, reason)`.
+
+This is a pure predicate: no side effects, no I/O. Placed in `context/canary.py`
+alongside the existing canary admission logic.
+
+### `eval/metrics.py` — rollout metrics aggregation
+
+Add `RolloutMetrics` (Pydantic model) and `build_rollout_metrics(eval_records,
+*, raw_tool_tokens_in_prompt, min_turns_for_canary, max_fail_open_rate)`.
+
+The function wraps `aggregate_context_pack_eval` (from `eval/context_pack_log`)
+and delegates the eligibility check to `is_canary_eligible`. It produces a
+single `RolloutMetrics` object with `canary_eligible`, `rollback_triggered`, and
+human-readable reasons.
+
+`raw_tool_tokens_in_prompt` is passed in by the caller (from `PollutionReport`)
+rather than recomputing it inside `build_rollout_metrics`. This keeps
+`build_rollout_metrics` focused and testable with synthetic values.
+
+### Fixture + tests
+
+- `tests/fixtures/v0.2/rollout_metrics_fixture.json` — four named scenarios
+  exercising each gate and the rollback path.
+- `tests/test_rollout_policy.py` — 14 tests: 8 unit tests for
+  `is_canary_eligible` and 6 fixture-driven tests for `build_rollout_metrics`.
+
+### Docs
+
+- `workspace/anvil/rollout_policy.md` — full checklist, rollback conditions,
+  and API usage examples.
+- `workspace/anvil/summary.md` — quick-reference section appended.
+
+## Alternatives considered
+
+- **Separate `eval/rollout.py` module**: rejected to keep the change minimal;
+  `RolloutMetrics` fits naturally alongside `MetricsReport` in `metrics.py`.
+- **`is_canary_eligible` inline in `build_rollout_metrics`**: rejected to avoid
+  duplicating logic; the predicate belongs in `context/canary.py` where the
+  canary policy lives.

--- a/dev-reports/issue-72/implementation-summary.md
+++ b/dev-reports/issue-72/implementation-summary.md
@@ -1,0 +1,50 @@
+# Implementation Summary — Issue #72
+
+## Files changed
+
+### `photon_action_memory/context/canary.py`
+- Added `CanaryRolloutPolicy` — Pydantic model with `min_turns_for_canary: int = 10`
+  and `max_fail_open_rate: float = 0.05`.
+- Added `CANARY_ROLLOUT_POLICY` default instance.
+- Added `is_canary_eligible(turn_count, raw_tool_tokens_in_prompt, *, fail_open_incident_rate, policy)
+  → tuple[bool, str]` — checks gates in order: turn count → raw tokens → fail-open rate.
+- Updated `__all__`.
+
+### `photon_action_memory/eval/metrics.py`
+- Added top-level imports: `CanaryRolloutPolicy`, `is_canary_eligible` from
+  `context.canary`; `RawContextPackEvalRecord`, `aggregate_context_pack_eval` from
+  `eval.context_pack_log`.
+- Added `ROLLOUT_METRICS_SCHEMA = "rollout-metrics.v1"`.
+- Added `RolloutMetrics` Pydantic model: `total_turns`, `raw_tool_tokens_in_prompt`,
+  `adoption_rate`, `fail_open_incident_rate`, `canary_eligible`, `ineligible_reason`,
+  `rollback_triggered`, `rollback_reason`.
+- Added `build_rollout_metrics(eval_records, *, raw_tool_tokens_in_prompt, min_turns_for_canary, max_fail_open_rate) → RolloutMetrics`.
+- Updated `__all__`.
+
+## Files created
+
+### `tests/fixtures/v0.2/rollout_metrics_fixture.json`
+Four scenarios: `canary_ready`, `too_few_turns`, `raw_tool_leak`, `high_fail_open`.
+
+### `tests/test_rollout_policy.py`
+14 tests: 8 unit tests for `is_canary_eligible`, 6 fixture-driven tests for
+`build_rollout_metrics` (including schema version and empty-records edge case).
+
+### `workspace/anvil/rollout_policy.md`
+Full shadow → canary promotion checklist, rollback conditions, API usage examples,
+and fixture scenario table.
+
+## Files updated
+
+### `workspace/anvil/summary.md`
+Added "Rollout Policy" section with quick-reference gate table and module index.
+
+## Acceptance criteria mapping
+
+| Criterion | Satisfied by |
+|---|---|
+| shadow/canary rollout checklist が docs 化 | `workspace/anvil/rollout_policy.md` |
+| Anvil evaluate fixture から rollout metrics を生成 | `build_rollout_metrics` + `rollout_metrics_fixture.json` |
+| turn 未満は canary 不可として判定 | `is_canary_eligible` turn-count gate, `too_few_turns` fixture test |
+| raw tool tokens in prompt が 0 であることを確認 | gate 2 in `is_canary_eligible`, `raw_tool_leak` fixture test |
+| rollback 条件を fixture test で検証 | `test_rollout_metrics_raw_tool_leak_triggers_rollback`, `test_rollout_metrics_high_fail_open_triggers_rollback` |

--- a/dev-reports/issue-72/verification.md
+++ b/dev-reports/issue-72/verification.md
@@ -1,0 +1,40 @@
+# Verification — Issue #72
+
+## Test run
+
+```
+python -m pytest tests/test_rollout_policy.py -v
+```
+
+```
+14 passed in 0.06s
+```
+
+All 14 tests pass:
+- `test_is_canary_eligible_passes_all_gates`
+- `test_is_canary_eligible_too_few_turns`
+- `test_is_canary_eligible_minimum_turns_boundary`
+- `test_is_canary_eligible_raw_tool_tokens_nonzero`
+- `test_is_canary_eligible_raw_tool_tokens_zero_passes`
+- `test_is_canary_eligible_high_fail_open_rate`
+- `test_is_canary_eligible_fail_open_at_threshold_passes`
+- `test_is_canary_eligible_turn_check_before_raw_token_check`
+- `test_rollout_metrics_canary_ready_fixture`
+- `test_rollout_metrics_too_few_turns_ineligible`
+- `test_rollout_metrics_raw_tool_leak_triggers_rollback`
+- `test_rollout_metrics_high_fail_open_triggers_rollback`
+- `test_rollout_metrics_schema_version`
+- `test_rollout_metrics_empty_records`
+
+## Regression check
+
+```
+python -m pytest tests/ --ignore=tests/integration -q
+```
+
+```
+770 passed in 1.90s
+```
+
+No regressions. The new imports in `eval/metrics.py` (`context.canary` and
+`eval.context_pack_log`) introduce no circular dependencies.

--- a/photon_action_memory/context/canary.py
+++ b/photon_action_memory/context/canary.py
@@ -188,13 +188,54 @@ def _decision(
     )
 
 
+class CanaryRolloutPolicy(BaseModel):
+    """Thresholds that gate promotion from shadow mode to canary injection."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    min_turns_for_canary: int = Field(default=10, ge=1)
+    max_fail_open_rate: float = Field(default=0.05, ge=0.0, le=1.0)
+
+
+CANARY_ROLLOUT_POLICY = CanaryRolloutPolicy()
+
+
+def is_canary_eligible(
+    turn_count: int,
+    raw_tool_tokens_in_prompt: int,
+    *,
+    fail_open_incident_rate: float = 0.0,
+    policy: CanaryRolloutPolicy = CANARY_ROLLOUT_POLICY,
+) -> tuple[bool, str]:
+    """Return (eligible, reason) for canary promotion.
+
+    Criteria (all must pass):
+    - turn_count >= policy.min_turns_for_canary
+    - raw_tool_tokens_in_prompt == 0
+    - fail_open_incident_rate <= policy.max_fail_open_rate
+    """
+    if turn_count < policy.min_turns_for_canary:
+        return False, f"turn count {turn_count} < min {policy.min_turns_for_canary}"
+    if raw_tool_tokens_in_prompt > 0:
+        return False, f"raw_tool_tokens_in_prompt={raw_tool_tokens_in_prompt} must be 0"
+    if fail_open_incident_rate > policy.max_fail_open_rate:
+        return (
+            False,
+            f"fail_open_incident_rate={fail_open_incident_rate:.3f} > {policy.max_fail_open_rate}",
+        )
+    return True, "eligible for canary"
+
+
 __all__ = [
     "CANARY_ALLOWED_CLASSES",
     "CANARY_DENIED_CLASSES",
     "CANARY_MODE_CONFIG",
     "CANARY_POLICY_NAME",
+    "CANARY_ROLLOUT_POLICY",
     "CanaryCandidate",
     "CanaryModeConfig",
+    "CanaryRolloutPolicy",
     "evaluate_canary_candidate",
     "evaluate_canary_candidates",
+    "is_canary_eligible",
 ]

--- a/photon_action_memory/eval/metrics.py
+++ b/photon_action_memory/eval/metrics.py
@@ -8,7 +8,17 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from photon_action_memory.context.canary import (
+    CanaryRolloutPolicy,
+    is_canary_eligible,
+)
+from photon_action_memory.eval.context_pack_log import (
+    RawContextPackEvalRecord,
+    aggregate_context_pack_eval,
+)
+
 REPORT_SCHEMA_VERSION = "eval-metrics.v1"
+ROLLOUT_METRICS_SCHEMA = "rollout-metrics.v1"
 
 
 class EvalModel(BaseModel):
@@ -224,12 +234,86 @@ def _count_values(values: Iterable[str]) -> dict[str, int]:
     return dict(sorted(counts.items()))
 
 
+class RolloutMetrics(BaseModel):
+    """Gate metrics for shadow → canary promotion.
+
+    Computed from a batch of Anvil evaluate records plus the aggregate
+    raw-tool-token count from the corresponding pollution report.
+    """
+
+    schema_version: Literal["rollout-metrics.v1"] = "rollout-metrics.v1"
+    total_turns: int
+    raw_tool_tokens_in_prompt: int
+    adoption_rate: float
+    fail_open_incident_rate: float
+    canary_eligible: bool
+    ineligible_reason: str | None
+    rollback_triggered: bool
+    rollback_reason: str | None
+
+
+def build_rollout_metrics(
+    eval_records: Sequence[RawContextPackEvalRecord],
+    *,
+    raw_tool_tokens_in_prompt: int = 0,
+    min_turns_for_canary: int = 10,
+    max_fail_open_rate: float = 0.05,
+) -> RolloutMetrics:
+    """Compute rollout gate metrics from Anvil evaluate records.
+
+    ``raw_tool_tokens_in_prompt`` should come from the aggregate
+    ``PollutionReport.total_raw_tool_tokens_in_prompt`` for the same batch.
+    """
+    adoption_report = aggregate_context_pack_eval(eval_records)
+
+    fail_open_incident_rate = _rate(
+        adoption_report.error_count + adoption_report.not_available_count,
+        adoption_report.total_turns,
+    )
+
+    rollback_triggered = False
+    rollback_reason: str | None = None
+    if raw_tool_tokens_in_prompt > 0:
+        rollback_triggered = True
+        rollback_reason = f"raw_tool_tokens_in_prompt={raw_tool_tokens_in_prompt} > 0"
+    elif fail_open_incident_rate > max_fail_open_rate:
+        rollback_triggered = True
+        rollback_reason = (
+            f"fail_open_incident_rate={fail_open_incident_rate:.3f} > {max_fail_open_rate}"
+        )
+
+    policy = CanaryRolloutPolicy(
+        min_turns_for_canary=min_turns_for_canary,
+        max_fail_open_rate=max_fail_open_rate,
+    )
+    eligible, eligibility_reason = is_canary_eligible(
+        adoption_report.total_turns,
+        raw_tool_tokens_in_prompt,
+        fail_open_incident_rate=fail_open_incident_rate,
+        policy=policy,
+    )
+
+    return RolloutMetrics(
+        total_turns=adoption_report.total_turns,
+        raw_tool_tokens_in_prompt=raw_tool_tokens_in_prompt,
+        adoption_rate=adoption_report.adoption_rate,
+        fail_open_incident_rate=fail_open_incident_rate,
+        canary_eligible=eligible,
+        ineligible_reason=None if eligible else eligibility_reason,
+        rollback_triggered=rollback_triggered,
+        rollback_reason=rollback_reason,
+    )
+
+
 __all__ = [
     "EvalAction",
     "EvalSuggestion",
     "EvalWarning",
     "MetricsReport",
     "REPORT_SCHEMA_VERSION",
+    "ROLLOUT_METRICS_SCHEMA",
+    "RolloutMetrics",
     "ShadowEvalRecord",
     "build_metrics_report",
+    "build_rollout_metrics",
 ]

--- a/tests/fixtures/v0.2/rollout_metrics_fixture.json
+++ b/tests/fixtures/v0.2/rollout_metrics_fixture.json
@@ -1,0 +1,65 @@
+{
+  "schema": "rollout-metrics-fixture.v1",
+  "description": "Rollout policy gate scenarios for shadow → canary promotion (Issue #72).",
+  "scenarios": {
+    "canary_ready": {
+      "description": "10 adopted turns, no raw tool tokens — all gates pass, canary eligible.",
+      "raw_tool_tokens_in_prompt": 0,
+      "eval_records": [
+        {"context_pack_request_id": "pack-ready-001", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 110.0},
+        {"context_pack_request_id": "pack-ready-002", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 120.0},
+        {"context_pack_request_id": "pack-ready-003", "adoption_status": "adopted", "items_adopted_count": 1, "items_ignored_count": 1, "outcome": "success", "latency_ms": 95.0},
+        {"context_pack_request_id": "pack-ready-004", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 130.0},
+        {"context_pack_request_id": "pack-ready-005", "adoption_status": "adopted", "items_adopted_count": 3, "items_ignored_count": 0, "outcome": "success", "latency_ms": 85.0},
+        {"context_pack_request_id": "pack-ready-006", "adoption_status": "partial", "items_adopted_count": 1, "items_ignored_count": 1, "outcome": "success", "latency_ms": 140.0},
+        {"context_pack_request_id": "pack-ready-007", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 105.0},
+        {"context_pack_request_id": "pack-ready-008", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 118.0},
+        {"context_pack_request_id": "pack-ready-009", "adoption_status": "adopted", "items_adopted_count": 1, "items_ignored_count": 0, "outcome": "success", "latency_ms": 92.0},
+        {"context_pack_request_id": "pack-ready-010", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 115.0}
+      ]
+    },
+    "too_few_turns": {
+      "description": "Only 5 turns — below min_turns_for_canary=10, canary ineligible.",
+      "raw_tool_tokens_in_prompt": 0,
+      "eval_records": [
+        {"context_pack_request_id": "pack-few-001", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 110.0},
+        {"context_pack_request_id": "pack-few-002", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 120.0},
+        {"context_pack_request_id": "pack-few-003", "adoption_status": "adopted", "items_adopted_count": 1, "items_ignored_count": 0, "outcome": "success", "latency_ms": 95.0},
+        {"context_pack_request_id": "pack-few-004", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 130.0},
+        {"context_pack_request_id": "pack-few-005", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 85.0}
+      ]
+    },
+    "raw_tool_leak": {
+      "description": "10 turns but raw_tool_tokens_in_prompt=124 — raw leak triggers rollback, canary ineligible.",
+      "raw_tool_tokens_in_prompt": 124,
+      "eval_records": [
+        {"context_pack_request_id": "pack-leak-001", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 110.0},
+        {"context_pack_request_id": "pack-leak-002", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 120.0},
+        {"context_pack_request_id": "pack-leak-003", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 95.0},
+        {"context_pack_request_id": "pack-leak-004", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 130.0},
+        {"context_pack_request_id": "pack-leak-005", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 85.0},
+        {"context_pack_request_id": "pack-leak-006", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 140.0},
+        {"context_pack_request_id": "pack-leak-007", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 105.0},
+        {"context_pack_request_id": "pack-leak-008", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 118.0},
+        {"context_pack_request_id": "pack-leak-009", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 92.0},
+        {"context_pack_request_id": "pack-leak-010", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 115.0}
+      ]
+    },
+    "high_fail_open": {
+      "description": "10 turns but 3/10 are errors — fail_open_incident_rate=0.3 > max 0.05, triggers rollback.",
+      "raw_tool_tokens_in_prompt": 0,
+      "eval_records": [
+        {"context_pack_request_id": "pack-failopen-001", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 110.0},
+        {"context_pack_request_id": "pack-failopen-002", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 120.0},
+        {"context_pack_request_id": "pack-failopen-003", "adoption_status": "error", "ignored_reason": "sidecar_error", "items_adopted_count": 0, "items_ignored_count": 0, "outcome": "failure", "latency_ms": 12.0},
+        {"context_pack_request_id": "pack-failopen-004", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 130.0},
+        {"context_pack_request_id": "pack-failopen-005", "adoption_status": "not_available", "ignored_reason": "sidecar_timeout", "items_adopted_count": 0, "items_ignored_count": 0, "outcome": "partial", "latency_ms": 5000.0},
+        {"context_pack_request_id": "pack-failopen-006", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 140.0},
+        {"context_pack_request_id": "pack-failopen-007", "adoption_status": "not_available", "ignored_reason": "sidecar_timeout", "items_adopted_count": 0, "items_ignored_count": 0, "outcome": "partial", "latency_ms": 5100.0},
+        {"context_pack_request_id": "pack-failopen-008", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 118.0},
+        {"context_pack_request_id": "pack-failopen-009", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 92.0},
+        {"context_pack_request_id": "pack-failopen-010", "adoption_status": "adopted", "items_adopted_count": 2, "items_ignored_count": 0, "outcome": "success", "latency_ms": 115.0}
+      ]
+    }
+  }
+}

--- a/tests/test_rollout_policy.py
+++ b/tests/test_rollout_policy.py
@@ -1,0 +1,187 @@
+"""Tests for Anvil shadow → canary rollout policy (Issue #72).
+
+Covers:
+- is_canary_eligible() turn-count gate
+- is_canary_eligible() raw-tool-token gate
+- is_canary_eligible() fail-open rate gate
+- build_rollout_metrics() generates correct metrics from Anvil eval fixtures
+- rollback conditions verified via fixture
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from photon_action_memory.context.canary import (
+    CanaryRolloutPolicy,
+    is_canary_eligible,
+)
+from photon_action_memory.eval.metrics import (
+    RolloutMetrics,
+    build_rollout_metrics,
+)
+
+FIXTURES_V2 = Path(__file__).parent / "fixtures" / "v0.2"
+
+
+def _load_rollout_fixture() -> dict[str, Any]:
+    return cast(
+        dict[str, Any],
+        json.loads((FIXTURES_V2 / "rollout_metrics_fixture.json").read_text(encoding="utf-8")),
+    )
+
+
+# ---------------------------------------------------------------------------
+# is_canary_eligible — unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_is_canary_eligible_passes_all_gates() -> None:
+    eligible, reason = is_canary_eligible(10, 0)
+    assert eligible is True
+    assert reason == "eligible for canary"
+
+
+def test_is_canary_eligible_too_few_turns() -> None:
+    policy = CanaryRolloutPolicy(min_turns_for_canary=10)
+    eligible, reason = is_canary_eligible(5, 0, policy=policy)
+    assert eligible is False
+    assert "turn count 5 < min 10" in reason
+
+
+def test_is_canary_eligible_minimum_turns_boundary() -> None:
+    policy = CanaryRolloutPolicy(min_turns_for_canary=10)
+    eligible_at_min, _ = is_canary_eligible(10, 0, policy=policy)
+    eligible_below, _ = is_canary_eligible(9, 0, policy=policy)
+    assert eligible_at_min is True
+    assert eligible_below is False
+
+
+def test_is_canary_eligible_raw_tool_tokens_nonzero() -> None:
+    eligible, reason = is_canary_eligible(15, 124)
+    assert eligible is False
+    assert "raw_tool_tokens_in_prompt=124 must be 0" in reason
+
+
+def test_is_canary_eligible_raw_tool_tokens_zero_passes() -> None:
+    eligible, _ = is_canary_eligible(15, 0)
+    assert eligible is True
+
+
+def test_is_canary_eligible_high_fail_open_rate() -> None:
+    policy = CanaryRolloutPolicy(min_turns_for_canary=5, max_fail_open_rate=0.05)
+    eligible, reason = is_canary_eligible(10, 0, fail_open_incident_rate=0.3, policy=policy)
+    assert eligible is False
+    assert "fail_open_incident_rate=0.300" in reason
+
+
+def test_is_canary_eligible_fail_open_at_threshold_passes() -> None:
+    policy = CanaryRolloutPolicy(max_fail_open_rate=0.05)
+    eligible, _ = is_canary_eligible(10, 0, fail_open_incident_rate=0.05, policy=policy)
+    assert eligible is True
+
+
+def test_is_canary_eligible_turn_check_before_raw_token_check() -> None:
+    # Turn count gate is checked first; raw-token gate is secondary.
+    policy = CanaryRolloutPolicy(min_turns_for_canary=10)
+    eligible, reason = is_canary_eligible(3, 200, policy=policy)
+    assert eligible is False
+    assert "turn count" in reason
+
+
+# ---------------------------------------------------------------------------
+# build_rollout_metrics — fixture-driven integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_rollout_metrics_canary_ready_fixture() -> None:
+    fixture = _load_rollout_fixture()
+    scenario = fixture["scenarios"]["canary_ready"]
+    metrics = build_rollout_metrics(
+        scenario["eval_records"],
+        raw_tool_tokens_in_prompt=scenario["raw_tool_tokens_in_prompt"],
+        min_turns_for_canary=10,
+    )
+    assert isinstance(metrics, RolloutMetrics)
+    assert metrics.total_turns == 10
+    assert metrics.raw_tool_tokens_in_prompt == 0
+    assert metrics.canary_eligible is True
+    assert metrics.ineligible_reason is None
+    assert metrics.rollback_triggered is False
+    assert metrics.rollback_reason is None
+
+
+def test_rollout_metrics_too_few_turns_ineligible() -> None:
+    fixture = _load_rollout_fixture()
+    scenario = fixture["scenarios"]["too_few_turns"]
+    metrics = build_rollout_metrics(
+        scenario["eval_records"],
+        raw_tool_tokens_in_prompt=scenario["raw_tool_tokens_in_prompt"],
+        min_turns_for_canary=10,
+    )
+    assert metrics.total_turns == 5
+    assert metrics.canary_eligible is False
+    assert metrics.ineligible_reason is not None
+    assert "turn count 5 < min 10" in metrics.ineligible_reason
+    assert metrics.rollback_triggered is False
+
+
+def test_rollout_metrics_raw_tool_leak_triggers_rollback() -> None:
+    fixture = _load_rollout_fixture()
+    scenario = fixture["scenarios"]["raw_tool_leak"]
+    metrics = build_rollout_metrics(
+        scenario["eval_records"],
+        raw_tool_tokens_in_prompt=scenario["raw_tool_tokens_in_prompt"],
+        min_turns_for_canary=10,
+    )
+    assert metrics.total_turns == 10
+    assert metrics.raw_tool_tokens_in_prompt == 124
+    assert metrics.rollback_triggered is True
+    assert metrics.rollback_reason is not None
+    assert "raw_tool_tokens_in_prompt=124" in metrics.rollback_reason
+    assert metrics.canary_eligible is False
+
+
+def test_rollout_metrics_high_fail_open_triggers_rollback() -> None:
+    fixture = _load_rollout_fixture()
+    scenario = fixture["scenarios"]["high_fail_open"]
+    metrics = build_rollout_metrics(
+        scenario["eval_records"],
+        raw_tool_tokens_in_prompt=scenario["raw_tool_tokens_in_prompt"],
+        min_turns_for_canary=10,
+        max_fail_open_rate=0.05,
+    )
+    assert metrics.total_turns == 10
+    assert metrics.fail_open_incident_rate == pytest.approx(0.3)
+    assert metrics.rollback_triggered is True
+    assert metrics.rollback_reason is not None
+    assert "fail_open_incident_rate" in metrics.rollback_reason
+    assert metrics.canary_eligible is False
+
+
+def test_rollout_metrics_schema_version() -> None:
+    metrics = build_rollout_metrics(
+        [
+            {
+                "context_pack_request_id": "x",
+                "adoption_status": "adopted",
+                "items_adopted_count": 1,
+                "items_ignored_count": 0,
+            }
+        ]
+        * 10,
+        raw_tool_tokens_in_prompt=0,
+    )
+    assert metrics.schema_version == "rollout-metrics.v1"
+
+
+def test_rollout_metrics_empty_records() -> None:
+    metrics = build_rollout_metrics([], raw_tool_tokens_in_prompt=0, min_turns_for_canary=10)
+    assert metrics.total_turns == 0
+    assert metrics.canary_eligible is False
+    assert metrics.ineligible_reason is not None
+    assert "turn count 0" in metrics.ineligible_reason

--- a/workspace/anvil/rollout_policy.md
+++ b/workspace/anvil/rollout_policy.md
@@ -1,0 +1,125 @@
+# Anvil ↔ photon-action-memory: Rollout Policy
+
+This document defines the promotion criteria for the Anvil photon-action-memory
+integration, moving from **shadow mode** (observe only) to **canary mode**
+(live injection for a fraction of Anvil sessions).
+
+---
+
+## Phase overview
+
+| Phase | Injection | Metrics collection | Promotion gate |
+|---|---|---|---|
+| Shadow | None — context pack is built but never sent to the prompt | All rollout metrics recorded as `shadow_not_injected` | Satisfy all canary gates below |
+| Canary | Live injection for a configurable percentage of sessions | Full adoption + pollution metrics | Satisfy rollback safety thresholds |
+| Full rollout | Live injection for all eligible sessions | Ongoing monitoring | N/A |
+
+---
+
+## Shadow → Canary checklist
+
+Before promoting to canary, **all** of the following must be green.
+
+### Gate 1 — Minimum turn count
+
+- **Condition**: `total_turns >= 10` (configurable via `CanaryRolloutPolicy.min_turns_for_canary`)
+- **Why**: A shadow run with fewer than 10 turns does not provide sufficient
+  statistical signal that the context pack behaves safely.
+- **Check**: `build_rollout_metrics(eval_records).canary_eligible`
+
+### Gate 2 — Zero raw tool tokens in prompt
+
+- **Condition**: `total_raw_tool_tokens_in_prompt == 0`
+- **Why**: Any non-zero value means raw stdout/stderr or raw tool output leaked
+  into the injected context, which violates the Anvil safety contract. This is a
+  hard gate; there is no threshold.
+- **Check**: `PollutionReport.total_raw_tool_tokens_in_prompt` from
+  `build_pollution_report(pollution_records)`
+
+### Gate 3 — Low fail-open incident rate
+
+- **Condition**: `(error_count + not_available_count) / total_turns <= 0.05`
+  (configurable via `CanaryRolloutPolicy.max_fail_open_rate`)
+- **Why**: A high rate of sidecar errors or timeouts indicates instability that
+  should be resolved before live injection.
+- **Check**: `build_rollout_metrics(eval_records).fail_open_incident_rate`
+
+---
+
+## Rollback conditions
+
+If **any** of the following is observed in canary or shadow mode, the integration
+must be rolled back immediately (revert to shadow or disable):
+
+| Condition | Signal | Action |
+|---|---|---|
+| `total_raw_tool_tokens_in_prompt > 0` | Raw tool output in prompt | Immediate rollback — disable injection |
+| `fail_open_incident_rate > max_fail_open_rate` | Sidecar errors / timeouts too frequent | Rollback — investigate sidecar stability |
+| Adoption rate collapses to 0 for multiple consecutive turns | Context pack systematically ignored | Investigate context pack quality |
+| Stale summary incidents spike | Summaries invalidated too frequently | Rollback + review summary store staleness policy |
+
+---
+
+## API helpers
+
+### `is_canary_eligible(turn_count, raw_tool_tokens_in_prompt, *, fail_open_incident_rate, policy)`
+
+Located in `photon_action_memory/context/canary.py`.
+
+Returns `(eligible: bool, reason: str)`. Checks all three gates in order:
+turn count → raw tool tokens → fail-open rate.
+
+```python
+from photon_action_memory.context.canary import CanaryRolloutPolicy, is_canary_eligible
+
+policy = CanaryRolloutPolicy(min_turns_for_canary=10, max_fail_open_rate=0.05)
+eligible, reason = is_canary_eligible(
+    turn_count=42,
+    raw_tool_tokens_in_prompt=0,
+    fail_open_incident_rate=0.02,
+    policy=policy,
+)
+# → (True, "eligible for canary")
+```
+
+### `build_rollout_metrics(eval_records, *, raw_tool_tokens_in_prompt, min_turns_for_canary, max_fail_open_rate)`
+
+Located in `photon_action_memory/eval/metrics.py`.
+
+Accepts a sequence of Anvil evaluate records (same shape as stored by
+`/v1/evaluate`) and the aggregate raw-tool-token count from the pollution report.
+Returns a `RolloutMetrics` instance with `canary_eligible`, `rollback_triggered`,
+and human-readable reasons.
+
+```python
+from photon_action_memory.eval.metrics import build_rollout_metrics
+from photon_action_memory.eval.pollution import build_pollution_report
+
+pollution = build_pollution_report(pollution_records)
+metrics = build_rollout_metrics(
+    eval_records,
+    raw_tool_tokens_in_prompt=pollution.total_raw_tool_tokens_in_prompt,
+    min_turns_for_canary=10,
+    max_fail_open_rate=0.05,
+)
+if metrics.rollback_triggered:
+    raise RuntimeError(f"rollback: {metrics.rollback_reason}")
+if not metrics.canary_eligible:
+    print(f"not yet eligible: {metrics.ineligible_reason}")
+```
+
+---
+
+## Fixture tests
+
+The fixture at `tests/fixtures/v0.2/rollout_metrics_fixture.json` contains four
+named scenarios:
+
+| Scenario | `total_turns` | `raw_tool_tokens_in_prompt` | Expected outcome |
+|---|---|---|---|
+| `canary_ready` | 10 | 0 | `canary_eligible=True`, `rollback_triggered=False` |
+| `too_few_turns` | 5 | 0 | `canary_eligible=False` (turn count gate) |
+| `raw_tool_leak` | 10 | 124 | `rollback_triggered=True`, `canary_eligible=False` |
+| `high_fail_open` | 10 | 0 | `rollback_triggered=True`, `fail_open_incident_rate=0.30` |
+
+Run with: `python -m pytest tests/test_rollout_policy.py -v`

--- a/workspace/anvil/summary.md
+++ b/workspace/anvil/summary.md
@@ -124,3 +124,25 @@ search by repo and task.
 |---|---|
 | `PHOTON_ACTION_MEMORY_DB` | `$TMPDIR/photon-action-memory/events.sqlite` |
 | `PHOTON_ACTION_MEMORY_SUMMARY_DB` | `$TMPDIR/photon-action-memory/summaries.sqlite` |
+
+## Rollout Policy (Issue #72)
+
+See `workspace/anvil/rollout_policy.md` for the full shadow → canary promotion
+checklist and rollback conditions.
+
+### Quick reference
+
+Three gates must all pass before canary injection is enabled:
+
+1. `total_turns >= 10` (configurable `min_turns_for_canary`)
+2. `total_raw_tool_tokens_in_prompt == 0` — hard gate, no threshold
+3. `fail_open_incident_rate <= 0.05` (configurable `max_fail_open_rate`)
+
+Rollback is triggered immediately if `raw_tool_tokens_in_prompt > 0` or
+`fail_open_incident_rate > max_fail_open_rate`.
+
+Key modules:
+- `photon_action_memory/context/canary.py` — `CanaryRolloutPolicy`, `is_canary_eligible()`
+- `photon_action_memory/eval/metrics.py` — `RolloutMetrics`, `build_rollout_metrics()`
+- `tests/fixtures/v0.2/rollout_metrics_fixture.json` — four named gate scenarios
+- `tests/test_rollout_policy.py` — 14 tests covering all gates and rollback conditions


### PR DESCRIPTION
Refs #72. Summary: add canary rollout policy gates, rollout metrics builder, fixture scenarios, tests, and Anvil rollout docs. Verification: ruff format --check ., ruff check ., python -m pytest tests/test_rollout_policy.py -q; worker also reported python -m pytest tests/ --ignore=tests/integration -q passed.