### PR TITLE
feat(seeds): add cross-lingual EN eval seeds

### DIFF
--- a/dev-reports/issue-101/design.md
+++ b/dev-reports/issue-101/design.md
@@ -1,0 +1,32 @@
+# Design Note - Issue #101
+
+## Goal
+
+Anvil's `cross_lingual` scenario set uses workdir basenames as photon `repo_id`
+values. The English variants use `S2-03-en`, `S3-01-en`, and `S5-01-en`, while
+the current photon seed fixtures only cover `S2-03`, `S3-01`, and `S5-01`.
+
+Add seed fixtures for the three English workdir names so `/v1/context/pack`
+retrieval can exercise photon injection for both the JP and EN sides of the
+scenario pair.
+
+## Approach
+
+- Add three ActionSummary fixtures under `tests/fixtures/shared/`:
+  - `anvil_eval_s2_03_en_action_summary.json`
+  - `anvil_eval_s3_01_en_action_summary.json`
+  - `anvil_eval_s5_01_en_action_summary.json`
+- Keep the existing scenario content and bilingual `lang=en/ja` facts and hints,
+  but change `repo_id`, `summary_id`, `session_id`, chunk ids, and evidence ids
+  to the `*-en` scenario names.
+- Register the fixtures in `scripts/seed_expanded_eval_scenarios.sh`.
+- Extend fixture tests so the new files validate as `ActionSummary`, fit the
+  context-pack budget, are referenced by the seed script, and are retrievable
+  through an exact `repo_id` match.
+
+## Verification
+
+- Focused pytest for the seed fixture suite.
+- Script dry-run for each new fixture through `seed_live_injection_summary.py`.
+- Local sidecar smoke: upsert the new fixtures and confirm `/v1/context/pack`
+  returns an admitted item for `S2-03-en`, `S3-01-en`, and `S5-01-en`.

--- a/dev-reports/issue-101/implementation-summary.md
+++ b/dev-reports/issue-101/implementation-summary.md
@@ -1,0 +1,25 @@
+# Implementation Summary - Issue #101
+
+## Changes
+
+- Added three Anvil cross-lingual English workdir seed fixtures:
+  - `tests/fixtures/shared/anvil_eval_s2_03_en_action_summary.json`
+  - `tests/fixtures/shared/anvil_eval_s3_01_en_action_summary.json`
+  - `tests/fixtures/shared/anvil_eval_s5_01_en_action_summary.json`
+- Updated `scripts/seed_expanded_eval_scenarios.sh` to seed the three new
+  fixtures.
+- Extended `tests/test_anvil_eval_multilingual_seeds.py` so the new fixtures:
+  - validate as `ActionSummary`;
+  - keep EN/JA variants for facts, hints, and avoid entries;
+  - fit the default context-pack budget;
+  - are referenced by the seed script;
+  - resolve through exact Anvil-style `repo.name` values:
+    `S2-03-en`, `S3-01-en`, and `S5-01-en`.
+
+## Notes
+
+The new fixtures intentionally keep the same task content as the existing
+non-`-en` scenario seeds while changing `repo_id` and id fields to match Anvil's
+English workdir basenames. This isolates the intended cross-lingual evaluation
+variable: JP tasks and EN tasks can now both retrieve photon memory, instead of
+the EN side accidentally running with no seed.

--- a/dev-reports/issue-101/verification.md
+++ b/dev-reports/issue-101/verification.md
@@ -1,0 +1,44 @@
+# Verification - Issue #101
+
+## Automated Checks
+
+- `python -m pytest tests/test_anvil_eval_multilingual_seeds.py -q`
+  - PASS: 52 passed
+- `python -m pytest tests/test_anvil_eval_multilingual_seeds.py tests/test_shared_fixtures.py -q`
+  - PASS: 62 passed
+- `python -m ruff format --check .`
+  - PASS: 101 files already formatted
+- `python -m ruff check .`
+  - PASS: All checks passed
+- `python -m mypy photon_action_memory tests`
+  - PASS: no issues found in 95 source files
+
+## Seed Dry Run
+
+Validated `seed_live_injection_summary.py --dry-run` for:
+
+- `anvil_eval_s2_03_en_action_summary.json`
+- `anvil_eval_s3_01_en_action_summary.json`
+- `anvil_eval_s5_01_en_action_summary.json`
+
+Each dry run emitted an `/v1/summary/upsert` payload with the expected
+`repo_id` and request id.
+
+## Curl Smoke
+
+Started a temporary sidecar from this branch on `127.0.0.1:18767` with isolated
+SQLite files:
+
+- `/tmp/photon-action-memory-issue-101-events.sqlite`
+- `/tmp/photon-action-memory-issue-101-summaries.sqlite`
+
+Seeded the three new fixtures, then called `/v1/context/pack` with Anvil-style
+repo names:
+
+| repo_id | result |
+| --- | --- |
+| `S2-03-en` | `sidecar_status=ok`, item `anvil-eval-s2-03-en-svelte-001`, decision `admit` |
+| `S3-01-en` | `sidecar_status=ok`, item `anvil-eval-s3-01-en-calculator-001`, decision `admit` |
+| `S5-01-en` | `sidecar_status=ok`, item `anvil-eval-s5-01-en-tool-double-001`, decision `admit` |
+
+The temporary sidecar process was stopped after verification.

--- a/scripts/seed_expanded_eval_scenarios.sh
+++ b/scripts/seed_expanded_eval_scenarios.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Seed photon memories for Anvil expanded eval scenarios with multilingual variants (Issue #98).
-# Each fixture carries lang=en/ja paired facts/next_hints/avoid for JA Anvil task alignment.
+# Seed photon memories for Anvil expanded eval scenarios with multilingual variants.
+# Each fixture carries lang=en/ja paired facts/next_hints/avoid for Anvil task alignment.
+# The *-en fixtures cover Anvil cross_lingual workdir repo_id values (Issue #101).
 # Run from the photon-action-memory repo root.
 set -euo pipefail
 
@@ -10,10 +11,13 @@ FIXTURES="$SCRIPT_DIR/../tests/fixtures/shared"
 SEEDS=(
   "anvil_eval_s1_02_action_summary.json:seed-anvil-eval-s1-02-001"
   "anvil_eval_s2_03_action_summary.json:seed-anvil-eval-s2-03-001"
+  "anvil_eval_s2_03_en_action_summary.json:seed-anvil-eval-s2-03-en-001"
   "anvil_eval_s3_01_action_summary.json:seed-anvil-eval-s3-01-001"
+  "anvil_eval_s3_01_en_action_summary.json:seed-anvil-eval-s3-01-en-001"
   "anvil_eval_s3_03_action_summary.json:seed-anvil-eval-s3-03-001"
   "anvil_eval_s3_04_action_summary.json:seed-anvil-eval-s3-04-001"
   "anvil_eval_s5_01_action_summary.json:seed-anvil-eval-s5-01-001"
+  "anvil_eval_s5_01_en_action_summary.json:seed-anvil-eval-s5-01-en-001"
   "anvil_eval_s6_04_action_summary.json:seed-anvil-eval-s6-04-001"
   "anvil_eval_sp01_action_summary.json:seed-anvil-eval-sp01-codename-001"
 )

--- a/tests/fixtures/shared/anvil_eval_s2_03_en_action_summary.json
+++ b/tests/fixtures/shared/anvil_eval_s2_03_en_action_summary.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "action-memory.v0.2",
+  "summary_id": "anvil-eval-s2-03-en-svelte-001",
+  "session_id": "anvil-eval-s2-03-en-session-001",
+  "repo_id": "S2-03-en",
+  "task_signature": "sveltekit-route-edit-add-control",
+  "summary_level": "chunk",
+  "source_chunk_ids": ["anvil-eval-s2-03-en-chunk-001"],
+  "actions_done": [
+    {
+      "kind": "edit",
+      "target": "src/routes/+page.svelte",
+      "outcome": "useful",
+      "status": "completed",
+      "evidence_ids": ["anvil-eval-s2-03-en-ev-001"]
+    }
+  ],
+  "facts": [
+    {
+      "text": "Repo S2-03-en is a SvelteKit project. The main page is src/routes/+page.svelte. The verify.mjs script checks that the page contains at least one interactive HTML element (button, select, input, or textarea) and does not use React or Next.js.",
+      "evidence_ids": ["anvil-eval-s2-03-en-ev-001"],
+      "confidence": 0.97,
+      "lang": "en"
+    },
+    {
+      "text": "リポジトリ S2-03-en は SvelteKit プロジェクト。メインページは src/routes/+page.svelte。verify.mjs は button / select / input / textarea などインタラクティブ HTML 要素が 1 つ以上含まれ、かつ React / Next.js を使っていないことを検査する。",
+      "evidence_ids": ["anvil-eval-s2-03-en-ev-001"],
+      "confidence": 0.97,
+      "lang": "ja"
+    }
+  ],
+  "hypotheses": [],
+  "failed_attempts": [],
+  "avoid": [
+    {
+      "action": "add React or Next.js components",
+      "reason": "verify.mjs explicitly fails if React or Next is detected",
+      "valid_until": "never",
+      "evidence_ids": ["anvil-eval-s2-03-en-ev-001"],
+      "lang": "en"
+    },
+    {
+      "action": "React や Next.js のコンポーネントを追加する",
+      "reason": "verify.mjs が React / Next.js を検出すると必ず失敗する",
+      "valid_until": "never",
+      "evidence_ids": ["anvil-eval-s2-03-en-ev-001"],
+      "lang": "ja"
+    }
+  ],
+  "next_hints": [
+    {
+      "kind": "edit",
+      "target": "src/routes/+page.svelte",
+      "reason": "Add a native Svelte interactive element (e.g. <button>) inside the existing +page.svelte. Run node verify.mjs to confirm.",
+      "confidence": 0.93,
+      "lang": "en"
+    },
+    {
+      "kind": "edit",
+      "target": "src/routes/+page.svelte",
+      "reason": "既存の +page.svelte に Svelte ネイティブのインタラクティブ要素（例: <button>）を追加する。node verify.mjs で確認する。",
+      "confidence": 0.93,
+      "lang": "ja"
+    }
+  ],
+  "validity": {"status": "valid"},
+  "token_cost": {
+    "estimated_summary_tokens": 212,
+    "estimated_raw_tokens": 424,
+    "tokens_saved_vs_raw": 212
+  }
+}

--- a/tests/fixtures/shared/anvil_eval_s3_01_en_action_summary.json
+++ b/tests/fixtures/shared/anvil_eval_s3_01_en_action_summary.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": "action-memory.v0.2",
+  "summary_id": "anvil-eval-s3-01-en-calculator-001",
+  "session_id": "anvil-eval-s3-01-en-session-001",
+  "repo_id": "S3-01-en",
+  "task_signature": "python-bug-fix-calculator",
+  "summary_level": "chunk",
+  "source_chunk_ids": ["anvil-eval-s3-01-en-chunk-001"],
+  "actions_done": [
+    {
+      "kind": "edit",
+      "target": "calculator.py",
+      "outcome": "useful",
+      "status": "completed",
+      "evidence_ids": ["anvil-eval-s3-01-en-ev-001"]
+    }
+  ],
+  "facts": [
+    {
+      "text": "Repo S3-01-en has a bug in calculator.py: the add() function returns a - b (subtraction) instead of a + b (addition). Fix: change return a - b to return a + b. Verify with: python3 verify.py.",
+      "evidence_ids": ["anvil-eval-s3-01-en-ev-001"],
+      "confidence": 0.99,
+      "lang": "en"
+    },
+    {
+      "text": "リポジトリ S3-01-en の calculator.py にバグがある。add() が a + b ではなく a - b を返している。修正方法は return a - b を return a + b に変えること。確認は python3 verify.py で行う。",
+      "evidence_ids": ["anvil-eval-s3-01-en-ev-001"],
+      "confidence": 0.99,
+      "lang": "ja"
+    }
+  ],
+  "hypotheses": [],
+  "failed_attempts": [],
+  "avoid": [],
+  "next_hints": [
+    {
+      "kind": "edit",
+      "target": "calculator.py",
+      "reason": "Fix the add() function: change return a - b to return a + b. Run python3 verify.py to confirm.",
+      "confidence": 0.97,
+      "lang": "en"
+    },
+    {
+      "kind": "edit",
+      "target": "calculator.py",
+      "reason": "add() 関数を修正する: return a - b を return a + b に変える。python3 verify.py で確認する。",
+      "confidence": 0.97,
+      "lang": "ja"
+    }
+  ],
+  "validity": {"status": "valid"},
+  "token_cost": {
+    "estimated_summary_tokens": 136,
+    "estimated_raw_tokens": 294,
+    "tokens_saved_vs_raw": 158
+  }
+}

--- a/tests/fixtures/shared/anvil_eval_s5_01_en_action_summary.json
+++ b/tests/fixtures/shared/anvil_eval_s5_01_en_action_summary.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "action-memory.v0.2",
+  "summary_id": "anvil-eval-s5-01-en-tool-double-001",
+  "session_id": "anvil-eval-s5-01-en-session-001",
+  "repo_id": "S5-01-en",
+  "task_signature": "python-bug-fix-anvil-md-verifier",
+  "summary_level": "chunk",
+  "source_chunk_ids": ["anvil-eval-s5-01-en-chunk-001"],
+  "actions_done": [
+    {
+      "kind": "edit",
+      "target": "tool.py",
+      "outcome": "useful",
+      "status": "completed",
+      "evidence_ids": ["anvil-eval-s5-01-en-ev-001"]
+    }
+  ],
+  "facts": [
+    {
+      "text": "Repo S5-01-en has a bug in tool.py: double(x) returns x + x + 1 instead of x + x. Fix: change return x + x + 1 to return x + x (or return x * 2). ANVIL.md specifies preferred verifier: python3 custom_check.py.",
+      "evidence_ids": ["anvil-eval-s5-01-en-ev-001"],
+      "confidence": 0.99,
+      "lang": "en"
+    },
+    {
+      "text": "リポジトリ S5-01-en の tool.py にバグがある。double(x) が x + x ではなく x + x + 1 を返している。修正は return x + x + 1 を return x + x（または return x * 2）に変えること。ANVIL.md は推奨検証コマンドを指定しており、python3 custom_check.py を使う。",
+      "evidence_ids": ["anvil-eval-s5-01-en-ev-001"],
+      "confidence": 0.99,
+      "lang": "ja"
+    }
+  ],
+  "hypotheses": [],
+  "failed_attempts": [],
+  "avoid": [
+    {
+      "action": "use pytest for verification",
+      "reason": "ANVIL.md explicitly says not to use pytest for this project",
+      "valid_until": "never",
+      "evidence_ids": ["anvil-eval-s5-01-en-ev-001"],
+      "lang": "en"
+    },
+    {
+      "action": "pytest で検証する",
+      "reason": "ANVIL.md がこのプロジェクトでは pytest を使わないよう明記している",
+      "valid_until": "never",
+      "evidence_ids": ["anvil-eval-s5-01-en-ev-001"],
+      "lang": "ja"
+    }
+  ],
+  "next_hints": [
+    {
+      "kind": "edit",
+      "target": "tool.py",
+      "reason": "Fix double(x): change return x + x + 1 to return x + x. Use the ANVIL.md preferred verifier: python3 custom_check.py.",
+      "confidence": 0.97,
+      "lang": "en"
+    },
+    {
+      "kind": "edit",
+      "target": "tool.py",
+      "reason": "double(x) を修正する: return x + x + 1 を return x + x に変える。ANVIL.md 推奨の python3 custom_check.py で検証する。",
+      "confidence": 0.97,
+      "lang": "ja"
+    }
+  ],
+  "validity": {"status": "valid"},
+  "token_cost": {
+    "estimated_summary_tokens": 204,
+    "estimated_raw_tokens": 344,
+    "tokens_saved_vs_raw": 140
+  }
+}

--- a/tests/test_anvil_eval_multilingual_seeds.py
+++ b/tests/test_anvil_eval_multilingual_seeds.py
@@ -15,14 +15,18 @@ import re
 from pathlib import Path
 
 import pytest
+from fastapi.testclient import TestClient
 
 from photon_action_memory.api.schema_v2 import (
     DEFAULT_SCHEMA_VERSION_V2,
     ActionSummary,
     ContextPackBudget,
 )
+from photon_action_memory.api.server import create_app
 from photon_action_memory.context.pack import build_context_pack
 from photon_action_memory.context.render import render_summary
+from photon_action_memory.memory.store import SQLiteEventStore
+from photon_action_memory.memory.summary_store import SummaryStore
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SHARED = REPO_ROOT / "tests" / "fixtures" / "shared"
@@ -31,13 +35,22 @@ SEED_SCRIPT = REPO_ROOT / "scripts" / "seed_expanded_eval_scenarios.sh"
 SEED_FILES: tuple[str, ...] = (
     "anvil_eval_s1_02_action_summary.json",
     "anvil_eval_s2_03_action_summary.json",
+    "anvil_eval_s2_03_en_action_summary.json",
     "anvil_eval_s3_01_action_summary.json",
+    "anvil_eval_s3_01_en_action_summary.json",
     "anvil_eval_s3_03_action_summary.json",
     "anvil_eval_s3_04_action_summary.json",
     "anvil_eval_s5_01_action_summary.json",
+    "anvil_eval_s5_01_en_action_summary.json",
     "anvil_eval_s6_04_action_summary.json",
     "anvil_eval_sp01_action_summary.json",
 )
+
+CROSS_LINGUAL_EN_SEEDS: dict[str, str] = {
+    "anvil_eval_s2_03_en_action_summary.json": "S2-03-en",
+    "anvil_eval_s3_01_en_action_summary.json": "S3-01-en",
+    "anvil_eval_s5_01_en_action_summary.json": "S5-01-en",
+}
 
 _JA_CHAR_RE = re.compile(r"[぀-ヿ㐀-鿿]")
 
@@ -124,3 +137,45 @@ def test_seed_script_references_all_fixtures() -> None:
     contents = SEED_SCRIPT.read_text(encoding="utf-8")
     for filename in SEED_FILES:
         assert filename in contents, f"seed script must reference {filename}"
+
+
+@pytest.mark.parametrize(("filename", "repo_id"), CROSS_LINGUAL_EN_SEEDS.items())
+def test_en_variant_seed_repo_id_matches_anvil_workdir(filename: str, repo_id: str) -> None:
+    summary = ActionSummary.model_validate(_load(filename))
+    assert summary.repo_id == repo_id
+    assert repo_id.lower().replace("-", "_") in filename
+
+
+@pytest.mark.parametrize(("filename", "repo_id"), CROSS_LINGUAL_EN_SEEDS.items())
+def test_en_variant_seed_resolves_by_exact_repo_id(
+    tmp_path: Path, filename: str, repo_id: str
+) -> None:
+    summary_store = SummaryStore(tmp_path / "summaries.sqlite")
+    event_store = SQLiteEventStore(tmp_path / "events.sqlite")
+    summary = ActionSummary.model_validate(_load(filename))
+    summary_store.upsert(summary)
+
+    body = {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": f"pack-{repo_id}",
+        "agent": {"name": "anvil", "version": "dev"},
+        "repo": {"root": f"/tmp/anvil-eval/{repo_id}", "name": repo_id},
+        "task": {
+            "user_request": "Use photon memory for the English cross-lingual scenario.",
+            "mode": "act",
+            "summary": "cross_lingual EN scenario",
+        },
+        "working_memory": {"touched_files": []},
+        "recent_event_ids": [],
+        "candidate_summary_ids": [],
+        "budget": {"max_memory_tokens": 800, "max_evidence_chars": 1200},
+    }
+    with TestClient(create_app(event_store, summary_store)) as client:
+        response = client.post("/v1/context/pack", json=body)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["sidecar_status"] == "ok"
+    assert payload["context_pack"]["repo_id"] == repo_id
+    assert [item["id"] for item in payload["context_pack"]["items"]] == [summary.summary_id]
+    assert payload["admission_decisions"][0]["decision"] == "admit"


### PR DESCRIPTION
Closes #101

## Summary
- Add Anvil cross_lingual EN workdir seed fixtures for S2-03-en, S3-01-en, and S5-01-en.
- Register the new fixtures in scripts/seed_expanded_eval_scenarios.sh.
- Extend multilingual seed tests to verify exact repo_id retrieval for the EN variants.

## Changed files
- tests/fixtures/shared/anvil_eval_s2_03_en_action_summary.json
- tests/fixtures/shared/anvil_eval_s3_01_en_action_summary.json
- tests/fixtures/shared/anvil_eval_s5_01_en_action_summary.json
- scripts/seed_expanded_eval_scenarios.sh
- tests/test_anvil_eval_multilingual_seeds.py
- dev-reports/issue-101/*

## Tests run
- python -m pytest tests/test_anvil_eval_multilingual_seeds.py -q
- python -m pytest tests/test_anvil_eval_multilingual_seeds.py tests/test_shared_fixtures.py -q
- python -m ruff format --check .
- python -m ruff check .
- python -m mypy photon_action_memory tests
- Temporary sidecar curl smoke for S2-03-en, S3-01-en, and S5-01-en repo_id matches

## Known risks
- Full Anvil cross_lingual evaluation was not run in this repository; photon-side seed match was verified through /v1/context/pack smoke.

## Orchestration run ID
- N/A