### PR TITLE
#73 [Anvil photon integration] C3: 運用ドキュメント

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ PHOTON Model
 
 The agent remains responsible for final decisions and tool execution. PHOTON Action Memory provides ranked suggestions and compact memory signals.
 
+Anvil operations docs:
+
+- `docs/photon-action-memory.md`: local sidecar startup and API smoke checks.
+- `docs/anvil-integration.md`: Anvil env/defaults, shadow/canary/rollback
+  checklists, shared fixture updates, and troubleshooting ownership.
+
 ## Inputs
 
 Typical inputs include:

--- a/dev-reports/issue-73/design.md
+++ b/dev-reports/issue-73/design.md
@@ -1,0 +1,42 @@
+# Design Note - Issue #73: Anvil Operations Docs
+
+## Objective
+
+Document the day-to-day Anvil integration workflow for photon-action-memory:
+starting the local sidecar, running API smoke checks, configuring Anvil
+shadow/canary mode, updating shared fixtures, and troubleshooting failures.
+
+## Scope
+
+This issue is documentation-only. The API and rollout helpers already exist:
+
+- `photon_action_memory/api/server.py` exposes `/health`,
+  `/v1/context/pack`, `/v1/evidence/expand`, `/v1/summary/upsert`,
+  `/v1/summary/validate`, and `/v1/evaluate`.
+- `workspace/anvil/summary.md` already captures shared fixture and rollout
+  references from Issues #71 and #72.
+- `workspace/anvil/rollout_policy.md` already defines the rollout gates.
+
+## Design
+
+Add two docs:
+
+- `docs/photon-action-memory.md`: photon-side sidecar quickstart and API smoke
+  checks that can be run without the Anvil repository.
+- `docs/anvil-integration.md`: Anvil-facing operations guide with env/defaults,
+  shadow/canary/rollback checklists, fixture update procedure, and split
+  troubleshooting responsibilities.
+
+Update navigation:
+
+- Link the docs from `README.md`.
+- Link the docs from `workspace/anvil/summary.md`.
+
+## Safety Notes
+
+- Use `127.0.0.1:18765` as the example sidecar URL.
+- Do not use port 3000 in the documentation.
+- Keep source-of-truth boundaries explicit:
+  photon docs own sidecar/API contract; Anvil docs own Anvil runtime config and
+  prompt/eval log behavior.
+

--- a/dev-reports/issue-73/implementation-summary.md
+++ b/dev-reports/issue-73/implementation-summary.md
@@ -1,0 +1,44 @@
+# Implementation Summary - Issue #73
+
+## Changes
+
+Added operational documentation for the Anvil photon-action-memory integration.
+
+### New docs
+
+- `docs/photon-action-memory.md`
+  - Sidecar install and startup.
+  - Local storage defaults.
+  - API smoke checks for `/health`, `/v1/context/pack`, `/v1/evaluate`, and
+    `/v1/summary/upsert`.
+  - Focused verification commands for Anvil integration contract changes.
+
+- `docs/anvil-integration.md`
+  - Architecture and source-of-truth boundaries.
+  - Anvil env/defaults aligned with the Anvil issues.
+  - API call sequence and endpoint responsibilities.
+  - Shadow, canary, and rollback checklists.
+  - Shared fixture update procedure.
+  - Troubleshooting split between Anvil responsibility and
+    photon-action-memory responsibility.
+
+### Updated navigation
+
+- `README.md`
+  - Added Anvil operations docs links under Target Integrations.
+
+- `workspace/anvil/summary.md`
+  - Added Issue #73 operations documentation section.
+  - Recorded Anvil env/default table.
+  - Explicitly notes that photon-action-memory examples do not use port 3000.
+
+## Acceptance Criteria Mapping
+
+| Acceptance criterion | Status |
+|---|---|
+| photon-action-memory docs explain sidecar startup and API smoke | Done in `docs/photon-action-memory.md` |
+| Anvil docs and env/defaults are aligned | Done in `docs/anvil-integration.md` and `workspace/anvil/summary.md` |
+| shadow/canary/rollback checklist exists | Done in `docs/anvil-integration.md` |
+| fixture update procedure exists | Done in `docs/anvil-integration.md` |
+| troubleshooting is split by Anvil vs photon responsibility | Done in `docs/anvil-integration.md` |
+

--- a/dev-reports/issue-73/verification.md
+++ b/dev-reports/issue-73/verification.md
@@ -1,0 +1,45 @@
+# Verification - Issue #73
+
+## Commands Run
+
+```bash
+python -m pytest tests/test_sidecar_api.py tests/test_shared_fixtures.py tests/test_rollout_policy.py -q
+```
+
+Result:
+
+```text
+30 passed in 0.28s
+```
+
+```bash
+ruff format --check .
+```
+
+Result:
+
+```text
+88 files already formatted
+```
+
+```bash
+ruff check .
+```
+
+Result:
+
+```text
+All checks passed!
+```
+
+## Documentation Checks
+
+Confirmed the docs include:
+
+- `127.0.0.1:18765` sidecar URL.
+- No recommendation to use port 3000.
+- Anvil env/defaults from the issue body.
+- Shadow/canary/rollback checklists.
+- Shared fixture update procedure.
+- Anvil vs photon troubleshooting ownership.
+

--- a/docs/anvil-integration.md
+++ b/docs/anvil-integration.md
@@ -1,0 +1,201 @@
+# Anvil Integration Operations
+
+This guide describes how Anvil should operate with the
+photon-action-memory sidecar in shadow, canary, and rollback workflows.
+
+## Architecture
+
+```text
+Anvil
+  -> HTTP calls to photon-action-memory sidecar
+  -> local SQLite event and summary stores
+  -> context pack, evidence expansion, rollout metrics
+```
+
+The sidecar is local-first and fail-open. If it is unavailable, Anvil continues
+the user turn without injected memory and records enough evaluation data to
+debug the failure later.
+
+## Source Of Truth Boundaries
+
+| Area | Source of truth |
+|---|---|
+| Sidecar process, endpoint shapes, API smoke checks | `docs/photon-action-memory.md` |
+| Anvil env/defaults, prompt injection, eval log fields | Anvil repository docs |
+| Shared JSON fixtures | `tests/fixtures/shared/` in both repositories |
+| Rollout gates | `workspace/anvil/rollout_policy.md` |
+
+## Environment Defaults
+
+These values must stay aligned with the Anvil docs and defaults.
+
+| Variable | Shadow default | Purpose |
+|---|---:|---|
+| `ANVIL_PHOTON_ENABLED` | `true` | Enables Anvil calls to the sidecar. |
+| `ANVIL_PHOTON_URL` | `http://127.0.0.1:18765` | Local sidecar URL. Do not use port 3000. |
+| `ANVIL_PHOTON_SHADOW_MODE` | `true` | Build/log context packs without prompt injection. |
+| `ANVIL_PHOTON_CANARY` | `false` | Live injection stays disabled during shadow mode. |
+| `ANVIL_PHOTON_TIMEOUT_MS` | `500` | Sidecar request timeout. |
+| `ANVIL_PHOTON_MAX_MEMORY_TOKENS` | `1200` | Context pack memory budget. |
+| `ANVIL_PHOTON_MAX_EVIDENCE_CHARS` | `4000` | Evidence expansion character budget. |
+
+Shadow mode:
+
+```bash
+export ANVIL_PHOTON_ENABLED=true
+export ANVIL_PHOTON_URL=http://127.0.0.1:18765
+export ANVIL_PHOTON_SHADOW_MODE=true
+export ANVIL_PHOTON_CANARY=false
+export ANVIL_PHOTON_TIMEOUT_MS=500
+export ANVIL_PHOTON_MAX_MEMORY_TOKENS=1200
+export ANVIL_PHOTON_MAX_EVIDENCE_CHARS=4000
+```
+
+Canary mode:
+
+```bash
+export ANVIL_PHOTON_ENABLED=true
+export ANVIL_PHOTON_URL=http://127.0.0.1:18765
+export ANVIL_PHOTON_SHADOW_MODE=false
+export ANVIL_PHOTON_CANARY=true
+```
+
+## API Contract
+
+| Endpoint | Anvil call timing | Expected behavior |
+|---|---|---|
+| `GET /health` | Startup and diagnostics | Returns sidecar health. |
+| `POST /v1/summary/upsert` | After Anvil summarizes useful turn history | Stores `ActionSummary` for later retrieval. |
+| `POST /v1/context/pack` | Before prompt assembly | Returns admitted memory items and denial decisions. |
+| `POST /v1/evidence/expand` | Optional, after context pack selection | Expands selected evidence only; raw output remains denied in Anvil profile. |
+| `POST /v1/evaluate` | After every turn | Logs adoption status, outcome, and rollout signals. |
+
+Required sequence for a turn:
+
+```text
+context_pack -> optional evidence_expand -> evaluate
+```
+
+`evaluate` remains required even in shadow mode because rollout metrics depend
+on shadow adoption and fail-open data.
+
+## Shadow Mode Checklist
+
+All items must be true before collecting rollout evidence.
+
+- Sidecar health succeeds at `http://127.0.0.1:18765/health`.
+- Anvil config has `ANVIL_PHOTON_ENABLED=true`.
+- Anvil config has `ANVIL_PHOTON_SHADOW_MODE=true`.
+- Anvil config has `ANVIL_PHOTON_CANARY=false`.
+- Anvil calls `/v1/context/pack` before prompt assembly.
+- Anvil does not inject returned context into the live prompt.
+- Anvil calls `/v1/evaluate` after the turn.
+- Evaluate records use `adoption_status=shadow_not_injected`.
+- `raw_tool_tokens_in_prompt` remains `0`.
+- Shared fixture tests pass in both repositories.
+
+## Canary Checklist
+
+Move to canary only after the rollout gates pass.
+
+- `total_turns >= 10`.
+- `raw_tool_tokens_in_prompt == 0`.
+- `fail_open_incident_rate <= 0.05`.
+- The latest shared fixture tests pass in both repositories.
+- Anvil can disable canary without code changes.
+- Operators know where event and eval logs are stored.
+
+Enable canary with:
+
+```bash
+export ANVIL_PHOTON_SHADOW_MODE=false
+export ANVIL_PHOTON_CANARY=true
+```
+
+During canary, continue to call `/v1/evaluate` after every turn and monitor:
+
+- fail-open incidents
+- raw tool token leakage
+- adoption rate
+- stale or contradicted summary incidents
+- latency versus `ANVIL_PHOTON_TIMEOUT_MS`
+
+## Rollback Checklist
+
+Rollback is immediate if any of these are observed:
+
+- `raw_tool_tokens_in_prompt > 0`
+- `fail_open_incident_rate > 0.05`
+- sidecar failures repeatedly exceed the timeout budget
+- prompt injection is enabled in a session that should be shadow-only
+
+Rollback to shadow:
+
+```bash
+export ANVIL_PHOTON_CANARY=false
+export ANVIL_PHOTON_SHADOW_MODE=true
+```
+
+Disable the integration:
+
+```bash
+export ANVIL_PHOTON_ENABLED=false
+```
+
+Also check persistent Anvil config such as `.anvil/config`; environment
+variables and checked-in/local config must not disagree.
+
+## Shared Fixture Update Procedure
+
+1. Edit the fixture under `tests/fixtures/shared/` in this repository.
+2. Run photon-side fixture tests:
+   ```bash
+   python -m pytest tests/test_shared_fixtures.py tests/test_schema_v2.py -k shared -q
+   ```
+3. Copy the same file to the Anvil repository at the same relative path.
+4. Run the Anvil-side shared fixture tests.
+5. Commit both repository updates as a PR pair and mention the changed fixture
+   file in both PR descriptions.
+
+## Troubleshooting
+
+### Anvil Responsibility
+
+- Confirm `ANVIL_PHOTON_URL` is `http://127.0.0.1:18765`.
+- Confirm Anvil is not using port 3000 for photon-action-memory.
+- Confirm `ANVIL_PHOTON_TIMEOUT_MS=500` unless intentionally overridden.
+- Confirm shadow sessions set `ANVIL_PHOTON_CANARY=false`.
+- Confirm canary sessions set `ANVIL_PHOTON_SHADOW_MODE=false`.
+- Confirm Anvil writes eval records after every turn.
+- Confirm prompt logs show no raw stdout/stderr injected into the prompt.
+- Confirm `.anvil/config` does not override the environment unexpectedly.
+
+### photon-action-memory Responsibility
+
+- Confirm `/health` returns `status=ok`.
+- Confirm the event DB path from `PHOTON_ACTION_MEMORY_DB` is writable.
+- Confirm the summary DB path from `PHOTON_ACTION_MEMORY_SUMMARY_DB` is writable.
+- Confirm `/v1/context/pack` returns 200 or a fail-open response, not an
+  uncaught process failure.
+- Confirm raw stdout/stderr are denied by context-pack admission decisions.
+- Confirm `/v1/evaluate` returns `logged=1` for context pack events.
+- Confirm rollout metrics are generated from the same evaluate batch used for
+  the canary decision.
+
+## Operational Smoke
+
+Use the photon-side smoke checks before debugging Anvil behavior:
+
+```bash
+python -m uvicorn photon_action_memory.api.server:app \
+  --host 127.0.0.1 \
+  --port 18765
+```
+
+Then run the commands in `docs/photon-action-memory.md`:
+
+- `GET /health`
+- `POST /v1/context/pack`
+- `POST /v1/evaluate`
+- `POST /v1/summary/upsert`
+

--- a/docs/photon-action-memory.md
+++ b/docs/photon-action-memory.md
@@ -1,0 +1,163 @@
+# photon-action-memory Sidecar Operations
+
+This document is the photon-action-memory side of the Anvil integration. It is
+enough to start the local sidecar and run API smoke checks without opening the
+Anvil repository.
+
+## Source Of Truth
+
+- Sidecar process and API contract: this repository.
+- Anvil runtime configuration and prompt/eval log behavior: Anvil docs.
+- Shared fixture files: `tests/fixtures/shared/` in both repositories.
+
+Use `127.0.0.1:18765` for local examples. Do not use port 3000 for this
+sidecar.
+
+## Install
+
+```bash
+python -m pip install -U pip
+python -m pip install -e ".[dev]"
+```
+
+## Local Storage
+
+The sidecar stores events and summaries in SQLite. Defaults are under the
+system temp directory.
+
+| Variable | Default |
+|---|---|
+| `PHOTON_ACTION_MEMORY_DB` | `$TMPDIR/photon-action-memory/events.sqlite` |
+| `PHOTON_ACTION_MEMORY_SUMMARY_DB` | `$TMPDIR/photon-action-memory/summaries.sqlite` |
+
+For repeatable smoke checks, set explicit paths:
+
+```bash
+export PHOTON_ACTION_MEMORY_DB="$TMPDIR/photon-action-memory/events.sqlite"
+export PHOTON_ACTION_MEMORY_SUMMARY_DB="$TMPDIR/photon-action-memory/summaries.sqlite"
+```
+
+## Start The Sidecar
+
+```bash
+python -m uvicorn photon_action_memory.api.server:app \
+  --host 127.0.0.1 \
+  --port 18765
+```
+
+Expected startup state:
+
+- The process listens on `http://127.0.0.1:18765`.
+- No Anvil process is required for the photon-side smoke checks.
+- The sidecar is fail-open for integration routes; callers should keep their own
+  turn execution path independent of this process.
+
+## API Smoke Checks
+
+Run these from the repository root while the sidecar is running.
+
+### Health
+
+```bash
+curl -fsS http://127.0.0.1:18765/health
+```
+
+Expected shape:
+
+```json
+{"status":"ok","schema_version":"action-memory.v1"}
+```
+
+### Context Pack
+
+This shared fixture includes raw stdout/stderr evidence. The raw evidence must
+not be returned as prompt items.
+
+```bash
+curl -fsS \
+  -H 'content-type: application/json' \
+  -X POST \
+  --data @tests/fixtures/shared/context_pack_request_with_raw_log.json \
+  http://127.0.0.1:18765/v1/context/pack
+```
+
+Expected checks:
+
+- HTTP status is 200.
+- `sidecar_status` is `ok` or `degraded`; `fail-open` means the caller should
+  continue without injected memory and inspect sidecar logs.
+- `context_pack.items` does not include raw stdout/stderr content.
+- `admission_decisions` explain denied raw evidence.
+
+### Evaluate
+
+This logs a shadow-mode turn without prompt injection.
+
+```bash
+curl -fsS \
+  -H 'content-type: application/json' \
+  -X POST \
+  --data @tests/fixtures/shared/evaluate_shadow_not_injected.json \
+  http://127.0.0.1:18765/v1/evaluate
+```
+
+Expected checks:
+
+- `status` is `ok`.
+- `logged` is `1`.
+- The stored event has `adoption_status=shadow_not_injected`.
+
+### Summary Upsert
+
+`/v1/summary/upsert` wraps an `ActionSummary` fixture in a request envelope:
+
+```bash
+python - <<'PY'
+import json
+from pathlib import Path
+
+summary = json.loads(Path("tests/fixtures/photon/anvil_action_summary.json").read_text())
+body = {
+    "schema_version": "action-memory.v0.2",
+    "request_id": "smoke-summary-upsert-001",
+    "summary": summary,
+}
+Path("/tmp/photon-summary-upsert.json").write_text(json.dumps(body))
+PY
+
+curl -fsS \
+  -H 'content-type: application/json' \
+  -X POST \
+  --data @/tmp/photon-summary-upsert.json \
+  http://127.0.0.1:18765/v1/summary/upsert
+```
+
+Expected checks:
+
+- `status` is `stored`.
+- `summary_id` is `anvil-sum-photon-001`.
+
+## Focused Verification
+
+Use these tests when changing the Anvil integration contract:
+
+```bash
+python -m pytest \
+  tests/test_anvil_contract.py \
+  tests/test_anvil_context_pack_api.py \
+  tests/test_anvil_evaluate.py \
+  tests/test_shared_fixtures.py \
+  tests/test_rollout_policy.py \
+  -q
+```
+
+Run full CI checks before merging shared behavior:
+
+```bash
+ruff format --check .
+ruff check .
+mypy photon_action_memory tests
+pytest -q
+python -m build
+```
+

--- a/workspace/anvil/summary.md
+++ b/workspace/anvil/summary.md
@@ -184,3 +184,26 @@ Key modules:
 - `photon_action_memory/eval/metrics.py` — `RolloutMetrics`, `build_rollout_metrics()`
 - `tests/fixtures/v0.2/rollout_metrics_fixture.json` — four named gate scenarios
 - `tests/test_rollout_policy.py` — 14 tests covering all gates and rollback conditions
+
+## Operations Documentation (Issue #73)
+
+Primary docs:
+
+- `docs/photon-action-memory.md` — photon-side sidecar startup and API smoke
+  checks.
+- `docs/anvil-integration.md` — Anvil env/defaults, shadow/canary/rollback
+  checklists, fixture updates, and troubleshooting ownership.
+
+Operational defaults stay aligned with the Anvil docs:
+
+| Variable | Default |
+|---|---|
+| `ANVIL_PHOTON_ENABLED` | `true` |
+| `ANVIL_PHOTON_URL` | `http://127.0.0.1:18765` |
+| `ANVIL_PHOTON_SHADOW_MODE` | `true` |
+| `ANVIL_PHOTON_CANARY` | `false` |
+| `ANVIL_PHOTON_TIMEOUT_MS` | `500` |
+| `ANVIL_PHOTON_MAX_MEMORY_TOKENS` | `1200` |
+| `ANVIL_PHOTON_MAX_EVIDENCE_CHARS` | `4000` |
+
+Port `3000` is intentionally not used for photon-action-memory examples.


### PR DESCRIPTION
Refs #73. Summary: add photon-side sidecar/API smoke docs, Anvil integration operations docs, README links, and Anvil summary defaults/troubleshooting references. Verification: ruff format --check ., ruff check ., python -m pytest tests/test_sidecar_api.py tests/test_shared_fixtures.py tests/test_rollout_policy.py -q. Note: requested #74 is already merged PR #74, not an open issue.