### PR TITLE
#85 [v0.4.0] P1: summarize quality gate で task overlap と早期終了リスクを抑制する

### DIFF
--- a/dev-reports/issue-85/design.md
+++ b/dev-reports/issue-85/design.md
@@ -1,0 +1,27 @@
+# Issue #85 Design
+
+## Goal
+
+Prevent low-value Anvil summaries from becoming prompt-visible when they mostly
+repeat the current task or encourage premature termination. Keep meta-information
+summaries, especially verifier or repo-specific policy guidance, admissible.
+
+## Approach
+
+- Add a small deterministic quality gate before ContextPack admission.
+- Compare the current task text with each summary's prompt-visible fields.
+- Reject high-overlap summaries when they add little new information and contain
+  direct next-step hints likely to shortcut exploration.
+- Keep verifier/meta-information summaries even when they contain some task
+  vocabulary.
+- Record the decision in both admission decisions and omitted items so Anvil can
+  inspect why a summary was not injected.
+
+## Scope
+
+- Implement the gate in the context packing path, where prompt visibility is
+  decided.
+- Pass task text from `POST /v1/context/pack` into the pack builder.
+- Add focused regression tests for S2-03-style low-value guidance and S5-01-style
+  meta-information guidance.
+

--- a/dev-reports/issue-85/implementation-summary.md
+++ b/dev-reports/issue-85/implementation-summary.md
@@ -1,0 +1,22 @@
+# Issue #85 Implementation Summary
+
+## Changes
+
+- Added `photon_action_memory.context.quality_gate` with deterministic task-overlap
+  and premature-termination checks for `ActionSummary` candidates.
+- Integrated the quality gate into `build_context_pack()` before normal admission.
+- Passed current task text from `POST /v1/context/pack` into the pack builder.
+- Recorded rejected summaries in both `context_pack.omitted` and
+  `admission_decisions` with `policy.detail_level=summarize_quality_gate`.
+- Added warnings for direct next hints that overlap the current task.
+- Added regression tests for:
+  - S2-03-style task-overlap seed rejection.
+  - S5-01-style meta-information seed retention.
+  - API-level quality gate response visibility.
+
+## Notes
+
+The gate is intentionally conservative. It does not reject summaries with
+explicit repo-policy or verifier meta-information such as `ANVIL.md`,
+`custom_check.py`, or `do not use pytest`.
+

--- a/dev-reports/issue-85/verification.md
+++ b/dev-reports/issue-85/verification.md
@@ -1,0 +1,26 @@
+# Issue #85 Verification
+
+## Commands
+
+```bash
+PYTHONPATH=. pytest -q tests/test_context_pack.py
+RUFF_CACHE_DIR=/tmp/ruff-cache-issue85 ruff format --check .
+RUFF_CACHE_DIR=/tmp/ruff-cache-issue85 ruff check .
+mypy photon_action_memory tests
+PYTHONPATH=. pytest -q -p no:cacheprovider tests/test_context_pack.py tests/test_anvil_context_pack_api.py tests/test_schema_v2.py tests/test_summary_feedback.py
+PYTHONPATH=. pytest -q -p no:cacheprovider
+```
+
+## Results
+
+- `tests/test_context_pack.py`: 41 passed
+- `ruff format --check .`: 98 files already formatted
+- `ruff check .`: All checks passed
+- `mypy photon_action_memory tests`: no issues in 92 source files
+- Focused regression suite: 154 passed
+- Full pytest suite: 868 passed, 1 skipped
+
+## Skip
+
+- `tests/integration/test_mlx_smoke.py` is opt-in outside the dedicated macOS workflow.
+

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -169,6 +169,7 @@ def create_app(
                 warnings=route_warnings,
                 raw_items=raw_items,
                 summary_feedback=feedback_map,
+                task_text=_context_task_text(request),
             )
             sidecar_status = "degraded" if route_warnings else "ok"
         except Exception as exc:
@@ -775,6 +776,14 @@ def _context_task_signature(request: ContextPackRequest) -> str | None:
         return None
     task_signature = str(raw).strip()
     return task_signature or None
+
+
+def _context_task_text(request: ContextPackRequest) -> str:
+    """Return task text used by task-aware ContextPack quality gates."""
+    parts = [request.task.user_request]
+    if request.task.summary:
+        parts.append(request.task.summary)
+    return "\n".join(part for part in parts if part)
 
 
 def build_fallback_suggestions(request: SuggestRequest) -> SuggestResponse:

--- a/photon_action_memory/context/pack.py
+++ b/photon_action_memory/context/pack.py
@@ -17,6 +17,7 @@ from photon_action_memory.api.schema_v2 import (
 )
 from photon_action_memory.context.admission import ContextAdmissionController
 from photon_action_memory.context.budget import TokenBudgetTracker
+from photon_action_memory.context.quality_gate import evaluate_summary_quality
 from photon_action_memory.context.raw_policy import RawEvidenceItem, evaluate_raw_item
 from photon_action_memory.context.render import estimate_tokens, render_summary
 from photon_action_memory.eval import summary_feedback as _summary_feedback_mod
@@ -28,6 +29,11 @@ _RAW_ADMISSION_POLICY = AdmissionPolicy(raw_evidence_policy="raw_tool_log_defaul
 def _raw_decision_id(item_id: str) -> str:
     digest = hashlib.sha256(item_id.encode()).hexdigest()[:12]
     return f"dec-raw-{digest}"
+
+
+def _quality_decision_id(item_id: str) -> str:
+    digest = hashlib.sha256(item_id.encode()).hexdigest()[:12]
+    return f"dec-quality-{digest}"
 
 
 def _disabled_reason(record: SummaryFeedbackRecord) -> str:
@@ -46,6 +52,7 @@ def build_context_pack(
     warnings: list[ContextPackWarning] | None = None,
     raw_items: list[RawEvidenceItem] | None = None,
     summary_feedback: dict[str, SummaryFeedbackRecord] | None = None,
+    task_text: str | None = None,
 ) -> tuple[ContextPack, list[ContextAdmissionDecision]]:
     """Run the admission pipeline and return a ContextPack with decisions.
 
@@ -66,6 +73,7 @@ def build_context_pack(
     items: list[ContextPackItem] = []
     omitted: list[OmittedItem] = []
     decisions: list[ContextAdmissionDecision] = []
+    pack_warnings = list(warnings or [])
 
     ordered_summaries, disabled_summaries = _apply_feedback(summaries, summary_feedback)
     for disabled_summary, disabled_reason in disabled_summaries:
@@ -79,6 +87,32 @@ def build_context_pack(
         )
 
     for summary in ordered_summaries:
+        quality = evaluate_summary_quality(summary, task_text)
+        for message in quality.warnings:
+            pack_warnings.append(ContextPackWarning(kind="summary_quality_gate", message=message))
+        if quality.decision == "reject":
+            quality_reason = quality.reason or "summary quality gate rejected"
+            decisions.append(
+                ContextAdmissionDecision(
+                    schema_version=DEFAULT_SCHEMA_VERSION_V2,
+                    decision_id=_quality_decision_id(summary.summary_id),
+                    item_id=summary.summary_id,
+                    item_kind="action_summary",
+                    decision="deny",
+                    reason=quality_reason,
+                    risk=quality.risk,
+                    policy=AdmissionPolicy(detail_level="summarize_quality_gate"),
+                )
+            )
+            omitted.append(
+                OmittedItem(
+                    kind="action_summary",
+                    id=summary.summary_id,
+                    reason=quality_reason,
+                )
+            )
+            continue
+
         decision, reason = controller.evaluate(summary)
         decisions.append(controller.make_decision(summary, decision, reason))
 
@@ -139,7 +173,7 @@ def build_context_pack(
         mode="summary_only",
         items=items,
         omitted=omitted,
-        warnings=warnings or [],
+        warnings=pack_warnings,
         token_budget=tracker.to_token_budget(),
     )
     return pack, decisions

--- a/photon_action_memory/context/quality_gate.py
+++ b/photon_action_memory/context/quality_gate.py
@@ -1,0 +1,190 @@
+"""Task-aware quality gate for prompt-visible ActionSummary admission."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from photon_action_memory.api.schema_v2 import ActionSummary
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "at",
+        "be",
+        "by",
+        "for",
+        "from",
+        "in",
+        "into",
+        "is",
+        "it",
+        "of",
+        "on",
+        "or",
+        "that",
+        "the",
+        "this",
+        "to",
+        "with",
+    }
+)
+_DIRECT_NEXT_ACTIONS = frozenset(
+    {
+        "add",
+        "change",
+        "create",
+        "implement",
+        "insert",
+        "modify",
+        "replace",
+        "set",
+        "update",
+        "use",
+        "write",
+    }
+)
+_META_MARKERS = (
+    "anvil.md",
+    "custom_check.py",
+    "do not use pytest",
+    "preferred verifier",
+    "use python3 custom_check.py",
+)
+_VERIFY_MARKERS = (
+    "before final",
+    "final answer",
+    "run verification",
+    "run verifier",
+    "verify before",
+)
+
+
+@dataclass(frozen=True)
+class SummaryQualityGateResult:
+    """Result of task-aware quality evaluation for one summary."""
+
+    decision: str
+    reason: str | None = None
+    risk: str | None = None
+    warnings: tuple[str, ...] = ()
+    task_overlap: float = 0.0
+    novel_ratio: float = 1.0
+
+
+def evaluate_summary_quality(
+    summary: ActionSummary, task_text: str | None
+) -> SummaryQualityGateResult:
+    """Reject summaries that mostly repeat the current task and shortcut exploration."""
+    task_tokens = _tokens(task_text or "")
+    if not task_tokens:
+        return SummaryQualityGateResult(decision="allow")
+
+    summary_text = _summary_prompt_text(summary)
+    summary_tokens = _tokens(summary_text)
+    if not summary_tokens:
+        return SummaryQualityGateResult(decision="allow")
+
+    overlap = len(summary_tokens & task_tokens) / len(summary_tokens)
+    novel_ratio = len(summary_tokens - task_tokens) / len(summary_tokens)
+    meta_info = _has_meta_information(summary_text)
+    verification_guidance = _has_verification_guidance(summary)
+    premature_risk = _has_premature_termination_risk(summary, task_tokens)
+
+    warnings: list[str] = []
+    if premature_risk:
+        warnings.append(
+            f"{summary.summary_id}: premature_termination_risk: "
+            "direct next_hint overlaps current task"
+        )
+
+    if meta_info or verification_guidance:
+        return SummaryQualityGateResult(
+            decision="allow",
+            warnings=tuple(warnings),
+            task_overlap=overlap,
+            novel_ratio=novel_ratio,
+        )
+
+    low_value_overlap = overlap >= 0.50 and novel_ratio <= 0.50
+    shortcut_overlap = premature_risk and overlap >= 0.30
+    if low_value_overlap or shortcut_overlap:
+        reason = (
+            "summary quality gate rejected: low_value task overlap "
+            f"(overlap={overlap:.2f}, novel={novel_ratio:.2f})"
+        )
+        if premature_risk:
+            reason += "; premature_termination_risk"
+        return SummaryQualityGateResult(
+            decision="reject",
+            reason=reason,
+            risk="medium" if premature_risk else "low",
+            warnings=tuple(warnings),
+            task_overlap=overlap,
+            novel_ratio=novel_ratio,
+        )
+
+    return SummaryQualityGateResult(
+        decision="allow",
+        warnings=tuple(warnings),
+        task_overlap=overlap,
+        novel_ratio=novel_ratio,
+    )
+
+
+def _tokens(text: str) -> set[str]:
+    return {token for token in _TOKEN_RE.findall(text.lower()) if token not in _STOPWORDS}
+
+
+def _summary_prompt_text(summary: ActionSummary) -> str:
+    parts: list[str] = []
+    parts.extend(fact.text for fact in summary.facts)
+    parts.extend(hyp.text for hyp in summary.hypotheses)
+    parts.extend(failed.action for failed in summary.failed_attempts)
+    parts.extend(failed.outcome for failed in summary.failed_attempts)
+    for avoid in summary.avoid:
+        parts.append(avoid.action)
+        parts.append(avoid.reason)
+    for hint in summary.next_hints:
+        parts.append(hint.kind)
+        if hint.target:
+            parts.append(hint.target)
+        parts.append(hint.reason)
+    return "\n".join(part for part in parts if part)
+
+
+def _has_meta_information(text: str) -> bool:
+    lowered = text.lower()
+    return any(marker in lowered for marker in _META_MARKERS)
+
+
+def _has_verification_guidance(summary: ActionSummary) -> bool:
+    for hint in summary.next_hints:
+        text = f"{hint.kind} {hint.reason}".lower()
+        if hint.kind.lower() in {"verify", "test"}:
+            return True
+        if any(marker in text for marker in _VERIFY_MARKERS):
+            return True
+    return False
+
+
+def _has_premature_termination_risk(summary: ActionSummary, task_tokens: set[str]) -> bool:
+    for hint in summary.next_hints:
+        if hint.kind.lower() in {"verify", "test", "inspect", "read"}:
+            continue
+        hint_tokens = _tokens(f"{hint.kind} {hint.target or ''} {hint.reason}")
+        if not hint_tokens:
+            continue
+        direct_action = bool(hint_tokens & _DIRECT_NEXT_ACTIONS)
+        overlap = len(hint_tokens & task_tokens) / len(hint_tokens)
+        if direct_action and overlap >= 0.35:
+            return True
+    return False
+
+
+__all__ = ["SummaryQualityGateResult", "evaluate_summary_quality"]

--- a/tests/test_context_pack.py
+++ b/tests/test_context_pack.py
@@ -23,6 +23,7 @@ from photon_action_memory.api.schema_v2 import (
     Fact,
     FailedAttempt,
     Hypothesis,
+    NextHint,
     TokenCost,
     Validity,
 )
@@ -49,6 +50,7 @@ def _make_summary(
     hypotheses: list[Hypothesis] | None = None,
     failed_attempts: list[FailedAttempt] | None = None,
     avoid: list[AvoidGuidance] | None = None,
+    next_hints: list[NextHint] | None = None,
     validity_status: str = "valid",
     token_cost: TokenCost | None = None,
 ) -> ActionSummary:
@@ -62,6 +64,7 @@ def _make_summary(
         hypotheses=hypotheses or [],
         failed_attempts=failed_attempts or [],
         avoid=avoid or [],
+        next_hints=next_hints or [],
         validity=Validity(status=validity_status),
         token_cost=token_cost,
     )
@@ -77,6 +80,10 @@ def _hypothesis(text: str) -> Hypothesis:
 
 def _failed(action: str) -> FailedAttempt:
     return FailedAttempt(action=action, outcome="error", evidence_ids=[])
+
+
+def _hint(kind: str, reason: str, target: str | None = None) -> NextHint:
+    return NextHint(kind=kind, target=target, reason=reason, confidence=0.8)
 
 
 # ---------------------------------------------------------------------------
@@ -407,6 +414,74 @@ def test_build_context_pack_failed_attempt_and_avoid_admitted() -> None:
     assert "AVOID:" in pack.items[0].text
 
 
+def test_build_context_pack_rejects_s2_style_task_overlap_seed() -> None:
+    task_text = (
+        "Create a SvelteKit page in src/routes/+page.svelte with at least one "
+        "interactive HTML element. Do not use React or Next.js."
+    )
+    summary = _make_summary(
+        "sum-s2-overlap",
+        facts=[
+            _fact(
+                "Repo S2-03 is a SvelteKit project. The main page is "
+                "src/routes/+page.svelte. verify.mjs checks that the page contains "
+                "at least one interactive HTML element and does not use React or Next.js."
+            )
+        ],
+        next_hints=[_hint("edit", "Add a native Svelte interactive element such as a button.")],
+    )
+
+    pack, decisions = build_context_pack(
+        request_id="req-quality-s2",
+        session_id=None,
+        repo_id=None,
+        summaries=[summary],
+        budget=ContextPackBudget(),
+        task_text=task_text,
+    )
+
+    assert pack.items == []
+    assert pack.omitted[0].id == "sum-s2-overlap"
+    assert "low_value task overlap" in pack.omitted[0].reason
+    assert "premature_termination_risk" in pack.omitted[0].reason
+    assert decisions[0].decision == "deny"
+    assert decisions[0].policy is not None
+    assert decisions[0].policy.detail_level == "summarize_quality_gate"
+    assert pack.warnings[0].kind == "summary_quality_gate"
+
+
+def test_build_context_pack_keeps_s5_style_meta_information_seed() -> None:
+    summary = _make_summary(
+        "sum-s5-meta",
+        facts=[
+            _fact(
+                "ANVIL.md specifies preferred verifier: python3 custom_check.py. "
+                "Do not use pytest for this fixture."
+            )
+        ],
+        avoid=[
+            AvoidGuidance(
+                action="use pytest for verification",
+                reason="ANVIL.md says python3 custom_check.py is the verifier",
+            )
+        ],
+    )
+
+    pack, decisions = build_context_pack(
+        request_id="req-quality-s5",
+        session_id=None,
+        repo_id=None,
+        summaries=[summary],
+        budget=ContextPackBudget(),
+        task_text="Fix the fixture and verify it before the final answer.",
+    )
+
+    assert [item.id for item in pack.items] == ["sum-s5-meta"]
+    assert pack.omitted == []
+    assert decisions[0].decision == "admit"
+    assert "custom_check.py" in pack.items[0].text
+
+
 # ---------------------------------------------------------------------------
 # API integration - POST /v1/context/pack
 # ---------------------------------------------------------------------------
@@ -608,6 +683,40 @@ def test_context_pack_api_auto_search_excludes_stale_and_omits_empty(
     assert item_ids == {"sum-valid"}
     assert "sum-stale" not in item_ids
     assert omitted_ids == {"sum-empty"}
+
+
+def test_context_pack_api_reports_quality_gate_rejection(tmp_path: Path) -> None:
+    ss = SummaryStore(tmp_path / "summaries.sqlite")
+    ss.upsert(
+        _make_summary(
+            "sum-s2-api",
+            repo_id="photon-test",
+            facts=[
+                _fact(
+                    "Repo S2-03 is a SvelteKit project. The main page is "
+                    "src/routes/+page.svelte. verify.mjs checks that the page contains "
+                    "at least one interactive HTML element and does not use React or Next.js."
+                )
+            ],
+            next_hints=[_hint("edit", "Add a native Svelte interactive element such as a button.")],
+        )
+    )
+    body = _pack_request()
+    body["task"]["user_request"] = (
+        "Create a SvelteKit page in src/routes/+page.svelte with at least one "
+        "interactive HTML element. Do not use React or Next.js."
+    )
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"), summary_store=ss)
+    with TestClient(app) as client:
+        response = client.post("/v1/context/pack", json=body)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["context_pack"]["items"] == []
+    assert payload["context_pack"]["omitted"][0]["id"] == "sum-s2-api"
+    assert "low_value task overlap" in payload["context_pack"]["omitted"][0]["reason"]
+    assert payload["admission_decisions"][0]["decision"] == "deny"
+    assert payload["context_pack"]["warnings"][0]["kind"] == "summary_quality_gate"
 
 
 def test_context_pack_api_masks_prompt_visible_summary_secrets(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #85

## Summary
- Add a task-aware ContextPack quality gate for low-value task-overlap summaries.
- Reject S2-03-style duplicate guidance with premature termination risk before prompt injection.
- Keep S5-01-style meta-information / verifier guidance admissible.
- Surface quality gate reasons through context_pack.omitted, admission_decisions, and warnings.

## Changed Files
- photon_action_memory/context/quality_gate.py
- photon_action_memory/context/pack.py
- photon_action_memory/api/server.py
- tests/test_context_pack.py
- dev-reports/issue-85/*

## Tests Run
- PYTHONPATH=. pytest -q tests/test_context_pack.py
- RUFF_CACHE_DIR=/tmp/ruff-cache-issue85 ruff format --check .
- RUFF_CACHE_DIR=/tmp/ruff-cache-issue85 ruff check .
- mypy photon_action_memory tests
- PYTHONPATH=. pytest -q -p no:cacheprovider tests/test_context_pack.py tests/test_anvil_context_pack_api.py tests/test_schema_v2.py tests/test_summary_feedback.py
- PYTHONPATH=. pytest -q -p no:cacheprovider

## Known Risks
- Quality gate thresholds are heuristic and intentionally conservative; future Anvil evals should tune them with more S2/S5-like fixtures.

## Orchestration
- Run ID: 20260513-125500-orchestrate
- CommandMate dispatch was blocked because the new worktree was not visible to CommandMate; Codex completed the issue directly in the dedicated worktree.