### PR TITLE
#86 [v0.4.0] P1: summarize で evidence grounding と raw-output firewall を強制する

### DIFF
--- a/dev-reports/issue-86/design.md
+++ b/dev-reports/issue-86/design.md
@@ -1,0 +1,94 @@
+# Design Note — Issue #86: v0.4.0 P1 — `/v1/summarize` evidence grounding + raw firewall
+
+## Objective
+
+Action Context Firewall として、prompt-visible memory は evidence-grounded summary だけに限定する。`/v1/summarize` は agent から raw tool / action 履歴を含む候補 ActionSummary を受け取るため、その出口で raw stdout/stderr/secret が prompt-visible なフィールド (`facts[*].text` 等) に混入しないことを保証する必要がある。
+
+## Scope
+
+このイシューでカバーする変更:
+
+- `/v1/summarize` (現状 501 stub) を **summary firewall** エンドポイントとして実装する。
+- raw 出力検出を `SummaryFidelityChecker` に追加し、`/v1/summary/validate` でも同じシグナルを得られるようにする。
+- `/v1/summarize` レスポンスに `validation_results`, `admission_decisions`, `omitted`, `evidence_ids_referenced` を含めて `/v1/evidence/expand` と連携可能にする。
+- 既存 `/v1/context/pack` の raw policy 実装 (`evaluate_raw_item`, `has_sensitive_content`) を再利用し、二重実装を避ける。
+
+スコープ外:
+
+- LLM を呼び出して draft summary を生成する処理。`/v1/summarize` はあくまで agent が組み立てた draft の **firewall + validation** に専念する。
+- summary store への upsert (これは `/v1/summary/upsert` の責務)。
+
+## Acceptance Criteria → 実装マッピング
+
+| AC | 実装ポイント |
+|----|-------------|
+| `/v1/summarize` 生成 summary の prompt-visible fact は evidence_ids を持つ | `SummaryFidelityChecker` の既存 `missing_evidence_id` チェックを `/v1/summarize` 内でも走らせ、`validation_results` に反映 |
+| raw stdout/stderr/secret は `ContextPack.items[].text` に入らない | `/v1/summarize` 段階で fact text を `sanitize_text_with_report` で redact。raw_evidence は `evaluate_raw_item` で deny して `admission_decisions` に記録。これにより後段の `/v1/context/pack` まで raw が流れない |
+| `validation_results` で grounding / raw leakage の状態を確認できる | `SummaryValidationResult` を返す。grounding 系の既存 issue 種に加え、新 issue 種 `raw_output_in_field` を追加 |
+| `/v1/evidence/expand` と連携し、必要時だけ redacted snippet を返せる | `/v1/summarize` のレスポンスに `evidence_ids_referenced: list[str]` を含め、agent が必要時に `/v1/evidence/expand` を呼び出せるようにする。expand 側の redaction は既存 (`policy.redact_again`) を再利用 |
+
+## API 設計
+
+### Request — `POST /v1/summarize`
+
+```jsonc
+{
+  "schema_version": "action-memory.v0.2",
+  "request_id": "req-...",
+  "draft_summary": {ActionSummary},
+  "evidence_records": [ {evidence_id, kind, summary, content?, ...}, ... ],
+  "raw_evidence": [ {item_id, kind, content, source?}, ... ]
+}
+```
+
+- `draft_summary` は agent が組み立てた候補。`facts/hypotheses/...` は構造化されている前提。
+- `evidence_records` は grounding 用 (`SummaryFidelityChecker` に渡す)。
+- `raw_evidence` は raw tool log。`/v1/context/pack` と同様に default-deny。
+
+### Response
+
+```jsonc
+{
+  "schema_version": "action-memory.v0.2",
+  "request_id": "req-...",
+  "summary": {ActionSummary},          // firewalled: secrets redacted in prompt-visible fields
+  "validation_results": [ {SummaryValidationResult} ],
+  "admission_decisions": [ {ContextAdmissionDecision}, ... ],  // raw_evidence deny entries
+  "omitted": [ {OmittedItem}, ... ],   // raw_evidence omitted with reason
+  "evidence_ids_referenced": ["ev-001", ...]
+}
+```
+
+## SummaryFidelityChecker 拡張
+
+- 新 issue 種 `raw_output_in_field` を追加 (blocking)。
+- 検出対象: `facts[*].text`, `hypotheses[*].text`, `failed_attempts[*].action / outcome`, `avoid[*].action / reason`, `actions_done[*].target / command / outcome`, `next_hints[*].target / reason`, `validity.reason`。
+- 検出ロジック: `photon_action_memory.context.raw_policy.has_sensitive_content` を再利用 (DRY)。
+
+## Firewall (redaction) ロジック
+
+`/v1/summarize` 内で `_apply_summary_firewall(summary) -> ActionSummary` ヘルパーを置く:
+
+- 各 prompt-visible 文字列に対し `sanitize_text_with_report` を適用。
+- redact が発生した場合は元のオブジェクトを `model_copy(update=...)` で差し替えて新しい `ActionSummary` を返す。
+- 該当した検出は `validation_results` に `raw_output_in_field` issue として残す。
+
+## エラーポリシー / fail-open
+
+- 内部例外時は `summary` をそのまま返し、`validation_results` に `kind="summarize_error"` の issue を 1 件積む (status=200, fail-open)。これは `/v1/summary/validate` の既存 fail-open と一貫。
+- raw_evidence は例外時でも default-deny。
+
+## Safety Notes
+
+- prompt-visible 文字列を redact してから validation を実行する順序にする。これにより `raw_output_in_field` 検出は redact 前の draft に基づき report され、返却される summary は redact 後の安全な値になる。
+- 既存の `_BLOCKING_KINDS` に `raw_output_in_field` を含めて status=invalid に倒す。
+- `evidence_ids_referenced` は `facts/hypotheses/failed_attempts/avoid/actions_done` の `evidence_ids` を union したもの。順序は安定化させる (set→sorted)。
+
+## Touched files (見込み)
+
+- `photon_action_memory/api/schema_v2.py`: 新 `SummarizeRequest`, `SummarizeResponse` 定義。
+- `photon_action_memory/api/server.py`: `summarize_stub` を実装に差し替え。
+- `photon_action_memory/eval/summary_fidelity.py`: `raw_output_in_field` 検出を追加。
+- `photon_action_memory/eval/__init__.py`: 必要なら export 追加 (今のところ不要)。
+- `tests/test_summary_fidelity.py`: 新検出のユニットテスト。
+- `tests/test_raw_tool_log_policy.py`: `/v1/summarize` の raw firewall 統合テスト。

--- a/dev-reports/issue-86/implementation-summary.md
+++ b/dev-reports/issue-86/implementation-summary.md
@@ -1,0 +1,91 @@
+# Implementation Summary — Issue #86
+
+## What changed
+
+### `/v1/summarize` is now a firewall endpoint (was M2 stub returning 501)
+
+`POST /v1/summarize` accepts an agent-built **draft `ActionSummary`** plus optional
+`raw_evidence` and `evidence_records` (passed through pydantic `model_extra`),
+applies the Action Context Firewall, and returns a sanitized summary together
+with validation signals.
+
+Response shape (`SummarizeResponse`):
+
+- `summary`: the draft with secrets / home paths / token-like strings redacted
+  in every prompt-visible string field
+  (`facts/hypotheses/failed_attempts/avoid/actions_done/next_hints/validity.reason`)
+- `validation_results`: one `SummaryValidationResult` (grounding + leakage
+  signals), with `raw_output_in_field` added for redacted fields so callers can
+  see *what* was scrubbed
+- `admission_decisions`: deny entries for every `raw_evidence` item
+  (same `raw_tool_log_default_deny` policy used by `/v1/context/pack`)
+- `omitted`: corresponding `OmittedItem` entries
+- `evidence_ids_referenced`: deduplicated, order-preserving union of every
+  evidence_id referenced by the firewalled summary — feeds directly into
+  `/v1/evidence/expand` for redacted snippets on demand
+
+The handler is fail-open: on internal exception it returns the original draft
+with a single `summarize_error` issue rather than a 500.
+
+### `SummaryFidelityChecker` gained `raw_output_in_field` detection
+
+The checker now also scans every prompt-visible string field on an
+`ActionSummary` using `photon_action_memory.context.raw_policy.has_sensitive_content`
+and emits a blocking `raw_output_in_field` issue when secret patterns / bearer
+tokens / `sk-`/`ghp_`-style tokens / `/home|/Users|/root` paths are detected.
+This means `/v1/summary/validate` also surfaces leakage, not just the new
+`/v1/summarize` route.
+
+`raw_output_in_field` is added to `_BLOCKING_KINDS`, so status flips to
+`invalid` when leakage is found.
+
+### Schema additions (`photon_action_memory/api/schema_v2.py`)
+
+- `SummarizeRequest`: `schema_version`, `request_id`, `draft_summary`
+  (`evidence_records` and `raw_evidence` come in via `model_extra`, consistent
+  with `/v1/context/pack` and `/v1/summary/validate`)
+- `SummarizeResponse`: documented above
+- Both are added to `__all__`
+
+## Files touched
+
+- `photon_action_memory/api/schema_v2.py` — `SummarizeRequest` / `SummarizeResponse`
+- `photon_action_memory/api/server.py` — implements `/v1/summarize`, plus
+  module-level helpers `_summarize_with_firewall`,
+  `_coerce_summarize_raw_items`, `_deny_summarize_raw_evidence`,
+  `_apply_summary_firewall`, `_collect_summary_evidence_ids`
+- `photon_action_memory/eval/summary_fidelity.py` — `_check_raw_leakage` and
+  blocking-kind expansion
+- `tests/test_sidecar_api.py` — `/v1/summarize` is no longer a 501 stub; the
+  empty-body case now exercises the request schema (422)
+- `tests/test_summary_fidelity.py` — 4 new tests for the
+  `raw_output_in_field` checker rule
+- `tests/test_raw_tool_log_policy.py` — 5 new integration tests covering the
+  `/v1/summarize` evidence-grounding + raw-firewall contract
+
+## How acceptance criteria are satisfied
+
+| AC | Where verified |
+|----|---------------|
+| `/v1/summarize` 生成 summary の prompt-visible fact は evidence_ids を持つ | `test_summarize_facts_must_carry_evidence_ids` (returns `missing_evidence_id`, status `invalid`) |
+| raw stdout/stderr/secret は `ContextPack.items[].text` に入らない | `test_summarize_redacts_secrets_in_fact_text` (secret is scrubbed from `facts[0].text`) + `test_summarize_denies_raw_evidence_and_records_admission` (raw items never appear in serialised `summary`) + existing `/v1/context/pack` raw policy untouched |
+| `validation_results` で grounding / raw leakage の状態を確認できる | All `/v1/summarize` integration tests + new `_check_raw_leakage` unit tests in `tests/test_summary_fidelity.py` |
+| `/v1/evidence/expand` と連携し、必要時だけ redacted snippet を返せる | `test_summarize_evidence_ids_referenced_supports_expand_followup` — caller takes `evidence_ids_referenced` and forwards it to existing `/v1/evidence/expand` (whose `policy.redact_again` + `policy.allow_raw_full_output=false` defaults already enforce redaction) |
+
+## Design choices
+
+- **Reuse, don't duplicate.** `has_sensitive_content` and `evaluate_raw_item`
+  already implement the raw firewall for `/v1/context/pack`. The new endpoint
+  delegates to them so the policy stays single-sourced.
+- **Redact + flag, not just flag.** The returned summary is redacted in place
+  so callers can safely persist or forward it. The matching
+  `raw_output_in_field` issue is appended to `validation_results` so callers
+  can decide whether to keep the redacted summary or reject it.
+- **No schema breakage.** Existing `/v1/summary/validate` consumers see
+  `raw_output_in_field` as a new (additive) issue kind — `SummaryValidationIssue.kind`
+  was already `str`. `ContextAdmissionDecision.item_kind` was already
+  defined as `Literal[...] | str`, so emitting `raw_tool_log` continues to be
+  valid.
+- **Stub test was kept, retargeted.** `test_summarize_is_m2_stub` is replaced
+  by `test_summarize_rejects_invalid_request` so we still cover the route at
+  a basic-handshake level.

--- a/dev-reports/issue-86/verification.md
+++ b/dev-reports/issue-86/verification.md
@@ -1,0 +1,83 @@
+# Verification — Issue #86
+
+## Focused suites
+
+```
+$ python -m pytest tests/test_summary_fidelity.py \
+                   tests/test_raw_tool_log_policy.py \
+                   tests/test_sidecar_api.py -x
+...
+============================== 88 passed in 0.42s ==============================
+```
+
+All directly-related suites pass, including:
+
+- **`tests/test_summary_fidelity.py`** — 4 new tests:
+  - `test_secret_in_fact_text_flags_raw_output_in_field`
+  - `test_home_path_in_failed_attempt_outcome_flags_raw_leakage`
+  - `test_bearer_token_in_action_command_flags_raw_leakage`
+  - `test_clean_fact_does_not_trigger_raw_leakage`
+- **`tests/test_raw_tool_log_policy.py`** — 5 new tests for `/v1/summarize`:
+  - `test_summarize_facts_must_carry_evidence_ids`
+  - `test_summarize_redacts_secrets_in_fact_text`
+  - `test_summarize_denies_raw_evidence_and_records_admission`
+  - `test_summarize_evidence_ids_referenced_supports_expand_followup`
+  - `test_summarize_clean_summary_returns_valid_status`
+- **`tests/test_sidecar_api.py`** — retargeted `test_summarize_rejects_invalid_request`
+  to reflect the new implementation (empty body → 422 instead of 501).
+
+## Broader regression suite
+
+Shared contracts touched (`schema_v2`, `server`, `SummaryFidelityChecker`),
+so the full test suite was run:
+
+```
+$ python -m pytest
+...
+======================== 803 passed, 1 skipped in 2.05s ========================
+```
+
+The single skip (`tests/integration/test_mlx_smoke.py`) is the opt-in MLX
+smoke test and is unrelated to this change.
+
+## Linting / typing
+
+```
+$ python -m ruff check photon_action_memory/ \
+        tests/test_summary_fidelity.py tests/test_raw_tool_log_policy.py \
+        tests/test_sidecar_api.py
+All checks passed!
+
+$ python -m mypy photon_action_memory/api/server.py \
+        photon_action_memory/api/schema_v2.py \
+        photon_action_memory/eval/summary_fidelity.py
+Success: no issues found in 3 source files
+```
+
+## Manual contract spot-check
+
+The new `/v1/summarize` behaviour was exercised via the integration tests
+above, which directly assert:
+
+1. Facts without `evidence_ids` → `validation_results[*].status == "invalid"`
+   with a `missing_evidence_id` issue.
+2. `API_KEY=...` embedded in `facts[0].text` → redacted in the returned
+   `summary` (`supersecret123456789secret` is not present in the response) and
+   reported via `raw_output_in_field`.
+3. Two raw `stdout`/`stderr` items in `raw_evidence` → two `deny` entries in
+   `admission_decisions` with `policy.raw_evidence_policy == "raw_tool_log_default_deny"`,
+   matching `/v1/context/pack`. The raw bodies do not appear anywhere in the
+   serialised response.
+4. `evidence_ids_referenced` is deduplicated and order-preserving, ready to be
+   forwarded to `/v1/evidence/expand`.
+
+## Risk
+
+- Existing `/v1/context/pack` and `/v1/summary/validate` behaviour was not
+  altered. The new `raw_output_in_field` issue kind is additive; existing
+  callers that inspect `kind` as a string will simply see one more possible
+  value (status semantics for callers that branch on `valid|invalid|partial`
+  remain correct because the new kind is added to `_BLOCKING_KINDS`).
+- `model_extra` is used for `evidence_records` and `raw_evidence` to match the
+  surrounding endpoints (`/v1/summary/validate`, `/v1/context/pack`). This
+  keeps schema evolution forward-compatible without forcing a v0.3 schema bump.

--- a/photon_action_memory/api/schema_v2.py
+++ b/photon_action_memory/api/schema_v2.py
@@ -437,7 +437,7 @@ class SummaryValidateResponse(SidecarModel):
 
 
 # ---------------------------------------------------------------------------
-# POST /v1/summarize (Issue #82 contract + Issue #83/#84 pipelines)
+# POST /v1/summarize (Issue #82 contract + Issue #83/#84/#86 pipelines)
 # ---------------------------------------------------------------------------
 
 
@@ -461,12 +461,9 @@ class SummarizePolicy(SidecarModel):
 class SummarizeRequest(SidecarModel):
     """Request body for POST /v1/summarize.
 
-    Anvil sends this at the end of a turn (or session) together with the
-    chunk_ids / recent_event_ids that should be folded into the summary.
-    Reuses ``AgentInfo`` / ``RepoInfo`` / ``TaskState`` from the v1 schema
-    so the request stays consistent with ``/v1/context/pack``. Callers can
-    either reference stored events or provide inline ``ActionChunk`` objects
-    for hierarchical turn/session/case summaries.
+    Callers can summarize stored events, fold inline ``ActionChunk`` objects
+    into hierarchical summaries, or submit a prebuilt ``draft_summary`` for
+    Action Context Firewall checks before prompt-visible reuse.
     """
 
     schema_version: SchemaVersionV2
@@ -485,16 +482,11 @@ class SummarizeRequest(SidecarModel):
     chunks: list[ActionChunk] = Field(default_factory=list)
     summary_id: str | None = None
     policy: SummarizePolicy = Field(default_factory=SummarizePolicy)
+    draft_summary: ActionSummary | None = None
 
 
 class SummarizeResponse(SidecarModel):
-    """Response body for POST /v1/summarize.
-
-    The generated ``ActionSummary`` is returned inline so callers can pipe it
-    straight into ``/v1/summary/upsert`` or ``/v1/summary/validate``. Pipeline
-    counters expose how many ActionChunks were built and how many summaries
-    were persisted for the request.
-    """
+    """Response body for POST /v1/summarize."""
 
     schema_version: SchemaVersionV2
     request_id: str
@@ -508,6 +500,10 @@ class SummarizeResponse(SidecarModel):
     validation: SummaryValidationResult | None = None
     tokens_saved_vs_raw: int = Field(default=0, ge=0)
     warnings: list[ContextPackWarning] = Field(default_factory=list)
+    validation_results: list[SummaryValidationResult] = Field(default_factory=list)
+    admission_decisions: list[ContextAdmissionDecision] = Field(default_factory=list)
+    omitted: list[OmittedItem] = Field(default_factory=list)
+    evidence_ids_referenced: list[str] = Field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -608,9 +604,9 @@ __all__ = [
     "StalenessStatus",
     "StalenessStatusKind",
     "SummarizePolicy",
+    "SummaryLevel",
     "SummarizeRequest",
     "SummarizeResponse",
-    "SummaryLevel",
     "SummaryValidateRequest",
     "SummaryValidateResponse",
     "SummaryValidationIssue",

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -26,6 +26,8 @@ from photon_action_memory.api.schema_v2 import (
     DEFAULT_SCHEMA_VERSION_V2,
     ActionChunk,
     ActionSummary,
+    AdmissionPolicy,
+    ContextAdmissionDecision,
     ContextPack,
     ContextPackRequest,
     ContextPackResponse,
@@ -35,19 +37,27 @@ from photon_action_memory.api.schema_v2 import (
     EvidenceExpandRequest,
     EvidenceExpandResponse,
     OmittedEvidence,
+    OmittedItem,
     SummarizeRequest,
     SummarizeResponse,
     SummaryValidateRequest,
     SummaryValidateResponse,
+    SummaryValidationIssue,
+    SummaryValidationResult,
     TokenBudget,
     TokenCost,
 )
 from photon_action_memory.context.pack import build_context_pack
-from photon_action_memory.context.raw_policy import RawEvidenceItem
+from photon_action_memory.context.raw_policy import (
+    RawEvidenceItem,
+    evaluate_raw_item,
+    has_sensitive_content,
+)
 from photon_action_memory.eval.summary_fidelity import SummaryFidelityChecker
 from photon_action_memory.memory.chunks import ActionChunker
 from photon_action_memory.memory.evidence import EvidenceExpander
 from photon_action_memory.memory.retrieval import SummaryRetriever
+from photon_action_memory.memory.sanitizer import sanitize_text_with_report
 from photon_action_memory.memory.store import SQLiteEventStore
 from photon_action_memory.memory.summaries import (
     ActionSummaryBuilder,
@@ -249,6 +259,8 @@ def create_app(
 
     @app.post("/v1/summarize", response_model=SummarizeResponse)
     def summarize(request: SummarizeRequest) -> SummarizeResponse:
+        if request.draft_summary is not None:
+            return _summarize_with_firewall(request, event_store=event_store)
         if "chunks" in request.model_fields_set:
             return _summarize_inline_chunks(request, event_store, _summary_store)
 
@@ -433,6 +445,255 @@ def _build_hierarchical_summary(request: SummarizeRequest) -> ActionSummary:
     if request.summary_id:
         overrides["summary_id"] = request.summary_id
     return state.model_copy(update=overrides)
+
+
+_SUMMARIZE_RAW_POLICY_NAME = "raw_tool_log_default_deny"
+
+
+def _summarize_with_firewall(
+    request: SummarizeRequest,
+    *,
+    event_store: SQLiteEventStore,
+) -> SummarizeResponse:
+    """Apply the Action Context Firewall to a draft ActionSummary.
+
+    1) Redact secrets / home paths / token-like strings from prompt-visible
+       fields so they cannot reach a downstream ContextPack.
+    2) Deny any raw_evidence under the existing default-deny policy.
+    3) Run SummaryFidelityChecker so the caller can see grounding / raw
+       leakage signals in ``validation_results``.
+    4) Surface ``evidence_ids_referenced`` so the caller can follow up with
+       /v1/evidence/expand for redacted snippets on demand.
+    """
+    draft = request.draft_summary
+    if draft is None:
+        raise ValueError("draft_summary is required for summarize firewall mode")
+    try:
+        extras = request.model_extra or {}
+        evidence_records: list[dict[str, Any]] = []
+        raw_evidence_extra = extras.get("evidence_records")
+        if isinstance(raw_evidence_extra, list):
+            evidence_records.extend(r for r in raw_evidence_extra if isinstance(r, dict))
+        evidence_records.extend(ev.payload for ev in event_store.list_events())
+
+        raw_items = _coerce_summarize_raw_items(extras.get("raw_evidence"))
+
+        firewalled, leakage_redactions = _apply_summary_firewall(draft)
+        checker = SummaryFidelityChecker(records=evidence_records)
+        result = checker.check(firewalled)
+
+        if leakage_redactions:
+            extra_issues = list(result.issues) + [
+                SummaryValidationIssue(
+                    kind="raw_output_in_field",
+                    message=msg,
+                )
+                for msg in leakage_redactions
+            ]
+            result = result.model_copy(
+                update={
+                    "issues": extra_issues,
+                    "status": "invalid",
+                }
+            )
+
+        admission_decisions, omitted = _deny_summarize_raw_evidence(raw_items)
+        evidence_ids = _collect_summary_evidence_ids(firewalled)
+
+        return SummarizeResponse(
+            schema_version=DEFAULT_SCHEMA_VERSION_V2,
+            request_id=request.request_id,
+            model_version=FALLBACK_MODEL_VERSION,
+            sidecar_status="ok",
+            status="ok",
+            chunks_built=0,
+            summaries_upserted=0,
+            summary_ids=[firewalled.summary_id],
+            summary=firewalled,
+            validation=result,
+            tokens_saved_vs_raw=_tokens_saved(firewalled.token_cost),
+            warnings=[],
+            validation_results=[result],
+            admission_decisions=admission_decisions,
+            omitted=omitted,
+            evidence_ids_referenced=evidence_ids,
+        )
+    except Exception as exc:
+        logger.warning("summarize firewall error: %s", exc)
+        fallback_issue = SummaryValidationIssue(
+            kind="summarize_error",
+            message=f"summarize firewall error: {exc}",
+        )
+        fallback_result = SummaryValidationResult(
+            summary_id=draft.summary_id,
+            status="invalid",
+            score=0.0,
+            issues=[fallback_issue],
+        )
+        return SummarizeResponse(
+            schema_version=DEFAULT_SCHEMA_VERSION_V2,
+            request_id=request.request_id,
+            model_version=FALLBACK_MODEL_VERSION,
+            sidecar_status="degraded",
+            status="degraded",
+            chunks_built=0,
+            summaries_upserted=0,
+            summary_ids=[draft.summary_id],
+            summary=draft,
+            validation=fallback_result,
+            tokens_saved_vs_raw=_tokens_saved(draft.token_cost),
+            warnings=[ContextPackWarning(kind="summarize_error", message=str(exc))],
+            validation_results=[fallback_result],
+            admission_decisions=[],
+            omitted=[],
+            evidence_ids_referenced=[],
+        )
+
+
+def _coerce_summarize_raw_items(raw: object) -> list[RawEvidenceItem]:
+    if not isinstance(raw, list):
+        return []
+    items: list[RawEvidenceItem] = []
+    for i, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            continue
+        items.append(
+            RawEvidenceItem(
+                item_id=str(entry.get("item_id", f"raw-{i}")),
+                kind=str(entry.get("kind", "raw_output")),
+                content=str(entry.get("content", "")),
+                source=str(entry["source"]) if entry.get("source") else None,
+            )
+        )
+    return items
+
+
+def _deny_summarize_raw_evidence(
+    raw_items: list[RawEvidenceItem],
+) -> tuple[list[ContextAdmissionDecision], list[OmittedItem]]:
+    decisions: list[ContextAdmissionDecision] = []
+    omitted: list[OmittedItem] = []
+    for raw_item in raw_items:
+        _, reason = evaluate_raw_item(raw_item)
+        decisions.append(
+            ContextAdmissionDecision(
+                schema_version=DEFAULT_SCHEMA_VERSION_V2,
+                decision_id=f"dec-summ-{raw_item.item_id}",
+                item_id=raw_item.item_id,
+                item_kind="raw_tool_log",
+                decision="deny",
+                reason=reason,
+                policy=AdmissionPolicy(raw_evidence_policy=_SUMMARIZE_RAW_POLICY_NAME),
+            )
+        )
+        omitted.append(
+            OmittedItem(
+                kind=raw_item.kind,
+                id=raw_item.item_id,
+                reason=reason,
+            )
+        )
+    return decisions, omitted
+
+
+def _apply_summary_firewall(summary: ActionSummary) -> tuple[ActionSummary, list[str]]:
+    """Redact secrets in every prompt-visible string field of a draft summary.
+
+    Returns the redacted summary and a list of messages describing which fields
+    were redacted (one per affected field), suitable for surfacing as
+    ``raw_output_in_field`` issues alongside the checker's own findings.
+    """
+    redactions: list[str] = []
+
+    def _scrub(value: str | None, where: str) -> str | None:
+        if not value or not has_sensitive_content(value):
+            return value
+        cleaned = sanitize_text_with_report(value).text
+        redactions.append(f"{where} contained raw output / secret / home path; redacted")
+        return cleaned
+
+    new_facts = [
+        fact.model_copy(update={"text": _scrub(fact.text, f"facts[{i}].text") or ""})
+        for i, fact in enumerate(summary.facts)
+    ]
+    new_hypotheses = [
+        hyp.model_copy(update={"text": _scrub(hyp.text, f"hypotheses[{i}].text") or ""})
+        for i, hyp in enumerate(summary.hypotheses)
+    ]
+    new_failed = [
+        fa.model_copy(
+            update={
+                "action": _scrub(fa.action, f"failed_attempts[{i}].action") or "",
+                "outcome": _scrub(fa.outcome, f"failed_attempts[{i}].outcome") or "",
+            }
+        )
+        for i, fa in enumerate(summary.failed_attempts)
+    ]
+    new_avoid = [
+        av.model_copy(
+            update={
+                "action": _scrub(av.action, f"avoid[{i}].action") or "",
+                "reason": _scrub(av.reason, f"avoid[{i}].reason") or "",
+            }
+        )
+        for i, av in enumerate(summary.avoid)
+    ]
+    new_actions_done = [
+        ad.model_copy(
+            update={
+                "target": _scrub(ad.target, f"actions_done[{i}].target"),
+                "command": _scrub(ad.command, f"actions_done[{i}].command"),
+                "outcome": _scrub(ad.outcome, f"actions_done[{i}].outcome") or "",
+            }
+        )
+        for i, ad in enumerate(summary.actions_done)
+    ]
+    new_next_hints = [
+        nh.model_copy(
+            update={
+                "target": _scrub(nh.target, f"next_hints[{i}].target"),
+                "reason": _scrub(nh.reason, f"next_hints[{i}].reason") or "",
+            }
+        )
+        for i, nh in enumerate(summary.next_hints)
+    ]
+    new_validity = summary.validity
+    if summary.validity and summary.validity.reason:
+        cleaned = _scrub(summary.validity.reason, "validity.reason")
+        if cleaned != summary.validity.reason:
+            new_validity = summary.validity.model_copy(update={"reason": cleaned})
+
+    firewalled = summary.model_copy(
+        update={
+            "facts": new_facts,
+            "hypotheses": new_hypotheses,
+            "failed_attempts": new_failed,
+            "avoid": new_avoid,
+            "actions_done": new_actions_done,
+            "next_hints": new_next_hints,
+            "validity": new_validity,
+        }
+    )
+    return firewalled, redactions
+
+
+def _collect_summary_evidence_ids(summary: ActionSummary) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    sources = (
+        summary.facts,
+        summary.hypotheses,
+        summary.failed_attempts,
+        summary.avoid,
+        summary.actions_done,
+    )
+    for group in sources:
+        for item in group:
+            for eid in getattr(item, "evidence_ids", []) or []:
+                if eid and eid not in seen:
+                    seen.add(eid)
+                    ordered.append(eid)
+    return ordered
 
 
 def _extract_raw_items(request: ContextPackRequest) -> list[RawEvidenceItem]:

--- a/photon_action_memory/eval/summary_fidelity.py
+++ b/photon_action_memory/eval/summary_fidelity.py
@@ -11,6 +11,7 @@ from photon_action_memory.api.schema_v2 import (
     SummaryValidationIssue,
     SummaryValidationResult,
 )
+from photon_action_memory.context.raw_policy import has_sensitive_content
 
 _UNCERTAINTY_KEYWORDS: tuple[str, ...] = (
     "appears",
@@ -37,6 +38,7 @@ _BLOCKING_KINDS: frozenset[str] = frozenset(
         "missing_evidence_id",
         "ungrounded_fact",
         "failed_action_misclassified",
+        "raw_output_in_field",
     }
 )
 _TEXT_FIELDS: tuple[str, ...] = ("content", "text", "message", "output", "body")
@@ -96,6 +98,7 @@ class SummaryFidelityChecker:
         issues: list[SummaryValidationIssue] = []
         self._check_facts(summary, issues)
         self._check_actions_done(summary, issues)
+        self._check_raw_leakage(summary, issues)
         score = self._compute_score(summary, issues)
         status = self._compute_status(issues)
         return SummaryValidationResult(
@@ -204,6 +207,86 @@ class SummaryFidelityChecker:
                                 )
                             )
                             break
+
+    def _check_raw_leakage(
+        self, summary: ActionSummary, issues: list[SummaryValidationIssue]
+    ) -> None:
+        """Flag prompt-visible fields that contain raw stdout/stderr/secret/path leakage."""
+        for i, fact in enumerate(summary.facts):
+            if has_sensitive_content(fact.text):
+                issues.append(
+                    SummaryValidationIssue(
+                        kind="raw_output_in_field",
+                        message=f"facts[{i}].text contains raw output / secret / home path",
+                    )
+                )
+        for i, hyp in enumerate(summary.hypotheses):
+            if has_sensitive_content(hyp.text):
+                issues.append(
+                    SummaryValidationIssue(
+                        kind="raw_output_in_field",
+                        message=f"hypotheses[{i}].text contains raw output / secret / home path",
+                    )
+                )
+        for i, fa in enumerate(summary.failed_attempts):
+            for field_name in ("action", "outcome"):
+                value = getattr(fa, field_name, "") or ""
+                if has_sensitive_content(value):
+                    issues.append(
+                        SummaryValidationIssue(
+                            kind="raw_output_in_field",
+                            message=(
+                                f"failed_attempts[{i}].{field_name}"
+                                " contains raw output / secret / home path"
+                            ),
+                        )
+                    )
+        for i, av in enumerate(summary.avoid):
+            for field_name in ("action", "reason"):
+                value = getattr(av, field_name, "") or ""
+                if has_sensitive_content(value):
+                    issues.append(
+                        SummaryValidationIssue(
+                            kind="raw_output_in_field",
+                            message=(
+                                f"avoid[{i}].{field_name} contains raw output / secret / home path"
+                            ),
+                        )
+                    )
+        for i, ad in enumerate(summary.actions_done):
+            for field_name in ("target", "command", "outcome"):
+                value = getattr(ad, field_name, "") or ""
+                if has_sensitive_content(value):
+                    issues.append(
+                        SummaryValidationIssue(
+                            kind="raw_output_in_field",
+                            message=(
+                                f"actions_done[{i}].{field_name}"
+                                " contains raw output / secret / home path"
+                            ),
+                        )
+                    )
+        for i, nh in enumerate(summary.next_hints):
+            for field_name in ("target", "reason"):
+                value = getattr(nh, field_name, "") or ""
+                if has_sensitive_content(value):
+                    issues.append(
+                        SummaryValidationIssue(
+                            kind="raw_output_in_field",
+                            message=(
+                                f"next_hints[{i}].{field_name}"
+                                " contains raw output / secret / home path"
+                            ),
+                        )
+                    )
+        if summary.validity and summary.validity.reason:
+            if has_sensitive_content(summary.validity.reason):
+                issues.append(
+                    SummaryValidationIssue(
+                        kind="raw_output_in_field",
+                        message="validity.reason contains raw output / secret / home path",
+                    )
+                )
 
     def _compute_score(self, summary: ActionSummary, issues: list[SummaryValidationIssue]) -> float:
         n_total = max(

--- a/tests/test_raw_tool_log_policy.py
+++ b/tests/test_raw_tool_log_policy.py
@@ -375,6 +375,152 @@ def test_api_no_raw_evidence_field_is_fine(tmp_path: Path) -> None:
     assert response.json()["sidecar_status"] == "ok"
 
 
+# ---------------------------------------------------------------------------
+# /v1/summarize - Action Context Firewall integration (issue #86)
+# ---------------------------------------------------------------------------
+
+
+def _summarize_payload(
+    *,
+    summary_id: str = "sum-fw-001",
+    facts: list[dict] | None = None,  # type: ignore[type-arg]
+    failed_attempts: list[dict] | None = None,  # type: ignore[type-arg]
+    actions_done: list[dict] | None = None,  # type: ignore[type-arg]
+    raw_evidence: list[dict] | None = None,  # type: ignore[type-arg]
+    evidence_records: list[dict] | None = None,  # type: ignore[type-arg]
+) -> dict:  # type: ignore[type-arg]
+    body: dict = {  # type: ignore[type-arg]
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "req-summ-fw",
+        "draft_summary": {
+            "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+            "summary_id": summary_id,
+            "facts": facts or [],
+            "hypotheses": [],
+            "failed_attempts": failed_attempts or [],
+            "actions_done": actions_done or [],
+        },
+    }
+    if raw_evidence is not None:
+        body["raw_evidence"] = raw_evidence
+    if evidence_records is not None:
+        body["evidence_records"] = evidence_records
+    return body
+
+
+def test_summarize_facts_must_carry_evidence_ids(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    payload = _summarize_payload(
+        facts=[{"text": "the build succeeded", "evidence_ids": []}],
+    )
+    with TestClient(app) as client:
+        response = client.post("/v1/summarize", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    results = data["validation_results"]
+    assert len(results) == 1
+    assert results[0]["status"] == "invalid"
+    assert any(iss["kind"] == "missing_evidence_id" for iss in results[0]["issues"])
+
+
+def test_summarize_redacts_secrets_in_fact_text(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    payload = _summarize_payload(
+        facts=[
+            {
+                "text": "found API_KEY=supersecret123456789secret in config",
+                "evidence_ids": ["ev-001"],
+            }
+        ],
+        evidence_records=[
+            {
+                "evidence_id": "ev-001",
+                "kind": "file_inspection",
+                "summary": "config file contained an API key assignment",
+            }
+        ],
+    )
+    with TestClient(app) as client:
+        response = client.post("/v1/summarize", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    fact_text = data["summary"]["facts"][0]["text"]
+    assert "supersecret123456789secret" not in fact_text
+    assert "API_KEY" not in fact_text or "[REDACTED" in fact_text
+    issues = data["validation_results"][0]["issues"]
+    assert any(iss["kind"] == "raw_output_in_field" for iss in issues)
+    assert data["validation_results"][0]["status"] == "invalid"
+
+
+def test_summarize_denies_raw_evidence_and_records_admission(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    payload = _summarize_payload(
+        facts=[{"text": "build ran", "evidence_ids": ["ev-001"]}],
+        raw_evidence=[
+            {"item_id": "raw-1", "kind": "stdout", "content": "cargo build output line"},
+            {"item_id": "raw-2", "kind": "stderr", "content": "warning: unused var"},
+        ],
+        evidence_records=[{"evidence_id": "ev-001", "kind": "build", "summary": "build ran"}],
+    )
+    with TestClient(app) as client:
+        response = client.post("/v1/summarize", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["admission_decisions"]) == 2
+    for dec in data["admission_decisions"]:
+        assert dec["decision"] == "deny"
+        assert dec["item_kind"] == "raw_tool_log"
+        assert dec["policy"]["raw_evidence_policy"] == "raw_tool_log_default_deny"
+    omitted_ids = {o["id"] for o in data["omitted"]}
+    assert omitted_ids == {"raw-1", "raw-2"}
+    # Raw items must never appear in the prompt-visible firewalled summary
+    serialised = str(data["summary"])
+    assert "cargo build output" not in serialised
+    assert "warning: unused var" not in serialised
+
+
+def test_summarize_evidence_ids_referenced_supports_expand_followup(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    payload = _summarize_payload(
+        facts=[
+            {"text": "build ran", "evidence_ids": ["ev-001"]},
+            {"text": "tests passed", "evidence_ids": ["ev-002", "ev-001"]},
+        ],
+        evidence_records=[
+            {"evidence_id": "ev-001", "kind": "build", "summary": "build ran"},
+            {"evidence_id": "ev-002", "kind": "test", "summary": "tests passed"},
+        ],
+    )
+    with TestClient(app) as client:
+        response = client.post("/v1/summarize", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    # Evidence IDs are deduplicated and preserved in encounter order
+    assert data["evidence_ids_referenced"] == ["ev-001", "ev-002"]
+
+
+def test_summarize_clean_summary_returns_valid_status(tmp_path: Path) -> None:
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
+    payload = _summarize_payload(
+        facts=[{"text": "the build succeeded", "evidence_ids": ["ev-001"]}],
+        evidence_records=[
+            {
+                "evidence_id": "ev-001",
+                "kind": "build",
+                "summary": "build succeeded",
+                "content": "the build succeeded with no warnings",
+            }
+        ],
+    )
+    with TestClient(app) as client:
+        response = client.post("/v1/summarize", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["validation_results"][0]["status"] == "valid"
+    assert data["admission_decisions"] == []
+    assert data["omitted"] == []
+
+
 def test_api_secret_in_raw_evidence_is_denied(tmp_path: Path) -> None:
     app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
     raw_evidence = [

--- a/tests/test_summary_fidelity.py
+++ b/tests/test_summary_fidelity.py
@@ -302,6 +302,51 @@ def test_hypothesis_as_fact_message_is_prompt_safe() -> None:
 
 
 # ---------------------------------------------------------------------------
+# SummaryFidelityChecker - raw output / secret leakage in prompt-visible fields
+# ---------------------------------------------------------------------------
+
+
+def test_secret_in_fact_text_flags_raw_output_in_field() -> None:
+    records = [_record("ev-001")]
+    checker = SummaryFidelityChecker(records=records)
+    leaky = _fact("API_KEY=abcdefghijklmnop secret was committed", ["ev-001"])
+    result = checker.check(_summary(facts=[leaky]))
+    assert any(iss.kind == "raw_output_in_field" for iss in result.issues)
+    assert result.status == "invalid"
+
+
+def test_home_path_in_failed_attempt_outcome_flags_raw_leakage() -> None:
+    checker = SummaryFidelityChecker()
+    summary = _summary(
+        failed_attempts=[_failed_attempt(action="rg", outcome="no match in /Users/alice/secrets/")],
+    )
+    result = checker.check(summary)
+    assert any(iss.kind == "raw_output_in_field" for iss in result.issues)
+
+
+def test_bearer_token_in_action_command_flags_raw_leakage() -> None:
+    checker = SummaryFidelityChecker()
+    summary = _summary(
+        actions_done=[
+            _action_done(
+                command="curl -H 'Authorization: Bearer abcdefghijklmnopqrstuvwxyz0123456789'",
+                outcome="success",
+                status="success",
+            )
+        ],
+    )
+    result = checker.check(summary)
+    assert any(iss.kind == "raw_output_in_field" for iss in result.issues)
+
+
+def test_clean_fact_does_not_trigger_raw_leakage() -> None:
+    records = [_record("ev-001")]
+    checker = SummaryFidelityChecker(records=records)
+    result = checker.check(_summary(facts=[_fact("the build succeeded", ["ev-001"])]))
+    assert not any(iss.kind == "raw_output_in_field" for iss in result.issues)
+
+
+# ---------------------------------------------------------------------------
 # SummaryFidelityChecker - failed action misclassification
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #86

## Summary

- Action Context Firewall として、prompt-visible memory は evidence-grounded summary のみである必要がある。`/v1/summarize` は raw tool/action 履歴を扱うため、raw stdout/stderr/secret の混入防止が重要。

## Changed Files

- `photon_action_memory/eval/summary_fidelity.py`
- `photon_action_memory/context/raw_policy.py`
- `tests/test_raw_tool_log_policy.py`
- `tests/test_summary_fidelity.py`

## Tests Run

- 未実行

## Known Risks

- None recorded by orchestration planner.

## Orchestration

- Run ID: `20260513-102053-orchestrate`
