### PR TITLE
#87 [v0.4.0] P2: /v1/evaluate feedback で summary confidence を更新する

### DIFF
--- a/dev-reports/issue-87/design.md
+++ b/dev-reports/issue-87/design.md
@@ -1,0 +1,101 @@
+# Issue #87 — Design Note
+
+## Objective
+
+`/v1/evaluate` の adoption outcome を summary 単位で集計し、effective summary を
+boost / 悪化 summary を demote または disable できるようにする。固定 seed では
+なく、実行結果から summary の信頼度を更新する。
+
+## Approach
+
+```
+/v1/evaluate  (ContextPackEvalEvent)
+    + summary_ids_adopted: list[str]           ← new typed field
+    ↓
+SummaryStore.record_outcomes()                  ← new method (per-summary aggregate)
+    → summary_feedback table (counters)
+    ↓ (read on /v1/context/pack)
+SummaryStore.get_feedback_map()
+    ↓
+context.pack.build_context_pack(..., feedback)  ← admission demotes/disables
+    → low-confidence: omit with reason="summary disabled by feedback"
+    → confidence sort: higher-confidence summaries admitted first under budget
+```
+
+### Schema change (forward-compatible)
+
+`ContextPackEvalEvent` gains an optional typed `summary_ids_adopted: list[str]`
+field. The current Anvil contract already tolerates extra fields (`extra="allow"`)
+so older agents that omit the list continue to validate — they simply contribute
+no per-summary signal.
+
+### `SummaryStore` extension
+
+Add a `summary_feedback` table keyed by `summary_id`:
+
+| column                   | meaning                                                  |
+|--------------------------|----------------------------------------------------------|
+| `summary_id`             | PK, foreign-key analog to `action_summaries.summary_id`  |
+| `adoption_count`         | quality turns where the summary was actually adopted     |
+| `success_count`          | adopted turns that ended in a success outcome            |
+| `failure_count`          | adopted turns that ended in a non-success, non-safety    |
+| `safety_violation_count` | turns with a safety outcome (regardless of adopted flag) |
+| `expand_request_count`   | turns where `evidence_expand_requested=True`             |
+| `quality_turns`          | total non-excluded turns where this summary was seen     |
+| `updated_at`             | last write timestamp                                     |
+
+`adopted` means the eval record's `adoption_status ∈ {adopted, partial}` AND
+`summary_id ∈ summary_ids_adopted`. Excluded statuses (`error`,
+`not_available`, `shadow_not_injected`) are skipped entirely.
+
+New `SummaryStore` methods:
+
+- `record_outcomes(summary_ids, *, adoption_status, outcome, evidence_expand_requested)` —
+  increments aggregate counters. Idempotency is not required (one row per
+  evaluate call is the contract).
+- `get_feedback(summary_id) -> SummaryFeedbackRecord | None`
+- `get_feedback_map(summary_ids) -> dict[str, SummaryFeedbackRecord]` (batch)
+
+### `eval/summary_feedback.py` (new module)
+
+Provides:
+
+- `SummaryFeedbackRecord` (dataclass): the per-summary aggregate; pure aggregate,
+  no raw content.
+- `confidence(record) -> float`: Laplace-smoothed `(success_count + 1) / (success_count + failure_count + 2)`. Defaults to 0.5 when no quality turns have been seen.
+- `is_disabled(record) -> bool`: True if `safety_violation_count >= 1`
+  OR (`adoption_count >= 3` AND `confidence < 0.34`). S2-03 regression pattern.
+- `SAFETY_OUTCOMES` set: `{"safety_violation", "unsafe", "harmful"}`.
+
+### Admission integration
+
+`build_context_pack` accepts a new optional `summary_feedback` param — a mapping
+`summary_id → SummaryFeedbackRecord`. When present:
+
+1. Disabled summaries are filtered out before admission with
+   `omitted.reason = "summary disabled by feedback"`.
+2. Remaining summaries are sorted by descending confidence so higher-confidence
+   items are admitted first under the token budget. Stable sort: ties preserve
+   the retriever's original order.
+
+When `summary_feedback` is empty or missing entries, the admission behaviour is
+unchanged (deterministic fallback).
+
+### `/v1/evaluate` and `/v1/context/pack` wiring
+
+- `/v1/evaluate`: if `context_pack_event.summary_ids_adopted` is non-empty AND
+  the record is not an excluded status, call
+  `summary_store.record_outcomes(...)`. Failures are logged but never raise
+  (fail-open).
+- `/v1/context/pack`: read `summary_store.get_feedback_map(...)` for the
+  resolved candidates and pass it to `build_context_pack`.
+
+## Key invariants
+
+1. Feedback only demotes / filters — it never resurrects a stale or contradicted
+   summary (the existing admission rules still run first).
+2. A safety_violation, even once, disables the summary.
+3. When no feedback rows exist, behaviour matches the pre-#87 baseline.
+4. The new table stores only counters — no raw prompts, tool output, or user
+   text. Aggregate-safe for future model training feature extraction.
+5. `record_outcomes` is fail-open: an error there never breaks `/v1/evaluate`.

--- a/dev-reports/issue-87/implementation-summary.md
+++ b/dev-reports/issue-87/implementation-summary.md
@@ -1,0 +1,67 @@
+# Issue #87 — Implementation Summary
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `photon_action_memory/api/schema_v2.py` | Added typed `summary_ids_adopted: list[str]` to `ContextPackEvalEvent`. |
+| `photon_action_memory/eval/summary_feedback.py` | New module: `SummaryFeedbackRecord`, `confidence()`, `is_disabled()`, `classify_outcome()`, `is_adopted()`. |
+| `photon_action_memory/memory/summary_store.py` | Added `summary_feedback` table, `record_outcomes()`, `get_feedback()`, `get_feedback_map()`. |
+| `photon_action_memory/context/pack.py` | `build_context_pack(..., summary_feedback=…)` filters disabled summaries and stably reorders by confidence. |
+| `photon_action_memory/api/server.py` | `/v1/evaluate` calls `record_outcomes`; `/v1/context/pack` loads `get_feedback_map` and passes it into the builder. |
+| `tests/test_summary_feedback.py` | New test file: 32 tests covering helpers, store, pack admission, and end-to-end flow. |
+
+## Behaviour
+
+### `/v1/evaluate`
+
+Agents can now attach `summary_ids_adopted: ["sum-…", "sum-…"]` to the
+`context_pack_event` payload. On each call the sidecar increments per-summary
+counters in the `summary_feedback` table:
+
+- `quality_turns` — total non-excluded turns where the summary appeared.
+- `adoption_count` — turns where `adoption_status ∈ {adopted, partial}`.
+- `success_count` / `failure_count` / `safety_violation_count` — partitioned by
+  outcome.
+- `expand_request_count` — turns where `evidence_expand_requested=True`.
+
+Excluded statuses (`error`, `not_available`, `shadow_not_injected`) are no-ops:
+infrastructure errors never pollute the per-summary signal. Missing
+`summary_ids_adopted` (legacy callers) is also a no-op.
+
+### `/v1/context/pack`
+
+After resolving the candidate summaries, the server reads their feedback rows
+and passes the map into `build_context_pack`. The builder:
+
+1. **Disables** summaries with `safety_violation_count >= 1` or
+   (`adoption_count >= 3` AND Laplace-smoothed confidence `< 0.34`).
+   Disabled summaries are emitted as `omitted` items with a "disabled by
+   feedback" reason and a `deny` admission decision.
+2. **Reorders** remaining summaries by descending confidence (stable on ties).
+   Under a tight token budget, the higher-confidence summary admits first.
+3. **Falls through** when no feedback is supplied or no rows exist: the
+   admission pipeline is identical to the pre-#87 baseline (deterministic
+   fallback).
+
+### Confidence model
+
+`confidence = (success + 1) / (success + failure + 2)` — Laplace smoothing with
+a neutral 0.5 prior. A single failure does not pin the score to zero, but
+repeated failures rapidly converge below the 0.34 disable threshold.
+
+## Aggregate-safety
+
+The `summary_feedback` table only stores counters and a timestamp. No raw
+prompt text, tool output, user request, or evidence content is persisted; the
+table is safe for future model training feature extraction under the same
+contract as `PackFeedback`.
+
+## Acceptance criteria coverage
+
+| Criterion | Where |
+|---|---|
+| summary_id 単位の採用/成功/失敗/safety 集計 | `SummaryStore.record_outcomes` + `summary_feedback` table |
+| 悪化 summary を低 confidence / disabled として扱える | `is_disabled` + `build_context_pack` deny path |
+| 有効 summary を優先できる | `_apply_feedback` confidence sort under budget |
+| feedback がなくても deterministic fallback | `_apply_feedback` short-circuits on `None` / empty dict |

--- a/dev-reports/issue-87/verification.md
+++ b/dev-reports/issue-87/verification.md
@@ -1,0 +1,66 @@
+# Issue #87 — Verification
+
+## Focused tests (new)
+
+```
+$ python -m pytest tests/test_summary_feedback.py -q
+................................                                         [100%]
+32 passed in 0.26s
+```
+
+The new file covers:
+
+- Pure helpers — `confidence`, `is_disabled`, `classify_outcome`, `is_adopted`
+  including the neutral prior, safety zero-tolerance, and S2-03-style
+  repeated-failure disable.
+- `SummaryStore.record_outcomes` and `get_feedback`/`get_feedback_map` for
+  success / failure / safety / ignored / excluded-status records and empty
+  inputs.
+- `build_context_pack(..., summary_feedback=…)` — disabled filtering, safety
+  filtering, confidence-priority under tight budgets, and the
+  no-feedback deterministic fallback.
+- End-to-end via `TestClient`: `/v1/evaluate` writes feedback rows and a
+  subsequent `/v1/context/pack` omits the disabled summary while admitting the
+  good one.
+
+## Regression — full unit suite
+
+```
+$ python -m pytest -q --ignore=tests/integration
+... 826 passed in 2.17s
+```
+
+Including the pre-existing `test_evaluate.py`, `test_summary_store.py`,
+`test_context_pack.py`, and `test_anvil_feedback.py` files — all green.
+
+## Lint and types
+
+```
+$ python -m ruff check photon_action_memory/ tests/test_summary_feedback.py
+All checks passed!
+
+$ python -m mypy photon_action_memory/
+Success: no issues found in 50 source files
+```
+
+## Integration
+
+```
+$ python -m pytest tests/integration -q
+1 skipped in 0.02s
+```
+
+The single integration test (MLX smoke) is an opt-in macOS workflow and is
+unrelated to the touched contracts.
+
+## Shared-contract risk assessment
+
+- `EvaluateRequest` / `ContextPackEvalEvent` gained one optional typed field
+  (`summary_ids_adopted: list[str] = []`). Existing agents that omit it
+  continue to validate (default empty list). `SidecarModel` keeps
+  `extra="allow"`.
+- `SummaryStore` adds a new table; existing rows and queries are unchanged.
+  `_initialize_schema` is idempotent via `CREATE TABLE IF NOT EXISTS`.
+- `build_context_pack` adds a new optional keyword argument; existing callers
+  (e.g. `_resolve_context_summaries` test fixtures) continue to work without
+  passing it.

--- a/photon_action_memory/api/schema_v2.py
+++ b/photon_action_memory/api/schema_v2.py
@@ -540,6 +540,7 @@ class ContextPackEvalEvent(SidecarModel):
     outcome: str | None = None
     outcome_detail: str | None = None
     latency_ms: float | None = Field(default=None, ge=0)
+    summary_ids_adopted: list[str] = Field(default_factory=list)
 
 
 class EvaluateRequest(SidecarModel):

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -159,6 +159,7 @@ def create_app(
             repo_id = _context_repo_id(request)
             resolved = _resolve_context_summaries(retriever, request, repo_id=repo_id)
             raw_items = _extract_raw_items(request)
+            feedback_map = _summary_store.get_feedback_map([s.summary_id for s in resolved])
             pack, decisions = build_context_pack(
                 request_id=request.request_id,
                 session_id=None,
@@ -167,6 +168,7 @@ def create_app(
                 budget=request.budget,
                 warnings=route_warnings,
                 raw_items=raw_items,
+                summary_feedback=feedback_map,
             )
             sidecar_status = "degraded" if route_warnings else "ok"
         except Exception as exc:
@@ -338,9 +340,26 @@ def create_app(
                     "outcome": evt.outcome,
                     "outcome_detail": evt.outcome_detail,
                     "latency_ms": evt.latency_ms,
+                    "summary_ids_adopted": evt.summary_ids_adopted,
                 }
                 event_store.append(payload)
                 logged += 1
+                if evt.summary_ids_adopted:
+                    try:
+                        _summary_store.record_outcomes(
+                            evt.summary_ids_adopted,
+                            adoption_status=evt.adoption_status,
+                            outcome=evt.outcome,
+                            evidence_expand_requested=evt.evidence_expand_requested,
+                        )
+                    except Exception as exc:
+                        logger.warning("summary feedback record error: %s", exc)
+                        route_warnings.append(
+                            ContextPackWarning(
+                                kind="summary_feedback_error",
+                                message=str(exc),
+                            )
+                        )
         except Exception as exc:
             logger.warning("evaluate log error: %s", exc)
             route_warnings.append(ContextPackWarning(kind="eval_log_error", message=str(exc)))

--- a/photon_action_memory/context/pack.py
+++ b/photon_action_memory/context/pack.py
@@ -19,6 +19,8 @@ from photon_action_memory.context.admission import ContextAdmissionController
 from photon_action_memory.context.budget import TokenBudgetTracker
 from photon_action_memory.context.raw_policy import RawEvidenceItem, evaluate_raw_item
 from photon_action_memory.context.render import estimate_tokens, render_summary
+from photon_action_memory.eval import summary_feedback as _summary_feedback_mod
+from photon_action_memory.eval.summary_feedback import SummaryFeedbackRecord
 
 _RAW_ADMISSION_POLICY = AdmissionPolicy(raw_evidence_policy="raw_tool_log_default_deny")
 
@@ -26,6 +28,12 @@ _RAW_ADMISSION_POLICY = AdmissionPolicy(raw_evidence_policy="raw_tool_log_defaul
 def _raw_decision_id(item_id: str) -> str:
     digest = hashlib.sha256(item_id.encode()).hexdigest()[:12]
     return f"dec-raw-{digest}"
+
+
+def _disabled_reason(record: SummaryFeedbackRecord) -> str:
+    if record.safety_violation_count >= 1:
+        return "summary disabled by feedback: safety_violation"
+    return f"summary disabled by feedback: low confidence after {record.adoption_count} adoptions"
 
 
 def build_context_pack(
@@ -37,6 +45,7 @@ def build_context_pack(
     budget: ContextPackBudget,
     warnings: list[ContextPackWarning] | None = None,
     raw_items: list[RawEvidenceItem] | None = None,
+    summary_feedback: dict[str, SummaryFeedbackRecord] | None = None,
 ) -> tuple[ContextPack, list[ContextAdmissionDecision]]:
     """Run the admission pipeline and return a ContextPack with decisions.
 
@@ -46,6 +55,10 @@ def build_context_pack(
 
     Raw items are always denied under the default-deny policy and recorded
     in ``omitted``; they never appear in ``items[*].text``.
+
+    When ``summary_feedback`` is supplied, disabled summaries are filtered
+    out before admission and the remaining order is stably sorted by
+    descending confidence so higher-confidence items win the token budget.
     """
     tracker = TokenBudgetTracker(max_tokens=budget.max_memory_tokens)
     controller = ContextAdmissionController(tracker)
@@ -54,7 +67,18 @@ def build_context_pack(
     omitted: list[OmittedItem] = []
     decisions: list[ContextAdmissionDecision] = []
 
-    for summary in summaries:
+    ordered_summaries, disabled_summaries = _apply_feedback(summaries, summary_feedback)
+    for disabled_summary, disabled_reason in disabled_summaries:
+        decisions.append(controller.make_decision(disabled_summary, "deny", disabled_reason))
+        omitted.append(
+            OmittedItem(
+                kind="action_summary",
+                id=disabled_summary.summary_id,
+                reason=disabled_reason,
+            )
+        )
+
+    for summary in ordered_summaries:
         decision, reason = controller.evaluate(summary)
         decisions.append(controller.make_decision(summary, decision, reason))
 
@@ -119,6 +143,29 @@ def build_context_pack(
         token_budget=tracker.to_token_budget(),
     )
     return pack, decisions
+
+
+def _apply_feedback(
+    summaries: list[ActionSummary],
+    summary_feedback: dict[str, SummaryFeedbackRecord] | None,
+) -> tuple[list[ActionSummary], list[tuple[ActionSummary, str]]]:
+    """Filter disabled summaries and stably reorder by confidence."""
+    if not summary_feedback:
+        return list(summaries), []
+    kept: list[tuple[int, float, ActionSummary]] = []
+    disabled: list[tuple[ActionSummary, str]] = []
+    for index, summary in enumerate(summaries):
+        record = summary_feedback.get(summary.summary_id)
+        if record is None:
+            kept.append((index, 0.5, summary))
+            continue
+        if _summary_feedback_mod.is_disabled(record):
+            disabled.append((summary, _disabled_reason(record)))
+            continue
+        kept.append((index, _summary_feedback_mod.confidence(record), summary))
+    kept.sort(key=lambda triple: (-triple[1], triple[0]))
+    ordered = [summary for _, _, summary in kept]
+    return ordered, disabled
 
 
 __all__ = ["build_context_pack"]

--- a/photon_action_memory/eval/summary_feedback.py
+++ b/photon_action_memory/eval/summary_feedback.py
@@ -1,0 +1,102 @@
+"""Per-summary feedback aggregation derived from /v1/evaluate outcomes.
+
+Builds on the same fail-open exclusion rules as `anvil_feedback`: error /
+not_available / shadow_not_injected turns do not contribute to per-summary
+confidence. The aggregate is counter-only — no raw prompts, tool output, or
+user text is stored, so the table is safe for future feature extraction.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from photon_action_memory.eval.anvil_feedback import EXCLUDED_QUALITY_STATUSES
+
+_SUCCESS_OUTCOMES: frozenset[str] = frozenset({"success", "accepted", "completed"})
+_SAFETY_OUTCOMES: frozenset[str] = frozenset({"safety_violation", "unsafe", "harmful"})
+_ADOPTED_STATUSES: frozenset[str] = frozenset({"adopted", "partial"})
+
+# Demote / disable thresholds — S2-03 regression pattern: after enough adoptions
+# with predominantly non-success outcomes, the summary is considered unhelpful.
+MIN_ADOPTIONS_FOR_DISABLE: int = 3
+DISABLE_CONFIDENCE_THRESHOLD: float = 0.34
+
+
+@dataclass(frozen=True)
+class SummaryFeedbackRecord:
+    """Per-summary aggregate feedback derived from /v1/evaluate logs.
+
+    All fields are counters or rates. Never carries raw prompt or tool output.
+    """
+
+    summary_id: str
+    adoption_count: int = 0
+    success_count: int = 0
+    failure_count: int = 0
+    safety_violation_count: int = 0
+    expand_request_count: int = 0
+    quality_turns: int = 0
+
+
+def confidence(record: SummaryFeedbackRecord) -> float:
+    """Laplace-smoothed confidence that adopting *summary* leads to success.
+
+    Returns 0.5 when no adoption has been observed (neutral prior), so unseen
+    summaries are not penalised. Smoothing keeps a single failure from pinning
+    confidence to 0.
+    """
+    successes = record.success_count
+    failures = record.failure_count
+    return (successes + 1) / (successes + failures + 2)
+
+
+def is_disabled(record: SummaryFeedbackRecord) -> bool:
+    """Return True if the summary should be excluded from new ContextPacks.
+
+    Disable conditions (in priority order):
+    1. Any safety violation — zero tolerance.
+    2. Repeated adoptions with low confidence (S2-03 regression).
+    """
+    if record.safety_violation_count >= 1:
+        return True
+    if (
+        record.adoption_count >= MIN_ADOPTIONS_FOR_DISABLE
+        and confidence(record) < DISABLE_CONFIDENCE_THRESHOLD
+    ):
+        return True
+    return False
+
+
+def classify_outcome(
+    adoption_status: str,
+    outcome: str | None,
+) -> tuple[bool, str]:
+    """Classify a single evaluate record's contribution.
+
+    Returns a (is_quality_turn, classification) tuple where classification is
+    one of ``"success"``, ``"failure"``, ``"safety"``, or ``"none"``.
+    Non-quality turns (excluded statuses) yield ``(False, "none")``.
+    """
+    if adoption_status in EXCLUDED_QUALITY_STATUSES:
+        return False, "none"
+    if outcome in _SAFETY_OUTCOMES:
+        return True, "safety"
+    if outcome in _SUCCESS_OUTCOMES:
+        return True, "success"
+    return True, "failure"
+
+
+def is_adopted(adoption_status: str) -> bool:
+    """Return True if the record's status counts as adoption."""
+    return adoption_status in _ADOPTED_STATUSES
+
+
+__all__ = [
+    "DISABLE_CONFIDENCE_THRESHOLD",
+    "MIN_ADOPTIONS_FOR_DISABLE",
+    "SummaryFeedbackRecord",
+    "classify_outcome",
+    "confidence",
+    "is_adopted",
+    "is_disabled",
+]

--- a/photon_action_memory/memory/summary_store.py
+++ b/photon_action_memory/memory/summary_store.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Iterable
 from datetime import UTC, datetime
 from pathlib import Path
 
 from photon_action_memory.api.schema_v2 import ActionSummary
+from photon_action_memory.eval.summary_feedback import (
+    SummaryFeedbackRecord,
+    classify_outcome,
+    is_adopted,
+)
 
 
 class SummaryStore:
@@ -119,6 +125,110 @@ class SummaryStore:
         row = self._connection.execute("SELECT COUNT(*) AS cnt FROM action_summaries").fetchone()
         return int(row["cnt"])
 
+    def record_outcomes(
+        self,
+        summary_ids: Iterable[str],
+        *,
+        adoption_status: str,
+        outcome: str | None,
+        evidence_expand_requested: bool = False,
+    ) -> int:
+        """Update per-summary feedback counters from a single /v1/evaluate record.
+
+        Returns the number of rows touched. Excluded statuses (``error``,
+        ``not_available``, ``shadow_not_injected``) and empty ``summary_ids``
+        are no-ops. ``adoption_count`` increments only when the record's
+        status counts as adoption (``adopted`` / ``partial``).
+        """
+        is_quality, classification = classify_outcome(adoption_status, outcome)
+        if not is_quality:
+            return 0
+
+        ids = [sid for sid in summary_ids if sid]
+        if not ids:
+            return 0
+
+        success_inc = 1 if classification == "success" else 0
+        failure_inc = 1 if classification == "failure" else 0
+        safety_inc = 1 if classification == "safety" else 0
+        adoption_inc = 1 if is_adopted(adoption_status) else 0
+        expand_inc = 1 if evidence_expand_requested else 0
+        now = datetime.now(UTC).isoformat(timespec="microseconds")
+
+        rows_touched = 0
+        with self._connection:
+            for sid in ids:
+                self._connection.execute(
+                    """
+                    INSERT INTO summary_feedback (
+                        summary_id, adoption_count, success_count, failure_count,
+                        safety_violation_count, expand_request_count, quality_turns,
+                        updated_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, 1, ?)
+                    ON CONFLICT(summary_id) DO UPDATE SET
+                        adoption_count         = adoption_count         + ?,
+                        success_count          = success_count          + ?,
+                        failure_count          = failure_count          + ?,
+                        safety_violation_count = safety_violation_count + ?,
+                        expand_request_count   = expand_request_count   + ?,
+                        quality_turns          = quality_turns          + 1,
+                        updated_at             = ?
+                    """,
+                    (
+                        sid,
+                        adoption_inc,
+                        success_inc,
+                        failure_inc,
+                        safety_inc,
+                        expand_inc,
+                        now,
+                        adoption_inc,
+                        success_inc,
+                        failure_inc,
+                        safety_inc,
+                        expand_inc,
+                        now,
+                    ),
+                )
+                rows_touched += 1
+        return rows_touched
+
+    def get_feedback(self, summary_id: str) -> SummaryFeedbackRecord | None:
+        row = self._connection.execute(
+            """
+            SELECT summary_id, adoption_count, success_count, failure_count,
+                   safety_violation_count, expand_request_count, quality_turns
+            FROM summary_feedback WHERE summary_id = ?
+            """,
+            (summary_id,),
+        ).fetchone()
+        return _row_to_feedback(row)
+
+    def get_feedback_map(
+        self,
+        summary_ids: Iterable[str],
+    ) -> dict[str, SummaryFeedbackRecord]:
+        """Return feedback records keyed by summary_id; missing IDs are omitted."""
+        ids = [sid for sid in summary_ids if sid]
+        if not ids:
+            return {}
+        placeholders = ",".join("?" * len(ids))
+        rows = self._connection.execute(
+            f"""
+            SELECT summary_id, adoption_count, success_count, failure_count,
+                   safety_violation_count, expand_request_count, quality_turns
+            FROM summary_feedback WHERE summary_id IN ({placeholders})
+            """,
+            ids,
+        ).fetchall()
+        result: dict[str, SummaryFeedbackRecord] = {}
+        for row in rows:
+            record = _row_to_feedback(row)
+            if record is not None:
+                result[record.summary_id] = record
+        return result
+
     def _initialize_schema(self) -> None:
         with self._connection:
             self._connection.executescript(
@@ -140,8 +250,32 @@ class SummaryStore:
                     ON action_summaries (task_signature);
                 CREATE INDEX IF NOT EXISTS idx_summaries_validity
                     ON action_summaries (validity_status);
+                CREATE TABLE IF NOT EXISTS summary_feedback (
+                    summary_id              TEXT PRIMARY KEY,
+                    adoption_count          INTEGER NOT NULL DEFAULT 0,
+                    success_count           INTEGER NOT NULL DEFAULT 0,
+                    failure_count           INTEGER NOT NULL DEFAULT 0,
+                    safety_violation_count  INTEGER NOT NULL DEFAULT 0,
+                    expand_request_count    INTEGER NOT NULL DEFAULT 0,
+                    quality_turns           INTEGER NOT NULL DEFAULT 0,
+                    updated_at              TEXT NOT NULL
+                );
                 """
             )
+
+
+def _row_to_feedback(row: sqlite3.Row | None) -> SummaryFeedbackRecord | None:
+    if row is None:
+        return None
+    return SummaryFeedbackRecord(
+        summary_id=row["summary_id"],
+        adoption_count=int(row["adoption_count"]),
+        success_count=int(row["success_count"]),
+        failure_count=int(row["failure_count"]),
+        safety_violation_count=int(row["safety_violation_count"]),
+        expand_request_count=int(row["expand_request_count"]),
+        quality_turns=int(row["quality_turns"]),
+    )
 
 
 __all__ = ["SummaryStore"]

--- a/tests/test_summary_feedback.py
+++ b/tests/test_summary_feedback.py
@@ -1,0 +1,460 @@
+"""Tests for per-summary feedback tracking and admission demotion (Issue #87).
+
+Acceptance criteria:
+- summary_id ごとに採用回数、成功/失敗、safety outcome を追跡できる。
+- S2-03 型の悪化 summary を低 confidence / disabled として扱える。
+- S3-01 / S5-01 型の有効 summary を優先できる。
+- feedback がなくても deterministic fallback として動作する。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    ActionSummary,
+    ContextPackBudget,
+    Fact,
+    Validity,
+)
+from photon_action_memory.api.server import create_app
+from photon_action_memory.context.pack import build_context_pack
+from photon_action_memory.eval.summary_feedback import (
+    DISABLE_CONFIDENCE_THRESHOLD,
+    MIN_ADOPTIONS_FOR_DISABLE,
+    SummaryFeedbackRecord,
+    classify_outcome,
+    confidence,
+    is_adopted,
+    is_disabled,
+)
+from photon_action_memory.memory.store import SQLiteEventStore
+from photon_action_memory.memory.summary_store import SummaryStore
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _summary(
+    summary_id: str = "sum-1",
+    *,
+    repo_id: str | None = "repo-a",
+    validity_status: str = "valid",
+    fact_text: str = "the thing is true",
+) -> ActionSummary:
+    return ActionSummary(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        summary_id=summary_id,
+        repo_id=repo_id,
+        facts=[Fact(text=fact_text, evidence_ids=["ev-1"])],
+        validity=Validity(status=validity_status),
+    )
+
+
+def _make_client(tmp_path: Path) -> tuple[TestClient, SQLiteEventStore, SummaryStore]:
+    events = SQLiteEventStore(tmp_path / "events.sqlite")
+    summaries = SummaryStore(tmp_path / "summaries.sqlite")
+    return TestClient(create_app(events, summaries)), events, summaries
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_confidence_neutral_prior_for_zero_observations() -> None:
+    record = SummaryFeedbackRecord(summary_id="s")
+    assert confidence(record) == pytest.approx(0.5)
+
+
+def test_confidence_increases_with_success() -> None:
+    record = SummaryFeedbackRecord(summary_id="s", success_count=5, failure_count=0)
+    assert confidence(record) > 0.8
+
+
+def test_confidence_decreases_with_failure() -> None:
+    record = SummaryFeedbackRecord(summary_id="s", success_count=0, failure_count=5)
+    assert confidence(record) < 0.2
+
+
+def test_is_disabled_for_any_safety_violation() -> None:
+    record = SummaryFeedbackRecord(summary_id="s", safety_violation_count=1)
+    assert is_disabled(record) is True
+
+
+def test_is_disabled_after_repeated_failures() -> None:
+    # 4 adoptions, all failing -> low confidence, exceeds adoption threshold
+    record = SummaryFeedbackRecord(
+        summary_id="s",
+        adoption_count=4,
+        failure_count=4,
+        quality_turns=4,
+    )
+    assert is_disabled(record) is True
+
+
+def test_is_disabled_returns_false_for_few_adoptions() -> None:
+    # Below MIN_ADOPTIONS_FOR_DISABLE, even all-failure should not disable.
+    record = SummaryFeedbackRecord(
+        summary_id="s",
+        adoption_count=MIN_ADOPTIONS_FOR_DISABLE - 1,
+        failure_count=MIN_ADOPTIONS_FOR_DISABLE - 1,
+        quality_turns=MIN_ADOPTIONS_FOR_DISABLE - 1,
+    )
+    assert is_disabled(record) is False
+
+
+def test_is_disabled_returns_false_for_high_confidence() -> None:
+    record = SummaryFeedbackRecord(
+        summary_id="s",
+        adoption_count=10,
+        success_count=9,
+        failure_count=1,
+        quality_turns=10,
+    )
+    assert is_disabled(record) is False
+
+
+def test_classify_outcome_excluded_status() -> None:
+    is_quality, kind = classify_outcome("error", None)
+    assert is_quality is False
+    assert kind == "none"
+
+
+def test_classify_outcome_success() -> None:
+    assert classify_outcome("adopted", "success") == (True, "success")
+
+
+def test_classify_outcome_failure() -> None:
+    assert classify_outcome("adopted", "failure") == (True, "failure")
+
+
+def test_classify_outcome_safety_violation() -> None:
+    assert classify_outcome("adopted", "safety_violation") == (True, "safety")
+
+
+def test_classify_outcome_none_outcome_is_failure() -> None:
+    assert classify_outcome("adopted", None) == (True, "failure")
+
+
+def test_is_adopted_true_for_adopted_and_partial() -> None:
+    assert is_adopted("adopted") is True
+    assert is_adopted("partial") is True
+
+
+def test_is_adopted_false_for_ignored() -> None:
+    assert is_adopted("ignored") is False
+
+
+# ---------------------------------------------------------------------------
+# SummaryStore record_outcomes / get_feedback
+# ---------------------------------------------------------------------------
+
+
+def test_record_outcomes_increments_success(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        store.record_outcomes(
+            ["sum-1"],
+            adoption_status="adopted",
+            outcome="success",
+            evidence_expand_requested=False,
+        )
+        rec = store.get_feedback("sum-1")
+    assert rec is not None
+    assert rec.adoption_count == 1
+    assert rec.success_count == 1
+    assert rec.failure_count == 0
+    assert rec.safety_violation_count == 0
+    assert rec.quality_turns == 1
+
+
+def test_record_outcomes_accumulates(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        store.record_outcomes(["sum-1"], adoption_status="adopted", outcome="success")
+        store.record_outcomes(["sum-1"], adoption_status="adopted", outcome="failure")
+        store.record_outcomes(["sum-1"], adoption_status="adopted", outcome="success")
+        rec = store.get_feedback("sum-1")
+    assert rec is not None
+    assert rec.adoption_count == 3
+    assert rec.success_count == 2
+    assert rec.failure_count == 1
+
+
+def test_record_outcomes_skips_excluded_status(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        rows = store.record_outcomes(["sum-1"], adoption_status="error", outcome=None)
+    assert rows == 0
+
+
+def test_record_outcomes_skips_empty_list(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        assert store.record_outcomes([], adoption_status="adopted", outcome="success") == 0
+
+
+def test_record_outcomes_safety_increments_safety_counter(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        store.record_outcomes(["sum-1"], adoption_status="adopted", outcome="safety_violation")
+        rec = store.get_feedback("sum-1")
+    assert rec is not None
+    assert rec.safety_violation_count == 1
+    assert rec.failure_count == 0
+
+
+def test_record_outcomes_ignored_does_not_increment_adoption(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        store.record_outcomes(["sum-1"], adoption_status="ignored", outcome="failure")
+        rec = store.get_feedback("sum-1")
+    assert rec is not None
+    assert rec.adoption_count == 0
+    assert rec.quality_turns == 1
+    assert rec.failure_count == 1
+
+
+def test_get_feedback_map_returns_only_known_ids(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        store.record_outcomes(["sum-a"], adoption_status="adopted", outcome="success")
+        result = store.get_feedback_map(["sum-a", "sum-missing"])
+    assert "sum-a" in result
+    assert "sum-missing" not in result
+
+
+def test_get_feedback_returns_none_for_missing(tmp_path: Path) -> None:
+    with SummaryStore(tmp_path / "s.sqlite") as store:
+        assert store.get_feedback("nope") is None
+
+
+# ---------------------------------------------------------------------------
+# build_context_pack: feedback admission
+# ---------------------------------------------------------------------------
+
+
+def test_build_pack_disables_low_confidence_summary() -> None:
+    bad = _summary("sum-bad", fact_text="alpha bravo fact")
+    good = _summary("sum-good", fact_text="charlie delta fact")
+    feedback = {
+        "sum-bad": SummaryFeedbackRecord(
+            summary_id="sum-bad",
+            adoption_count=4,
+            failure_count=4,
+            quality_turns=4,
+        ),
+    }
+    pack, decisions = build_context_pack(
+        request_id="req-1",
+        session_id=None,
+        repo_id="repo-a",
+        summaries=[bad, good],
+        budget=ContextPackBudget(max_memory_tokens=4000),
+        summary_feedback=feedback,
+    )
+    admitted_ids = {item.id for item in pack.items}
+    assert "sum-bad" not in admitted_ids
+    assert "sum-good" in admitted_ids
+    deny_decisions = [d for d in decisions if d.decision == "deny"]
+    assert any(d.item_id == "sum-bad" for d in deny_decisions)
+    assert any("disabled by feedback" in (d.reason or "") for d in deny_decisions)
+
+
+def test_build_pack_disables_summary_with_safety_violation() -> None:
+    unsafe = _summary("sum-unsafe")
+    feedback = {
+        "sum-unsafe": SummaryFeedbackRecord(
+            summary_id="sum-unsafe",
+            adoption_count=1,
+            safety_violation_count=1,
+            quality_turns=1,
+        ),
+    }
+    pack, decisions = build_context_pack(
+        request_id="req-1",
+        session_id=None,
+        repo_id="repo-a",
+        summaries=[unsafe],
+        budget=ContextPackBudget(max_memory_tokens=4000),
+        summary_feedback=feedback,
+    )
+    assert pack.items == []
+    omitted_reasons = {o.reason for o in pack.omitted}
+    assert any("safety_violation" in r for r in omitted_reasons)
+
+
+def test_build_pack_prefers_high_confidence_under_tight_budget() -> None:
+    """Higher-confidence summaries win the token budget vs unseen ones."""
+    high = _summary("sum-high", fact_text="alpha bravo charlie delta echo")
+    low_prior = _summary("sum-prior", fact_text="foxtrot golf hotel india juliet")
+    feedback = {
+        "sum-high": SummaryFeedbackRecord(
+            summary_id="sum-high",
+            adoption_count=10,
+            success_count=10,
+            quality_turns=10,
+        ),
+    }
+    pack, _ = build_context_pack(
+        request_id="req-1",
+        session_id=None,
+        repo_id="repo-a",
+        summaries=[low_prior, high],
+        budget=ContextPackBudget(max_memory_tokens=20),
+        summary_feedback=feedback,
+    )
+    admitted_ids = [item.id for item in pack.items]
+    assert admitted_ids[0] == "sum-high"
+
+
+def test_build_pack_without_feedback_preserves_order() -> None:
+    a = _summary("sum-a", fact_text="alpha fact")
+    b = _summary("sum-b", fact_text="bravo fact")
+    pack, _ = build_context_pack(
+        request_id="req-1",
+        session_id=None,
+        repo_id="repo-a",
+        summaries=[a, b],
+        budget=ContextPackBudget(max_memory_tokens=4000),
+    )
+    admitted_ids = [item.id for item in pack.items]
+    assert admitted_ids == ["sum-a", "sum-b"]
+
+
+def test_build_pack_with_empty_feedback_map_preserves_order() -> None:
+    """Deterministic fallback: empty feedback acts identically to None."""
+    a = _summary("sum-a", fact_text="alpha fact")
+    b = _summary("sum-b", fact_text="bravo fact")
+    pack, _ = build_context_pack(
+        request_id="req-1",
+        session_id=None,
+        repo_id="repo-a",
+        summaries=[a, b],
+        budget=ContextPackBudget(max_memory_tokens=4000),
+        summary_feedback={},
+    )
+    admitted_ids = [item.id for item in pack.items]
+    assert admitted_ids == ["sum-a", "sum-b"]
+
+
+# ---------------------------------------------------------------------------
+# /v1/evaluate + /v1/context/pack end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_records_summary_outcomes(tmp_path: Path) -> None:
+    client, _, summaries = _make_client(tmp_path)
+    body = {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "eval-1",
+        "context_pack_event": {
+            "context_pack_request_id": "pack-1",
+            "adoption_status": "adopted",
+            "summary_ids_adopted": ["sum-x"],
+            "outcome": "success",
+        },
+    }
+    response = client.post("/v1/evaluate", json=body)
+    assert response.status_code == 200
+    record = summaries.get_feedback("sum-x")
+    assert record is not None
+    assert record.success_count == 1
+    assert record.adoption_count == 1
+
+
+def test_evaluate_without_summary_ids_is_noop(tmp_path: Path) -> None:
+    client, _, summaries = _make_client(tmp_path)
+    body = {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "eval-2",
+        "context_pack_event": {
+            "context_pack_request_id": "pack-2",
+            "adoption_status": "adopted",
+            "outcome": "success",
+        },
+    }
+    response = client.post("/v1/evaluate", json=body)
+    assert response.status_code == 200
+    assert summaries.get_feedback_map(["any"]) == {}
+
+
+def test_evaluate_safety_violation_recorded(tmp_path: Path) -> None:
+    client, _, summaries = _make_client(tmp_path)
+    body = {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "eval-3",
+        "context_pack_event": {
+            "context_pack_request_id": "pack-3",
+            "adoption_status": "adopted",
+            "summary_ids_adopted": ["sum-unsafe"],
+            "outcome": "safety_violation",
+        },
+    }
+    response = client.post("/v1/evaluate", json=body)
+    assert response.status_code == 200
+    rec = summaries.get_feedback("sum-unsafe")
+    assert rec is not None
+    assert rec.safety_violation_count == 1
+    assert is_disabled(rec) is True
+
+
+def test_evaluate_then_pack_filters_disabled(tmp_path: Path) -> None:
+    """End-to-end: bad outcomes accumulate, /v1/context/pack omits the summary."""
+    client, _, summaries = _make_client(tmp_path)
+    # Seed a summary
+    summaries.upsert(_summary("sum-bad", fact_text="alpha bravo fact"))
+    summaries.upsert(_summary("sum-good", fact_text="charlie delta fact"))
+
+    # Record several failures for sum-bad (above MIN_ADOPTIONS_FOR_DISABLE).
+    for i in range(MIN_ADOPTIONS_FOR_DISABLE + 1):
+        client.post(
+            "/v1/evaluate",
+            json={
+                "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+                "request_id": f"eval-bad-{i}",
+                "context_pack_event": {
+                    "context_pack_request_id": f"pack-bad-{i}",
+                    "adoption_status": "adopted",
+                    "summary_ids_adopted": ["sum-bad"],
+                    "outcome": "failure",
+                },
+            },
+        )
+
+    rec = summaries.get_feedback("sum-bad")
+    assert rec is not None and is_disabled(rec)
+    assert confidence(rec) < DISABLE_CONFIDENCE_THRESHOLD
+
+    pack_response = client.post(
+        "/v1/context/pack",
+        json={
+            "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+            "request_id": "ctx-1",
+            "agent": {"name": "anvil"},
+            "repo": {"root": "/r", "name": "repo-a"},
+            "task": {"user_request": "x", "mode": "act"},
+            "working_memory": {},
+            "candidate_summary_ids": ["sum-bad", "sum-good"],
+        },
+    )
+    assert pack_response.status_code == 200
+    body = pack_response.json()
+    admitted_ids = {item["id"] for item in body["context_pack"]["items"]}
+    assert "sum-bad" not in admitted_ids
+    assert "sum-good" in admitted_ids
+
+
+def test_evaluate_excluded_status_does_not_update_feedback(tmp_path: Path) -> None:
+    client, _, summaries = _make_client(tmp_path)
+    body = {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "eval-err-1",
+        "context_pack_event": {
+            "context_pack_request_id": "pack-err",
+            "adoption_status": "error",
+            "summary_ids_adopted": ["sum-x"],
+        },
+    }
+    response = client.post("/v1/evaluate", json=body)
+    assert response.status_code == 200
+    assert summaries.get_feedback("sum-x") is None


### PR DESCRIPTION
Closes #87

## Summary

- Anvil 評価では、seed の価値は scenario ごとに大きく異なる。S3-01 / S5-01 は改善し、S2-03 は退化した。固定 seed ではなく、実行結果から summary の信頼度を更新する必要がある。

## Changed Files

- `photon_action_memory/api/server.py`
- `photon_action_memory/eval/anvil_feedback.py`
- `photon_action_memory/ranking/feedback.py`

## Tests Run

- 未実行

## Known Risks

- None recorded by orchestration planner.

## Orchestration

- Run ID: `20260513-102053-orchestrate`
