### PR TITLE
#83 [v0.4.0] P0: /v1/summarize event-to-summary pipeline を実装する

### DIFF
--- a/dev-reports/issue-83/design.md
+++ b/dev-reports/issue-83/design.md
@@ -1,0 +1,113 @@
+# Design Note — Issue #83: /v1/summarize event-to-summary pipeline
+
+## Objective
+
+Wire the existing `ActionChunker` → `ActionSummaryBuilder` → `SummaryStore`
+components together behind `POST /v1/summarize`, which is currently a stub
+returning HTTP 501.
+
+After this change:
+
+- A caller can `POST /v1/events` to ingest raw events, then `POST /v1/summarize`
+  to build chunk-level `ActionSummary` records from those events and persist them
+  to the local `SummaryStore`.
+- `POST /v1/context/pack` (no `candidate_summary_ids`, repo-based search) will
+  return those summaries on the very next call.
+- Re-running `/v1/summarize` over the same event set must not produce duplicate
+  rows in `SummaryStore`.
+
+## Scope
+
+Wiring only — no behavioural changes to the underlying components. The
+deterministic ID logic already lives inside `ActionChunker` and
+`ActionSummaryBuilder`; we rely on it for idempotency.
+
+## Request / Response schemas
+
+Add two new models to `photon_action_memory/api/schema_v2.py`:
+
+```python
+class SummarizeRequest(SidecarModel):
+    schema_version: SchemaVersionV2
+    request_id: str
+    session_id: str | None = None      # filter EventStore.list_events
+    repo_id: str | None = None         # filter EventStore.list_events
+    task_signature: str | None = None  # stamped onto created summaries
+
+class SummarizeResponse(SidecarModel):
+    schema_version: SchemaVersionV2
+    request_id: str
+    status: str                        # "ok"
+    chunks_built: int = Field(default=0, ge=0)
+    summaries_upserted: int = Field(default=0, ge=0)
+    summary_ids: list[str] = Field(default_factory=list)
+```
+
+`session_id` / `repo_id` filters mirror `EventStore.list_events(...)`. When
+both are `None`, the pipeline summarises every event in the store — useful for
+tests and local exploration.
+
+`task_signature`, when provided, is stamped onto every created summary via
+`ActionSummary.task_signature` (already in the v0.2 schema). This lets later
+context-pack search by task_signature find the summaries.
+
+## Pipeline
+
+In `photon_action_memory/api/server.py` replace `summarize_stub` with:
+
+1. Read events via `event_store.list_events(session_id=..., repo_id=...)`.
+2. Pass the list through `ActionChunker().chunk(events)`.
+3. For each chunk, build a summary with `ActionSummaryBuilder().build(chunk)`.
+4. If `task_signature` was supplied, attach it to the summary via
+   `model_copy(update={"task_signature": ...})`.
+5. Run each summary through `SummaryCanonicalizer().canonicalize(...)` to keep
+   the same grounding invariants the existing upsert path enforces.
+6. `_summary_store.upsert(summary)` for each canonicalized summary.
+7. Return a `SummarizeResponse` with the list of `summary_id`s.
+
+Errors during the loop are caught and surfaced as HTTP 500 with the original
+exception text, consistent with `upsert_summary`.
+
+## Idempotency
+
+The chain `(event_ids) → chunk_id → summary_id` is deterministic:
+
+- `_deterministic_chunk_id(event_ids)` hashes sorted event IDs (chunks.py:96).
+- `_deterministic_summary_id(chunk_id)` hashes the chunk_id (summaries.py:31).
+- `SummaryStore.upsert` is keyed on `summary_id` with `ON CONFLICT ... DO UPDATE`.
+
+Therefore re-running `/v1/summarize` over the same `(session_id, turn_id)`
+events produces the same `summary_id`s and the same row count in the store.
+Verified by a focused test.
+
+## Test plan
+
+In `tests/test_sidecar_api.py`:
+
+- Replace `test_summarize_is_m2_stub` with `test_summarize_returns_ok_for_empty_store`
+  (200 + zero summaries).
+- Add `test_summarize_builds_and_persists_summary` — ingest events, summarise,
+  assert `SummaryStore.count() == chunks_built` and that the returned
+  `summary_ids` resolve in `SummaryStore.get()`.
+- Add `test_summarize_then_context_pack_returns_summary` — summarise, then call
+  `/v1/context/pack` for the same `repo_id` (no candidate IDs) and assert the
+  generated summary appears in `context_pack.items`.
+- Add `test_summarize_is_idempotent` — call `/v1/summarize` twice; assert
+  `SummaryStore.count()` does not grow on the second call.
+- Add `test_summarize_filters_by_session_id` — two sessions, only one is
+  summarised when `session_id` is set.
+
+## Non-goals
+
+- No turn-level vs session-level rollup logic; we keep `summary_level="chunk"`
+  as `ActionSummaryBuilder` already does.
+- No incremental updates via `SummaryStateUpdater`; that lives in summaries.py
+  for future M3 work and is out of scope here.
+- No new client wrapper in `api/client.py`.
+
+## Safety Notes
+
+- The endpoint reads only from local stores (event_store, summary_store) created
+  by `create_app`. No network calls, no LLM.
+- Errors are caught and returned as HTTP 500 rather than letting the FastAPI
+  default handler leak internal traces.

--- a/dev-reports/issue-83/implementation-summary.md
+++ b/dev-reports/issue-83/implementation-summary.md
@@ -1,0 +1,71 @@
+# Implementation Summary — Issue #83
+
+## What changed
+
+Replaced the `POST /v1/summarize` HTTP 501 stub with a working pipeline that
+ingests events from the local `EventStore`, runs them through the existing
+`ActionChunker` and `ActionSummaryBuilder`, canonicalizes the resulting
+summaries, and persists them to `SummaryStore`.
+
+### `photon_action_memory/api/schema_v2.py`
+
+- Added `SummarizeRequest` (`schema_version`, `request_id`, optional
+  `session_id`, `repo_id`, `task_signature`).
+- Added `SummarizeResponse` (`status`, `chunks_built`, `summaries_upserted`,
+  `summary_ids`).
+- Exported both via `__all__`.
+
+### `photon_action_memory/api/server.py`
+
+- Imported the new request/response models, plus `ActionChunker`,
+  `ActionSummaryBuilder`, and `SummaryCanonicalizer`.
+- Replaced `summarize_stub` with the `/v1/summarize` handler:
+  - Filters events by `session_id` / `repo_id` via `event_store.list_events`.
+  - Builds chunks with `ActionChunker().chunk(...)`.
+  - For each chunk: builds an `ActionSummary`, attaches `task_signature` if
+    supplied, canonicalizes it, and upserts to `SummaryStore`.
+  - Wraps the loop in `try/except` and returns HTTP 500 on failure
+    (mirrors `/v1/summary/upsert`).
+  - Returns a `SummarizeResponse` with the deterministic `summary_id` list.
+
+### `tests/test_sidecar_api.py`
+
+- Removed `test_summarize_is_m2_stub` (the 501 contract is gone).
+- Added five focused tests:
+  - `test_summarize_returns_ok_for_empty_store` — 200, zero chunks.
+  - `test_summarize_builds_and_persists_summary` — generates a summary and
+    persists it; `task_signature` is preserved.
+  - `test_summarize_then_context_pack_returns_summary` — the generated
+    `summary_id` shows up in the next `/v1/context/pack` items.
+  - `test_summarize_is_idempotent_across_repeat_calls` — re-running over the
+    same event set returns the same `summary_ids` and does not grow
+    `SummaryStore.count()`.
+  - `test_summarize_filters_by_session_id` — `session_id` filter is honored
+    end-to-end.
+
+## Acceptance Criteria checklist
+
+| Criterion | Status |
+|---|---|
+| `/v1/summarize` returns 200 for a valid request | ✅ covered by `test_summarize_returns_ok_for_empty_store` and the build/persist test |
+| Raw events → `ActionChunk` and `ActionSummary` are generated | ✅ `test_summarize_builds_and_persists_summary` |
+| Generated summary is stored in `SummaryStore` | ✅ `summary_store.count() == 1` and `summary_store.get(id)` returns the summary |
+| Following `/v1/context/pack` retrieves the saved summary | ✅ `test_summarize_then_context_pack_returns_summary` |
+| Re-running over same event set does not duplicate summaries | ✅ `test_summarize_is_idempotent_across_repeat_calls` |
+| Existing tests still pass | ✅ 798 passed, 1 skipped |
+
+## Idempotency mechanism
+
+`ActionChunker` produces a SHA-256 chunk_id from sorted event IDs, and
+`ActionSummaryBuilder` derives a SHA-256 summary_id from the chunk_id. The
+`SummaryStore.upsert` SQL uses `ON CONFLICT(summary_id) DO UPDATE`, so the same
+event set yields the same row across repeated calls.
+
+## Files touched
+
+- `photon_action_memory/api/schema_v2.py`
+- `photon_action_memory/api/server.py`
+- `tests/test_sidecar_api.py`
+- `dev-reports/issue-83/design.md` (new)
+- `dev-reports/issue-83/implementation-summary.md` (new)
+- `dev-reports/issue-83/verification.md` (new)

--- a/dev-reports/issue-83/verification.md
+++ b/dev-reports/issue-83/verification.md
@@ -1,0 +1,67 @@
+# Verification — Issue #83
+
+## Commands
+
+### Focused: /v1/summarize tests
+
+```
+$ python -m pytest tests/test_sidecar_api.py -x -q
+..........
+10 passed in 0.32s
+```
+
+The 10 tests include the 5 new `test_summarize_*` cases plus the existing
+health/events/suggest/evaluate/client tests, which all continue to pass.
+
+### Adjacent: chunks, summaries, summary store, context pack, schema v2
+
+```
+$ python -m pytest tests/test_chunks.py tests/test_summaries.py \
+    tests/test_summary_store.py tests/test_anvil_context_pack_api.py \
+    tests/test_context_pack.py tests/test_schema_v2.py -x -q
+...
+252 passed in 0.64s
+```
+
+No regressions in the modules whose contracts the new endpoint touches.
+
+### Full suite
+
+```
+$ python -m pytest -x -q
+...
+798 passed, 1 skipped in 2.53s
+```
+
+Single skip is the opt-in MLX smoke (`tests/integration/test_mlx_smoke.py`),
+unrelated to this change.
+
+### Lint
+
+```
+$ python -m ruff check photon_action_memory/api/server.py \
+    photon_action_memory/api/schema_v2.py tests/test_sidecar_api.py
+All checks passed!
+```
+
+### Type check (strict)
+
+```
+$ python -m mypy photon_action_memory
+Success: no issues found in 49 source files
+```
+
+## Acceptance criteria evidence
+
+- **200 on valid request** — see `test_summarize_returns_ok_for_empty_store`
+  and `test_summarize_builds_and_persists_summary`.
+- **Events → ActionChunk → ActionSummary** — the build/persist test asserts
+  `chunks_built == 1`, `summaries_upserted == 1`, and a non-empty
+  `actions_done` carrying the original `evt-sum-a` evidence id.
+- **Stored in SummaryStore** — `summary_store.count() == 1` and
+  `summary_store.get(summary_id)` returns the same summary.
+- **Retrievable via /v1/context/pack** — the post-summarize context pack
+  contains the freshly-generated `summary_id` in `context_pack.items`.
+- **Idempotent re-runs** — second call returns the identical `summary_ids`
+  list and does not grow `summary_store.count()`.
+- **Existing tests intact** — full suite passes (798/1 skipped).

--- a/photon_action_memory/api/schema_v2.py
+++ b/photon_action_memory/api/schema_v2.py
@@ -437,7 +437,7 @@ class SummaryValidateResponse(SidecarModel):
 
 
 # ---------------------------------------------------------------------------
-# POST /v1/summarize (Issue #82 — v0.4.0 P0 contract)
+# POST /v1/summarize (Issue #82 contract + Issue #83 pipeline)
 # ---------------------------------------------------------------------------
 
 
@@ -473,7 +473,9 @@ class SummarizeRequest(SidecarModel):
     turn_id: str | None = None
     agent: AgentInfo | None = None
     repo: RepoInfo | None = None
+    repo_id: str | None = None
     task: TaskState | None = None
+    task_signature: str | None = None
     summary_level: SummaryLevel | str = "turn"
     chunk_ids: list[str] = Field(default_factory=list)
     recent_event_ids: list[str] = Field(default_factory=list)
@@ -485,16 +487,19 @@ class SummarizeResponse(SidecarModel):
     """Response body for POST /v1/summarize.
 
     The generated ``ActionSummary`` is returned inline so callers can pipe it
-    straight into ``/v1/summary/upsert`` or ``/v1/summary/validate``. While
-    the generator is not yet implemented, ``sidecar_status="not_implemented"``
-    is returned with ``summary=None`` and a non-fatal warning so Anvil can
-    fail-open without a contract break.
+    straight into ``/v1/summary/upsert`` or ``/v1/summary/validate``. Pipeline
+    counters expose how many ActionChunks were built and how many summaries
+    were persisted for the request.
     """
 
     schema_version: SchemaVersionV2
     request_id: str
     model_version: str
     sidecar_status: str
+    status: str = "ok"
+    chunks_built: int = Field(default=0, ge=0)
+    summaries_upserted: int = Field(default=0, ge=0)
+    summary_ids: list[str] = Field(default_factory=list)
     summary: ActionSummary | None = None
     validation: SummaryValidationResult | None = None
     warnings: list[ContextPackWarning] = Field(default_factory=list)

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -43,9 +43,11 @@ from photon_action_memory.api.schema_v2 import (
 from photon_action_memory.context.pack import build_context_pack
 from photon_action_memory.context.raw_policy import RawEvidenceItem
 from photon_action_memory.eval.summary_fidelity import SummaryFidelityChecker
+from photon_action_memory.memory.chunks import ActionChunker
 from photon_action_memory.memory.evidence import EvidenceExpander
 from photon_action_memory.memory.retrieval import SummaryRetriever
 from photon_action_memory.memory.store import SQLiteEventStore
+from photon_action_memory.memory.summaries import ActionSummaryBuilder, SummaryCanonicalizer
 from photon_action_memory.memory.summary_store import SummaryStore
 from photon_action_memory.models.photon_adapter import score_suggestions_with_optional_adapter
 from photon_action_memory.ranking.fallback import build_ranked_suggestions
@@ -241,22 +243,45 @@ def create_app(
 
     @app.post("/v1/summarize", response_model=SummarizeResponse)
     def summarize(request: SummarizeRequest) -> SummarizeResponse:
+        try:
+            repo_id = request.repo_id
+            if repo_id is None and request.repo is not None:
+                repo_id = request.repo.name
+            task_signature = request.task_signature
+            if task_signature is None and request.task is not None:
+                task_signature = request.task.summary or request.task.user_request
+
+            stored_events = event_store.list_events(
+                session_id=request.session_id,
+                repo_id=repo_id,
+            )
+            chunks = ActionChunker().chunk(stored_events)
+            builder = ActionSummaryBuilder()
+            canonicalizer = SummaryCanonicalizer()
+            summaries: list[ActionSummary] = []
+            summary_ids: list[str] = []
+            for chunk in chunks:
+                summary = builder.build(chunk)
+                if task_signature is not None:
+                    summary = summary.model_copy(update={"task_signature": task_signature})
+                summary = canonicalizer.canonicalize(summary).summary
+                _summary_store.upsert(summary)
+                summaries.append(summary)
+                summary_ids.append(summary.summary_id)
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
         return SummarizeResponse(
             schema_version=DEFAULT_SCHEMA_VERSION_V2,
             request_id=request.request_id,
             model_version=FALLBACK_MODEL_VERSION,
-            sidecar_status="not_implemented",
-            summary=None,
+            sidecar_status="ok",
+            status="ok",
+            chunks_built=len(chunks),
+            summaries_upserted=len(summary_ids),
+            summary_ids=summary_ids,
+            summary=summaries[0] if summaries else None,
             validation=None,
-            warnings=[
-                ContextPackWarning(
-                    kind="not_implemented",
-                    message=(
-                        "summarize contract is fixed in v0.4.0 P0; "
-                        "generator body lands in a follow-up issue"
-                    ),
-                )
-            ],
+            warnings=[],
         )
 
     @app.post("/v1/evaluate", response_model=EvaluateResponse)

--- a/tests/test_sidecar_api.py
+++ b/tests/test_sidecar_api.py
@@ -7,8 +7,10 @@ from fastapi.testclient import TestClient
 
 from photon_action_memory import SCHEMA_VERSION
 from photon_action_memory.api.client import SidecarClient
+from photon_action_memory.api.schema_v2 import DEFAULT_SCHEMA_VERSION_V2
 from photon_action_memory.api.server import create_app
 from photon_action_memory.memory.store import SQLiteEventStore
+from photon_action_memory.memory.summary_store import SummaryStore
 
 
 def test_health_check_succeeds(tmp_path: Path) -> None:
@@ -96,6 +98,50 @@ def test_suggest_returns_no_model_fallback(tmp_path: Path) -> None:
     ]
 
 
+def _summarize_request(
+    *,
+    request_id: str,
+    session_id: str | None = None,
+    repo_id: str | None = None,
+    task_signature: str | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": request_id,
+    }
+    if session_id is not None:
+        payload["session_id"] = session_id
+    if repo_id is not None:
+        payload["repo_id"] = repo_id
+    if task_signature is not None:
+        payload["task_signature"] = task_signature
+    return payload
+
+
+def _seed_event(
+    *,
+    event_id: str,
+    session_id: str = "session-summarize-1",
+    turn_id: str = "turn-summarize-1",
+    repo_id: str = "repo-summarize-1",
+    event_type: str = "file_read",
+    summary: str = "read photon_action_memory/api/server.py",
+    outcome: str = "useful",
+) -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "event_id": event_id,
+        "event_type": event_type,
+        "session_id": session_id,
+        "turn_id": turn_id,
+        "repo_id": repo_id,
+        "timestamp": "2026-04-30T12:00:00+00:00",
+        "summary": summary,
+        "outcome": outcome,
+        "redaction_status": "clean",
+    }
+
+
 def test_summarize_empty_payload_returns_422(tmp_path: Path) -> None:
     app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
 
@@ -105,26 +151,23 @@ def test_summarize_empty_payload_returns_422(tmp_path: Path) -> None:
     assert summarize_response.status_code == 422
 
 
-def test_summarize_minimum_valid_payload_returns_not_implemented_envelope(
-    tmp_path: Path,
-) -> None:
+def test_summarize_returns_ok_for_empty_store(tmp_path: Path) -> None:
     app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
-    payload = {
-        "schema_version": "action-memory.v0.2",
-        "request_id": "summarize-001",
-    }
 
     with TestClient(app) as client:
-        response = client.post("/v1/summarize", json=payload)
+        response = client.post(
+            "/v1/summarize",
+            json=_summarize_request(request_id="sum-empty-1"),
+        )
 
     assert response.status_code == 200
-    body = response.json()
-    assert body["schema_version"] == "action-memory.v0.2"
-    assert body["request_id"] == "summarize-001"
-    assert body["sidecar_status"] == "not_implemented"
-    assert body["summary"] is None
-    assert body["validation"] is None
-    assert body["warnings"][0]["kind"] == "not_implemented"
+    data = response.json()
+    assert data["sidecar_status"] == "ok"
+    assert data["status"] == "ok"
+    assert data["chunks_built"] == 0
+    assert data["summaries_upserted"] == 0
+    assert data["summary_ids"] == []
+    assert data["summary"] is None
 
 
 def test_summarize_full_anvil_turn_payload_validates(tmp_path: Path) -> None:
@@ -152,7 +195,169 @@ def test_summarize_full_anvil_turn_payload_validates(tmp_path: Path) -> None:
     assert response.status_code == 200
     body = response.json()
     assert body["request_id"] == "summarize-turn-007"
-    assert body["sidecar_status"] == "not_implemented"
+    assert body["sidecar_status"] == "ok"
+    assert body["status"] == "ok"
+    assert body["summary_ids"] == []
+    assert body["summary"] is None
+
+
+def test_summarize_builds_and_persists_summary(tmp_path: Path) -> None:
+    event_store = SQLiteEventStore(tmp_path / "events.sqlite")
+    summary_store = SummaryStore(tmp_path / "summaries.sqlite")
+    app = create_app(event_store, summary_store)
+
+    events = [
+        _seed_event(event_id="evt-sum-a", repo_id="repo-A"),
+        _seed_event(event_id="evt-sum-b", repo_id="repo-A"),
+    ]
+    with TestClient(app) as client:
+        ingest = client.post(
+            "/v1/events",
+            json={
+                "schema_version": SCHEMA_VERSION,
+                "request_id": "req-ingest-1",
+                "events": events,
+            },
+        )
+        assert ingest.status_code == 200
+
+        response = client.post(
+            "/v1/summarize",
+            json=_summarize_request(
+                request_id="sum-build-1",
+                repo_id="repo-A",
+                task_signature="task-A",
+            ),
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["sidecar_status"] == "ok"
+    assert data["status"] == "ok"
+    assert data["chunks_built"] == 1
+    assert data["summaries_upserted"] == 1
+    assert data["summary"] is not None
+    assert summary_store.count() == 1
+    summary = summary_store.get(data["summary_ids"][0])
+    assert summary is not None
+    assert summary.repo_id == "repo-A"
+    assert summary.task_signature == "task-A"
+    assert set(summary.source_chunk_ids)  # at least one chunk recorded
+    assert any("evt-sum-a" in done.evidence_ids for done in summary.actions_done)
+
+
+def test_summarize_then_context_pack_returns_summary(tmp_path: Path) -> None:
+    event_store = SQLiteEventStore(tmp_path / "events.sqlite")
+    summary_store = SummaryStore(tmp_path / "summaries.sqlite")
+    app = create_app(event_store, summary_store)
+
+    events = [
+        _seed_event(event_id="evt-pack-a", repo_id="repo-pack"),
+        _seed_event(event_id="evt-pack-b", repo_id="repo-pack"),
+    ]
+    with TestClient(app) as client:
+        client.post(
+            "/v1/events",
+            json={
+                "schema_version": SCHEMA_VERSION,
+                "request_id": "req-pack-ingest",
+                "events": events,
+            },
+        )
+        sum_resp = client.post(
+            "/v1/summarize",
+            json=_summarize_request(request_id="sum-pack-1", repo_id="repo-pack"),
+        )
+        assert sum_resp.status_code == 200
+        new_summary_id = sum_resp.json()["summary_ids"][0]
+
+        pack_resp = client.post(
+            "/v1/context/pack",
+            json={
+                "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+                "request_id": "pack-after-summarize-1",
+                "agent": {"name": "codex"},
+                "repo": {"root": str(tmp_path), "name": "repo-pack"},
+                "task": {
+                    "user_request": "inspect server",
+                    "mode": "act",
+                    "summary": "inspect",
+                },
+                "working_memory": {"touched_files": []},
+                "recent_event_ids": [],
+                "candidate_summary_ids": [],
+                "budget": {"max_memory_tokens": 800, "max_evidence_chars": 1200},
+            },
+        )
+
+    assert pack_resp.status_code == 200
+    data = pack_resp.json()
+    item_ids = {item["id"] for item in data["context_pack"]["items"]}
+    assert new_summary_id in item_ids
+
+
+def test_summarize_is_idempotent_across_repeat_calls(tmp_path: Path) -> None:
+    event_store = SQLiteEventStore(tmp_path / "events.sqlite")
+    summary_store = SummaryStore(tmp_path / "summaries.sqlite")
+    app = create_app(event_store, summary_store)
+
+    events = [
+        _seed_event(event_id="evt-idem-a"),
+        _seed_event(event_id="evt-idem-b"),
+    ]
+    with TestClient(app) as client:
+        client.post(
+            "/v1/events",
+            json={
+                "schema_version": SCHEMA_VERSION,
+                "request_id": "req-idem-ingest",
+                "events": events,
+            },
+        )
+        first = client.post(
+            "/v1/summarize",
+            json=_summarize_request(request_id="sum-idem-1"),
+        )
+        second = client.post(
+            "/v1/summarize",
+            json=_summarize_request(request_id="sum-idem-2"),
+        )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["summary_ids"] == second.json()["summary_ids"]
+    assert summary_store.count() == first.json()["summaries_upserted"]
+
+
+def test_summarize_filters_by_session_id(tmp_path: Path) -> None:
+    event_store = SQLiteEventStore(tmp_path / "events.sqlite")
+    summary_store = SummaryStore(tmp_path / "summaries.sqlite")
+    app = create_app(event_store, summary_store)
+
+    events = [
+        _seed_event(event_id="evt-sess-a", session_id="sess-A", turn_id="turn-A"),
+        _seed_event(event_id="evt-sess-b", session_id="sess-B", turn_id="turn-B"),
+    ]
+    with TestClient(app) as client:
+        client.post(
+            "/v1/events",
+            json={
+                "schema_version": SCHEMA_VERSION,
+                "request_id": "req-sess-ingest",
+                "events": events,
+            },
+        )
+        response = client.post(
+            "/v1/summarize",
+            json=_summarize_request(request_id="sum-sess-1", session_id="sess-A"),
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["summaries_upserted"] == 1
+    only_summary = summary_store.get(data["summary_ids"][0])
+    assert only_summary is not None
+    assert only_summary.session_id == "sess-A"
 
 
 def test_evaluate_returns_ok_for_valid_request(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #83

## Summary

- 既存実装には `ActionChunker`、`ActionSummaryBuilder`、`SummaryStateUpdater`、`SummaryStore` があるが、API 経由で接続されていない。

## Changed Files

- `photon_action_memory/memory/chunks.py`
- `photon_action_memory/memory/summaries.py`
- `photon_action_memory/memory/summary_store.py`
- `tests/test_chunks.py`
- `tests/test_summaries.py`

## Tests Run

- 未実行

## Known Risks

- None recorded by orchestration planner.

## Orchestration

- Run ID: `20260513-102053-orchestrate`
