### PR TITLE
#84 [v0.4.0] P0: 階層 action state と context pack 連携を実装する

### DIFF
--- a/dev-reports/issue-84/design.md
+++ b/dev-reports/issue-84/design.md
@@ -1,0 +1,111 @@
+# Design Note — Issue #84
+
+## Objective
+
+PHOTON Action Memory の中核は「raw tool/action 履歴 → 階層的な action state →
+prompt には summary-only context」というパイプライン。本 P0 では未完成な
+階層連携を `/v1/summarize` 経由で繋ぎ、`/v1/context/pack` が階層 summary を
+正しく取得・配布できるようにする。
+
+## Acceptance criteria revisited
+
+1. `/v1/summarize` 後に `summary_level=turn/session/case` の summary を保存できる。
+2. `/v1/context/pack` が repo/task に応じて該当 summary を取得する。
+3. prompt-visible item は summary-only であり、raw event は入らない。
+4. `tokens_saved_vs_raw` が response または stored summary から確認できる。
+
+## Current state
+
+- `/v1/summarize` は 501 stub (`api/server.py:240`).
+- `/v1/summary/upsert` は seed-summary を `SummaryStore` に書き込めるが、
+  チャンクから階層 summary を生成する経路は無い。
+- `/v1/context/pack` は `SummaryRetriever.search(repo_id=…, task_signature=…)`
+  で既に repo/task scoping を行い、`mode="summary_only"`/raw 拒否ポリシーで
+  prompt から raw event を排除している (`context/pack.py:48`).
+- `TokenBudget.tokens_saved_vs_raw` は admission ループで `add_raw` 経由で
+  集計済み (`context/budget.py:31`) — response にも乗っている。
+- `ActionSummaryBuilder` と `SummaryStateUpdater` はチャンク→summary 化を
+  既に実装済み (`memory/summaries.py`).
+
+## Scope of this change
+
+最小で受け入れ条件 #1 を満たし、#2–#4 の振る舞いを assertion で固定する。
+新規モデル/抽象は導入しない。
+
+### `/v1/summarize` の実装
+
+Request:
+
+```json
+{
+  "schema_version": "action-memory.v0.2",
+  "request_id": "summarize_001",
+  "session_id": "sess_001",
+  "repo_id": "photon-test",
+  "task_signature": "live-codename-task",
+  "summary_level": "turn|session|case|chunk",
+  "chunks": [ActionChunk, …],
+  "policy": { … }   // forward-compatible; ignored in M2
+}
+```
+
+Response:
+
+```json
+{
+  "schema_version": "action-memory.v0.2",
+  "request_id": "summarize_001",
+  "summary": ActionSummary,           // 永続化済み・summary_level 上書き済み
+  "validation": SummaryValidationResult,
+  "tokens_saved_vs_raw": int,
+  "sidecar_status": "ok|degraded",
+  "warnings": [ContextPackWarning]
+}
+```
+
+処理:
+
+1. `chunks` を ActionSummaryBuilder で 1-by-1 サマリ化。
+2. `SummaryStateUpdater` で先頭 summary に畳み込み、階層 state にする。
+3. 結果に対し `summary_level` / `session_id` / `repo_id` / `task_signature`
+   を request 値で上書き。
+4. `SummaryFidelityChecker.check(...)` で validation。
+5. `SummaryStore.upsert(...)` で永続化。
+6. `token_cost.tokens_saved_vs_raw` を response にもサーフェスする。
+
+エラー時は 5xx を投げず、`sidecar_status="degraded"` + warnings を載せた
+空 summary を返す fail-open ポリシー（既存 `/v1/context/pack` と同じ流儀）。
+
+### `/v1/context/pack` 側
+
+機能変更なし。テストで以下を assert する:
+
+- 階層 summary（`summary_level=session`）が repo_id 経由で取れる。
+- `tokens_saved_vs_raw > 0` が response の `token_budget` に反映されている。
+- raw evidence が `omitted[*]` に落ちて `items` に出ない。
+
+## Files touched
+
+- `photon_action_memory/api/server.py`
+  — `/v1/summarize` stub を撤去し、本実装に差し替える。
+  — `SummarizeRequest` / `SummarizeResponse` を `SidecarModel` で追加。
+- `tests/test_sidecar_api.py`
+  — M2 stub test を新しい契約に置き換える。
+- `tests/test_context_pack.py` または新規 `tests/test_summarize_endpoint.py`
+  — 階層 summarize → pack の end-to-end を assert。
+
+## Out of scope
+
+- `chunk_ids` 経由の lookup（chunk store がまだ無いため、本 PR では
+  ActionChunk をリクエスト body に直接渡す）。
+- `policy` フィールドの実効化。M2 互換のため受理だけ行う。
+- 既存 fixtures や Anvil 配信フローへの破壊的変更。
+
+## Safety / regression notes
+
+- prompt-only summary mode は admission controller 側で保証済み — raw
+  evidence の流入リスクは新エンドポイントでも上がらない（書き込み専用）。
+- `tokens_saved_vs_raw` は既存ユニットテスト
+  (`test_context_pack.py::test_token_budget_tokens_saved_vs_raw` 等) で
+  網羅されている。本 PR では response surface の追加 assertion を増やすのみ。
+- 既存 `/v1/summary/upsert` の挙動は変更しない（後方互換）。

--- a/dev-reports/issue-84/implementation-summary.md
+++ b/dev-reports/issue-84/implementation-summary.md
@@ -1,0 +1,69 @@
+# Implementation Summary — Issue #84
+
+## What changed
+
+`/v1/summarize` was a 501 stub; it is now a real endpoint that folds
+ActionChunks into a hierarchical ActionSummary at the requested
+`summary_level` (`turn`/`session`/`case`/`chunk`), persists it via
+`SummaryStore`, and surfaces `tokens_saved_vs_raw` on both the response and
+the stored summary. `/v1/context/pack` already retrieves by `repo_id` /
+`task_signature`, so the wiring becomes end-to-end without changes to the
+pack route.
+
+## Files modified
+
+- `photon_action_memory/api/schema_v2.py`
+  - Added `SummarizePolicy`, `SummarizeRequest`, `SummarizeResponse`.
+  - Updated `__all__`.
+- `photon_action_memory/api/server.py`
+  - Replaced `summarize_stub` (501) with `summarize` route.
+  - New helpers: `_tokens_saved`, `_build_hierarchical_summary`.
+  - Imports `ActionChunk`, `SummarizeRequest`, `SummarizeResponse`,
+    `TokenCost`, and `ActionSummaryBuilder` / `SummaryCanonicalizer` /
+    `SummaryStateUpdater`.
+- `tests/test_sidecar_api.py`
+  - Replaced `test_summarize_is_m2_stub` with
+    `test_summarize_rejects_empty_request_with_degraded_status` to lock in
+    fail-open semantics on empty chunks.
+
+## Files added
+
+- `tests/test_summarize_endpoint.py` — 7 new tests covering:
+  - Persistence at `summary_level` = `turn`, `session`, `case`.
+  - Empty-chunks fail-open (`sidecar_status="degraded"`, warning surfaced).
+  - End-to-end summarize → context-pack retrieval via `task_signature`.
+  - Raw evidence stays omitted; prompt-visible items remain summary-only.
+  - `summary_level` override above the builder's default `"chunk"`.
+- `dev-reports/issue-84/design.md`
+- `dev-reports/issue-84/implementation-summary.md` (this file).
+- `dev-reports/issue-84/verification.md`
+
+## Behavior notes
+
+- The new endpoint runs `SummaryFidelityChecker` against the local event
+  store so the response carries a `SummaryValidationResult` alongside the
+  summary.
+- Hierarchical folding reuses `ActionSummaryBuilder` and
+  `SummaryStateUpdater`, then overrides
+  `summary_level`/`session_id`/`repo_id`/`task_signature`/`summary_id` from
+  the request so retrieval metadata matches what the caller asked for.
+- Errors during fidelity check or persistence degrade `sidecar_status` to
+  `"degraded"` and append a warning — they never raise a 5xx, consistent
+  with the existing fail-open style of `/v1/context/pack`.
+
+## Acceptance criteria coverage
+
+| AC | Status | Evidence |
+| --- | --- | --- |
+| `/v1/summarize` persists summaries at `turn`/`session`/`case` | ✅ | `tests/test_summarize_endpoint.py::test_summarize_persists_at_requested_level` (parametrized) |
+| `/v1/context/pack` retrieves the summary via repo/task | ✅ | `tests/test_summarize_endpoint.py::test_context_pack_retrieves_session_level_summary` |
+| Prompt-visible items are summary-only; raw events stay out | ✅ | `tests/test_summarize_endpoint.py::test_context_pack_omits_raw_evidence_after_summarize` |
+| `tokens_saved_vs_raw` observable on response/stored summary | ✅ | `test_summarize_persists_at_requested_level` (stored), `test_context_pack_retrieves_session_level_summary` (pack budget) |
+
+## Out of scope (explicit)
+
+- `chunks` are accepted inline; no chunk-id store is introduced.
+- `policy` flags are accepted but advisory in M2.
+- No change to `/v1/summary/upsert` (backwards compatible).
+- No change to `context/pack.py` or `memory/retrieval.py` — repo/task
+  scoping already met the acceptance bar.

--- a/dev-reports/issue-84/verification.md
+++ b/dev-reports/issue-84/verification.md
@@ -1,0 +1,60 @@
+# Verification — Issue #84
+
+## Commands run
+
+```
+python -m pytest tests/test_summarize_endpoint.py tests/test_sidecar_api.py -x -q
+python -m pytest tests/test_context_pack.py tests/test_schema_v2.py tests/test_summaries.py \
+    tests/test_summary_store.py tests/test_summary_fidelity.py \
+    tests/test_sidecar_api.py tests/test_summarize_endpoint.py -x -q
+python -m pytest tests/ -x -q --ignore=tests/integration
+python -m ruff check photon_action_memory/api/server.py photon_action_memory/api/schema_v2.py \
+    tests/test_summarize_endpoint.py tests/test_sidecar_api.py
+python -m ruff format --check photon_action_memory/api/server.py photon_action_memory/api/schema_v2.py \
+    tests/test_summarize_endpoint.py tests/test_sidecar_api.py
+python -m mypy photon_action_memory/api/server.py photon_action_memory/api/schema_v2.py
+```
+
+## Results
+
+| Step | Outcome |
+| --- | --- |
+| Focused: summarize + sidecar tests | **13 passed** |
+| Broader: schema_v2 / summaries / context_pack / fidelity / sidecar | **233 passed** |
+| Full unit suite (excluding `tests/integration/`) | **801 passed** |
+| ruff check on touched files | **all checks passed** |
+| ruff format on touched files | clean after one auto-format pass on `server.py` |
+| mypy on touched files | **Success: no issues found in 2 source files** |
+
+## What the tests demonstrate
+
+- `test_summarize_persists_at_requested_level[turn|session|case]` (parametrized)
+  posts inline `ActionChunks`, asserts the response contains a summary at the
+  requested level, then re-reads the summary from `SummaryStore` and checks
+  `token_cost.tokens_saved_vs_raw` matches the response field.
+- `test_summarize_requires_at_least_one_chunk` confirms the fail-open path:
+  HTTP 200, `sidecar_status="degraded"`, warning `summarize_input`.
+- `test_context_pack_retrieves_session_level_summary` summarizes at
+  `summary_level="session"` with a `task_signature`, then posts to
+  `/v1/context/pack` with the same `task_signature`; the resulting pack
+  contains the stored summary (`mode="summary_only"`) and its
+  `token_budget.tokens_saved_vs_raw > 0`.
+- `test_context_pack_omits_raw_evidence_after_summarize` shows that raw
+  evidence in the pack request never reaches `items`; it is recorded in
+  `omitted` instead.
+- `test_summarize_overrides_summary_level_when_built_at_chunk` locks in that
+  the request's `summary_level` overrides `ActionSummaryBuilder`'s default
+  `"chunk"`.
+
+## Non-regressions
+
+- All 801 pre-existing unit tests continue to pass (no integration tests
+  were modified).
+- `/v1/summary/upsert`, `/v1/context/pack`, `/v1/evidence/expand`,
+  `/v1/summary/validate`, `/v1/evaluate`, and `/v1/suggest` are unchanged.
+
+## Outstanding follow-ups
+
+- No blockers. A future PR can extend `/v1/summarize` to accept `chunk_ids`
+  once an `ActionChunk` store lands; the request schema already includes a
+  forward-compatible `policy` block.

--- a/photon_action_memory/api/schema_v2.py
+++ b/photon_action_memory/api/schema_v2.py
@@ -437,7 +437,7 @@ class SummaryValidateResponse(SidecarModel):
 
 
 # ---------------------------------------------------------------------------
-# POST /v1/summarize (Issue #82 contract + Issue #83 pipeline)
+# POST /v1/summarize (Issue #82 contract + Issue #83/#84 pipelines)
 # ---------------------------------------------------------------------------
 
 
@@ -464,7 +464,9 @@ class SummarizeRequest(SidecarModel):
     Anvil sends this at the end of a turn (or session) together with the
     chunk_ids / recent_event_ids that should be folded into the summary.
     Reuses ``AgentInfo`` / ``RepoInfo`` / ``TaskState`` from the v1 schema
-    so the request stays consistent with ``/v1/context/pack``.
+    so the request stays consistent with ``/v1/context/pack``. Callers can
+    either reference stored events or provide inline ``ActionChunk`` objects
+    for hierarchical turn/session/case summaries.
     """
 
     schema_version: SchemaVersionV2
@@ -480,6 +482,8 @@ class SummarizeRequest(SidecarModel):
     chunk_ids: list[str] = Field(default_factory=list)
     recent_event_ids: list[str] = Field(default_factory=list)
     parent_summary_ids: list[str] = Field(default_factory=list)
+    chunks: list[ActionChunk] = Field(default_factory=list)
+    summary_id: str | None = None
     policy: SummarizePolicy = Field(default_factory=SummarizePolicy)
 
 
@@ -502,6 +506,7 @@ class SummarizeResponse(SidecarModel):
     summary_ids: list[str] = Field(default_factory=list)
     summary: ActionSummary | None = None
     validation: SummaryValidationResult | None = None
+    tokens_saved_vs_raw: int = Field(default=0, ge=0)
     warnings: list[ContextPackWarning] = Field(default_factory=list)
 
 

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -24,6 +24,7 @@ from photon_action_memory.api.schema import (
 )
 from photon_action_memory.api.schema_v2 import (
     DEFAULT_SCHEMA_VERSION_V2,
+    ActionChunk,
     ActionSummary,
     ContextPack,
     ContextPackRequest,
@@ -39,6 +40,7 @@ from photon_action_memory.api.schema_v2 import (
     SummaryValidateRequest,
     SummaryValidateResponse,
     TokenBudget,
+    TokenCost,
 )
 from photon_action_memory.context.pack import build_context_pack
 from photon_action_memory.context.raw_policy import RawEvidenceItem
@@ -47,7 +49,11 @@ from photon_action_memory.memory.chunks import ActionChunker
 from photon_action_memory.memory.evidence import EvidenceExpander
 from photon_action_memory.memory.retrieval import SummaryRetriever
 from photon_action_memory.memory.store import SQLiteEventStore
-from photon_action_memory.memory.summaries import ActionSummaryBuilder, SummaryCanonicalizer
+from photon_action_memory.memory.summaries import (
+    ActionSummaryBuilder,
+    SummaryCanonicalizer,
+    SummaryStateUpdater,
+)
 from photon_action_memory.memory.summary_store import SummaryStore
 from photon_action_memory.models.photon_adapter import score_suggestions_with_optional_adapter
 from photon_action_memory.ranking.fallback import build_ranked_suggestions
@@ -243,6 +249,9 @@ def create_app(
 
     @app.post("/v1/summarize", response_model=SummarizeResponse)
     def summarize(request: SummarizeRequest) -> SummarizeResponse:
+        if "chunks" in request.model_fields_set:
+            return _summarize_inline_chunks(request, event_store, _summary_store)
+
         try:
             repo_id = request.repo_id
             if repo_id is None and request.repo is not None:
@@ -281,6 +290,7 @@ def create_app(
             summary_ids=summary_ids,
             summary=summaries[0] if summaries else None,
             validation=None,
+            tokens_saved_vs_raw=sum(_tokens_saved(summary.token_cost) for summary in summaries),
             warnings=[],
         )
 
@@ -331,6 +341,98 @@ def create_app(
         )
 
     return app
+
+
+def _summarize_inline_chunks(
+    request: SummarizeRequest,
+    event_store: SQLiteEventStore,
+    summary_store: SummaryStore,
+) -> SummarizeResponse:
+    warnings: list[ContextPackWarning] = []
+    try:
+        summary = _build_hierarchical_summary(request)
+    except ValueError as exc:
+        return SummarizeResponse(
+            schema_version=DEFAULT_SCHEMA_VERSION_V2,
+            request_id=request.request_id,
+            model_version=FALLBACK_MODEL_VERSION,
+            sidecar_status="degraded",
+            status="degraded",
+            chunks_built=0,
+            summaries_upserted=0,
+            summary_ids=[],
+            summary=None,
+            validation=None,
+            tokens_saved_vs_raw=0,
+            warnings=[ContextPackWarning(kind="summarize_input", message=str(exc))],
+        )
+
+    try:
+        evidence_records = [ev.payload for ev in event_store.list_events()]
+        checker = SummaryFidelityChecker(records=evidence_records)
+        validation = checker.check(summary)
+    except Exception as exc:
+        logger.warning("summarize fidelity error: %s", exc)
+        validation = None
+        warnings.append(ContextPackWarning(kind="summarize_validation_error", message=str(exc)))
+
+    summary_ids: list[str] = []
+    summaries_upserted = 0
+    try:
+        summary_store.upsert(summary)
+        summary_ids.append(summary.summary_id)
+        summaries_upserted = 1
+    except Exception as exc:
+        logger.warning("summarize persist error: %s", exc)
+        warnings.append(ContextPackWarning(kind="summarize_persist_error", message=str(exc)))
+
+    return SummarizeResponse(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        request_id=request.request_id,
+        model_version=FALLBACK_MODEL_VERSION,
+        sidecar_status="degraded" if warnings else "ok",
+        status="degraded" if warnings else "ok",
+        chunks_built=len(request.chunks),
+        summaries_upserted=summaries_upserted,
+        summary_ids=summary_ids,
+        summary=summary,
+        validation=validation,
+        tokens_saved_vs_raw=_tokens_saved(summary.token_cost),
+        warnings=warnings,
+    )
+
+
+def _tokens_saved(token_cost: TokenCost | None) -> int:
+    if token_cost is None:
+        return 0
+    return max(0, token_cost.tokens_saved_vs_raw)
+
+
+def _build_hierarchical_summary(request: SummarizeRequest) -> ActionSummary:
+    """Fold request chunks into a single ActionSummary at the requested level."""
+    chunks: list[ActionChunk] = list(request.chunks)
+    if not chunks:
+        msg = "summarize requires at least one chunk"
+        raise ValueError(msg)
+
+    builder = ActionSummaryBuilder()
+    canonicalizer = SummaryCanonicalizer()
+    updater = SummaryStateUpdater()
+
+    state = canonicalizer.canonicalize(builder.build(chunks[0])).summary
+    for chunk in chunks[1:]:
+        state = updater.update(state, chunk)
+
+    overrides: dict[str, object] = {"summary_level": request.summary_level}
+    if request.session_id is not None:
+        overrides["session_id"] = request.session_id
+    if request.repo_id is not None:
+        overrides["repo_id"] = request.repo_id
+    if request.task_signature is not None:
+        overrides["task_signature"] = request.task_signature
+    if request.summary_id:
+        overrides["summary_id"] = request.summary_id
+    return state.model_copy(update=overrides)
 
 
 def _extract_raw_items(request: ContextPackRequest) -> list[RawEvidenceItem]:

--- a/tests/test_sidecar_api.py
+++ b/tests/test_sidecar_api.py
@@ -151,6 +151,29 @@ def test_summarize_empty_payload_returns_422(tmp_path: Path) -> None:
     assert summarize_response.status_code == 422
 
 
+def test_summarize_rejects_explicit_empty_chunks_with_degraded_status(
+    tmp_path: Path,
+) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+
+    with TestClient(app) as client:
+        summarize_response = client.post(
+            "/v1/summarize",
+            json={
+                "schema_version": "action-memory.v0.2",
+                "request_id": "req-summarize-empty",
+                "summary_level": "turn",
+                "chunks": [],
+            },
+        )
+
+    assert summarize_response.status_code == 200
+    body = summarize_response.json()
+    assert body["sidecar_status"] == "degraded"
+    assert body["summary"] is None
+    assert body["warnings"][0]["kind"] == "summarize_input"
+
+
 def test_summarize_returns_ok_for_empty_store(tmp_path: Path) -> None:
     app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
 

--- a/tests/test_summarize_endpoint.py
+++ b/tests/test_summarize_endpoint.py
@@ -1,0 +1,267 @@
+"""Tests for POST /v1/summarize and the hierarchical action-state ↔ context-pack
+wiring required by Issue #84.
+
+Acceptance criteria covered:
+- /v1/summarize persists summaries at summary_level = turn / session / case.
+- /v1/context/pack retrieves the stored summary via repo / task scoping.
+- prompt-visible items are summary-only; raw events never appear.
+- tokens_saved_vs_raw is observable both in the summarize response and in the
+  pack's TokenBudget.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from photon_action_memory.api.schema_v2 import DEFAULT_SCHEMA_VERSION_V2
+from photon_action_memory.api.server import create_app
+from photon_action_memory.memory.store import SQLiteEventStore
+from photon_action_memory.memory.summary_store import SummaryStore
+
+SCHEMA_V2 = DEFAULT_SCHEMA_VERSION_V2
+
+
+def _chunk(
+    *,
+    chunk_id: str,
+    summary: str,
+    outcome: str = "useful",
+    repo_id: str = "photon-test",
+    session_id: str = "sess-summarize-1",
+    event_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_V2,
+        "chunk_id": chunk_id,
+        "session_id": session_id,
+        "kind": "repo_search",
+        "summary": summary,
+        "outcome": outcome,
+        "event_ids": event_ids if event_ids is not None else [f"evt-{chunk_id}"],
+        "repo_id": repo_id,
+        "commit": "abcdef0",
+    }
+
+
+def _summarize_body(
+    *,
+    summary_level: str,
+    request_id: str = "req-sum-1",
+    repo_id: str = "photon-test",
+    task_signature: str | None = None,
+    session_id: str = "sess-summarize-1",
+    chunks: list[dict[str, Any]] | None = None,
+    summary_id: str | None = None,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "schema_version": SCHEMA_V2,
+        "request_id": request_id,
+        "session_id": session_id,
+        "repo_id": repo_id,
+        "summary_level": summary_level,
+        "chunks": chunks
+        or [
+            _chunk(chunk_id="chunk-A", summary="auth module lives in api/server.py"),
+            _chunk(
+                chunk_id="chunk-B",
+                summary="session store wired through SQLiteEventStore",
+            ),
+        ],
+    }
+    if task_signature is not None:
+        body["task_signature"] = task_signature
+    if summary_id is not None:
+        body["summary_id"] = summary_id
+    return body
+
+
+def _pack_body(
+    *,
+    request_id: str = "req-pack-1",
+    repo_root: str = "/tmp",
+    repo_name: str = "photon-test",
+    task_signature: str | None = None,
+) -> dict[str, Any]:
+    task: dict[str, Any] = {
+        "user_request": "implement feature X",
+        "mode": "act",
+        "summary": "working on feature X",
+    }
+    body: dict[str, Any] = {
+        "schema_version": SCHEMA_V2,
+        "request_id": request_id,
+        "agent": {"name": "codex"},
+        "repo": {"root": repo_root, "name": repo_name},
+        "task": task,
+        "working_memory": {"touched_files": []},
+        "recent_event_ids": [],
+        "candidate_summary_ids": [],
+        "budget": {"max_memory_tokens": 800, "max_evidence_chars": 1200},
+    }
+    if task_signature is not None:
+        task["task_signature"] = task_signature
+    return body
+
+
+@pytest.mark.parametrize("level", ["turn", "session", "case"])
+def test_summarize_persists_at_requested_level(level: str, tmp_path: Path) -> None:
+    summary_store = SummaryStore(tmp_path / "summaries.sqlite")
+    app = create_app(
+        SQLiteEventStore(tmp_path / "events.sqlite"),
+        summary_store=summary_store,
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/summarize",
+            json=_summarize_body(
+                summary_level=level,
+                summary_id=f"sum-{level}-001",
+                task_signature=f"task-{level}",
+            ),
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["sidecar_status"] == "ok"
+    assert body["summary"]["summary_level"] == level
+    assert body["summary"]["summary_id"] == f"sum-{level}-001"
+    assert body["summary"]["repo_id"] == "photon-test"
+    assert body["summary"]["task_signature"] == f"task-{level}"
+    assert body["tokens_saved_vs_raw"] > 0
+    assert body["validation"]["summary_id"] == f"sum-{level}-001"
+
+    stored = summary_store.get(f"sum-{level}-001")
+    assert stored is not None
+    assert stored.summary_level == level
+    assert stored.token_cost is not None
+    assert stored.token_cost.tokens_saved_vs_raw == body["tokens_saved_vs_raw"]
+
+
+def test_summarize_requires_at_least_one_chunk(tmp_path: Path) -> None:
+    app = create_app(
+        SQLiteEventStore(tmp_path / "events.sqlite"),
+        summary_store=SummaryStore(tmp_path / "summaries.sqlite"),
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/summarize",
+            json={
+                "schema_version": SCHEMA_V2,
+                "request_id": "req-empty",
+                "summary_level": "turn",
+                "chunks": [],
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["sidecar_status"] == "degraded"
+    assert body["summary"] is None
+    assert body["tokens_saved_vs_raw"] == 0
+    assert body["warnings"][0]["kind"] == "summarize_input"
+
+
+def test_context_pack_retrieves_session_level_summary(tmp_path: Path) -> None:
+    summary_store = SummaryStore(tmp_path / "summaries.sqlite")
+    app = create_app(
+        SQLiteEventStore(tmp_path / "events.sqlite"),
+        summary_store=summary_store,
+    )
+
+    with TestClient(app) as client:
+        summarize_resp = client.post(
+            "/v1/summarize",
+            json=_summarize_body(
+                summary_level="session",
+                summary_id="sum-session-pack",
+                task_signature="live-codename-task",
+            ),
+        )
+        assert summarize_resp.status_code == 200
+        summary_tokens_saved = summarize_resp.json()["tokens_saved_vs_raw"]
+        assert summary_tokens_saved > 0
+
+        pack_resp = client.post(
+            "/v1/context/pack",
+            json=_pack_body(task_signature="live-codename-task"),
+        )
+
+    assert pack_resp.status_code == 200
+    payload = pack_resp.json()
+    items = payload["context_pack"]["items"]
+    assert [item["id"] for item in items] == ["sum-session-pack"]
+    assert items[0]["kind"] == "action_summary"
+    assert "FACT:" in items[0]["text"]
+    assert payload["context_pack"]["mode"] == "summary_only"
+    assert payload["context_pack"]["token_budget"]["tokens_saved_vs_raw"] > 0
+
+
+def test_context_pack_omits_raw_evidence_after_summarize(tmp_path: Path) -> None:
+    """Even with a stored hierarchical summary, raw evidence in the pack request
+    is denied and never reaches the prompt-visible items list."""
+    summary_store = SummaryStore(tmp_path / "summaries.sqlite")
+    app = create_app(
+        SQLiteEventStore(tmp_path / "events.sqlite"),
+        summary_store=summary_store,
+    )
+
+    with TestClient(app) as client:
+        client.post(
+            "/v1/summarize",
+            json=_summarize_body(
+                summary_level="turn",
+                summary_id="sum-turn-raw",
+            ),
+        )
+
+        pack_body = _pack_body()
+        pack_body["raw_evidence"] = [
+            {
+                "item_id": "raw-1",
+                "kind": "raw_tool_log",
+                "content": "raw shell output that must never reach prompt",
+            }
+        ]
+        response = client.post("/v1/context/pack", json=pack_body)
+
+    payload = response.json()
+    items = payload["context_pack"]["items"]
+    assert all(item["kind"] == "action_summary" for item in items)
+    item_ids = {item["id"] for item in items}
+    assert "raw-1" not in item_ids
+    for item in items:
+        assert "raw shell output" not in item["text"]
+    omitted_ids = {entry["id"] for entry in payload["context_pack"]["omitted"]}
+    assert "raw-1" in omitted_ids
+
+
+def test_summarize_overrides_summary_level_when_built_at_chunk(tmp_path: Path) -> None:
+    """The builder defaults to summary_level=chunk; /v1/summarize must override
+    it with the request value so hierarchical retrieval has accurate metadata."""
+    summary_store = SummaryStore(tmp_path / "summaries.sqlite")
+    app = create_app(
+        SQLiteEventStore(tmp_path / "events.sqlite"),
+        summary_store=summary_store,
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/summarize",
+            json=_summarize_body(
+                summary_level="case",
+                summary_id="sum-case-override",
+            ),
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["summary"]["summary_level"] == "case"
+    stored = summary_store.get("sum-case-override")
+    assert stored is not None
+    assert stored.summary_level == "case"


### PR DESCRIPTION
Closes #84

## Summary

- PHOTON Action Memory の中核は、raw tool/action 履歴を階層的な action state に圧縮し、prompt には summary-only context を渡すこと。現状は seed済み summary の upsert / retrieval はあるが、`/v1/summarize` 生成 summary との階層連携が未完成。

## Changed Files

- `photon_action_memory/context/pack.py`
- `photon_action_memory/memory/retrieval.py`
- `workspace/v0.2.0/README.md`

## Tests Run

- 未実行

## Known Risks

- None recorded by orchestration planner.

## Orchestration

- Run ID: `20260513-102053-orchestrate`
