### PR TITLE
feat(detector): tune premature overlap threshold

### DIFF
--- a/dev-reports/issue-103/design.md
+++ b/dev-reports/issue-103/design.md
@@ -1,0 +1,30 @@
+# Design Note - Issue #103
+
+## Goal
+
+Make the multilingual quality gate emit `premature_termination_risk` for
+realistic Anvil cross-lingual S2-03 tasks, not only for near-duplicate curl
+smoke prompts.
+
+## Approach
+
+- Replace the hard-coded direct next-hint overlap threshold with a configurable
+  helper.
+- Default the threshold to `0.15`, low enough to catch the observed realistic
+  Anvil S2-03 JP/EN task wording.
+- Allow runtime tuning through `PHOTON_PREMATURE_OVERLAP_THRESHOLD`.
+- Keep false positives down by exempting concrete code-replacement hints from
+  premature-termination warnings. These hints carry specific implementation
+  evidence, unlike the S2-03 generic "add an interactive element" hint.
+- Do not emit premature-termination warnings for meta/verifier summaries such
+  as S5-01, because Anvil should continue to consume verifier guidance.
+
+## Verification Plan
+
+- Add focused tests for:
+  - realistic S2-03 JP task warning emission;
+  - realistic S2-03 EN task warning emission;
+  - S5-01 meta seed remaining admitted with no warning;
+  - S3-01 concrete code replacement remaining admitted with no warning;
+  - environment override for the threshold.
+- Run focused context-pack and overlap detector tests, then ruff and mypy.

--- a/dev-reports/issue-103/implementation-summary.md
+++ b/dev-reports/issue-103/implementation-summary.md
@@ -1,0 +1,22 @@
+# Implementation Summary - Issue #103
+
+## Changes
+
+- Replaced the hard-coded `0.35` direct next-hint premature-overlap threshold
+  with `premature_overlap_threshold()`.
+- Default threshold is now `0.15`, which covers the observed realistic Anvil
+  S2-03 JP/EN task wording.
+- Added `PHOTON_PREMATURE_OVERLAP_THRESHOLD` for rollout tuning.
+- Suppressed premature warnings for:
+  - meta/verifier summaries such as S5-01;
+  - concrete code-replacement hints such as S3-01 `return a - b` ->
+    `return a + b`.
+- Added regression tests for realistic S2-03 warning emission and S3/S5
+  false-positive avoidance.
+
+## Notes
+
+The S2-03 realistic task now emits `summary_quality_gate` /
+`premature_termination_risk` while still admitting the summary. This matches the
+Anvil warning-filter flow: photon surfaces the warning and the Anvil side can
+decide whether to block injection for that turn.

--- a/dev-reports/issue-103/verification.md
+++ b/dev-reports/issue-103/verification.md
@@ -1,0 +1,26 @@
+# Verification - Issue #103
+
+## Automated Checks
+
+- `python -m pytest tests/test_context_pack.py tests/test_overlap_detector.py -q`
+  - PASS: 59 passed, 2 warnings
+- `python -m ruff format --check .`
+  - PASS: 101 files already formatted
+- `python -m ruff check .`
+  - PASS: All checks passed
+- `python -m mypy photon_action_memory tests`
+  - PASS: no issues found in 95 source files
+
+## Coverage Added
+
+- Realistic S2-03 JP task emits `premature_termination_risk`.
+- Realistic S2-03 EN task emits `premature_termination_risk`.
+- S5-01 meta/verifier seed is admitted and emits no premature warning.
+- S3-01 concrete code-replacement seed emits no premature warning.
+- `PHOTON_PREMATURE_OVERLAP_THRESHOLD` override is covered.
+
+## Not Run
+
+- Full Anvil `cross_lingual` evaluation was not run from this repository. The
+  photon-side behavior that Anvil consumes is covered through focused
+  context-pack tests using the same seed fixtures and realistic task wording.

--- a/photon_action_memory/context/quality_gate.py
+++ b/photon_action_memory/context/quality_gate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 
 from photon_action_memory.api.schema_v2 import ActionSummary
@@ -39,6 +40,14 @@ _VERIFY_MARKERS = (
     "run verification",
     "run verifier",
     "verify before",
+)
+_PREMATURE_THRESHOLD_ENV = "PHOTON_PREMATURE_OVERLAP_THRESHOLD"
+_DEFAULT_PREMATURE_THRESHOLD = 0.15
+_CONCRETE_CODE_CHANGE_MARKERS = (
+    "return ",
+    "change return",
+    " to return ",
+    "->",
 )
 
 
@@ -85,7 +94,7 @@ def evaluate_summary_quality(
     premature_risk = _has_premature_termination_risk(summary, task_tokens, mode=mode)
 
     warnings: list[str] = []
-    if premature_risk:
+    if premature_risk and not (meta_info or verification_guidance):
         warnings.append(
             f"{summary.summary_id}: premature_termination_risk: "
             "direct next_hint overlaps current task"
@@ -167,14 +176,46 @@ def _has_premature_termination_risk(
         if hint.kind.lower() in {"verify", "test", "inspect", "read"}:
             continue
         hint_text = f"{hint.kind} {hint.target or ''} {hint.reason}"
+        if _has_concrete_code_change(hint_text):
+            continue
         hint_tokens = tokenize(hint_text, mode=mode)
         if not hint_tokens:
             continue
         direct_action = bool(hint_tokens & _DIRECT_NEXT_ACTIONS)
         overlap = len(hint_tokens & task_tokens) / len(hint_tokens)
-        if direct_action and overlap >= 0.35:
+        if direct_action and overlap >= premature_overlap_threshold():
             return True
     return False
 
 
-__all__ = ["SummaryQualityGateResult", "evaluate_summary_quality"]
+def premature_overlap_threshold() -> float:
+    """Return the direct next-hint overlap threshold for premature risk.
+
+    The default is intentionally lower than the original 0.35 so realistic
+    Anvil task phrasing can still trip the warning. Invalid environment values
+    fail closed to the default instead of disabling the gate.
+    """
+    raw = (os.environ.get(_PREMATURE_THRESHOLD_ENV) or "").strip()
+    if not raw:
+        return _DEFAULT_PREMATURE_THRESHOLD
+    try:
+        threshold = float(raw)
+    except ValueError:
+        return _DEFAULT_PREMATURE_THRESHOLD
+    if threshold < 0.0:
+        return 0.0
+    if threshold > 1.0:
+        return 1.0
+    return threshold
+
+
+def _has_concrete_code_change(text: str) -> bool:
+    lowered = text.lower()
+    return any(marker in lowered for marker in _CONCRETE_CODE_CHANGE_MARKERS)
+
+
+__all__ = [
+    "SummaryQualityGateResult",
+    "evaluate_summary_quality",
+    "premature_overlap_threshold",
+]

--- a/tests/test_context_pack.py
+++ b/tests/test_context_pack.py
@@ -11,8 +11,10 @@ Acceptance criteria covered:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 
 from photon_action_memory.api.schema_v2 import (
@@ -31,6 +33,10 @@ from photon_action_memory.api.server import create_app
 from photon_action_memory.context.admission import ContextAdmissionController
 from photon_action_memory.context.budget import TokenBudgetTracker
 from photon_action_memory.context.pack import build_context_pack
+from photon_action_memory.context.quality_gate import (
+    evaluate_summary_quality,
+    premature_overlap_threshold,
+)
 from photon_action_memory.context.render import estimate_tokens, render_summary
 from photon_action_memory.memory.sanitizer import REDACTED_SECRET
 from photon_action_memory.memory.store import SQLiteEventStore
@@ -39,6 +45,8 @@ from photon_action_memory.memory.summary_store import SummaryStore
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+SHARED_FIXTURES = Path(__file__).parent / "fixtures" / "shared"
 
 
 def _make_summary(
@@ -84,6 +92,11 @@ def _failed(action: str) -> FailedAttempt:
 
 def _hint(kind: str, reason: str, target: str | None = None) -> NextHint:
     return NextHint(kind=kind, target=target, reason=reason, confidence=0.8)
+
+
+def _load_shared_summary(filename: str) -> ActionSummary:
+    raw = json.loads((SHARED_FIXTURES / filename).read_text(encoding="utf-8"))
+    return ActionSummary.model_validate(raw)
 
 
 # ---------------------------------------------------------------------------
@@ -527,6 +540,96 @@ def test_build_context_pack_keeps_s5_style_meta_information_seed() -> None:
     assert pack.omitted == []
     assert decisions[0].decision == "admit"
     assert "custom_check.py" in pack.items[0].text
+    assert pack.warnings == []
+
+
+def test_premature_overlap_threshold_defaults_to_realistic_anvil_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PHOTON_PREMATURE_OVERLAP_THRESHOLD", raising=False)
+    assert premature_overlap_threshold() == 0.15
+
+
+def test_premature_overlap_threshold_can_be_overridden(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PHOTON_PREMATURE_OVERLAP_THRESHOLD", "0.22")
+    assert premature_overlap_threshold() == 0.22
+
+
+def test_realistic_s2_japanese_task_emits_premature_warning() -> None:
+    summary = _load_shared_summary("anvil_eval_s2_03_action_summary.json")
+    task_text = (
+        "既存のSvelteKit画面を読み、Operations Consoleにステータス切替の操作UIを追加してください。"
+    )
+
+    pack, decisions = build_context_pack(
+        request_id="req-quality-s2-realistic-jp",
+        session_id=None,
+        repo_id=summary.repo_id,
+        summaries=[summary],
+        budget=ContextPackBudget(),
+        task_text=task_text,
+    )
+
+    assert decisions[0].decision == "admit"
+    assert [item.id for item in pack.items] == [summary.summary_id]
+    assert any("premature_termination_risk" in warning.message for warning in pack.warnings)
+
+
+def test_realistic_s2_english_task_emits_premature_warning() -> None:
+    summary = _load_shared_summary("anvil_eval_s2_03_en_action_summary.json")
+    task_text = "Read the existing SvelteKit page and add status toggle UI to Operations Console."
+
+    pack, decisions = build_context_pack(
+        request_id="req-quality-s2-realistic-en",
+        session_id=None,
+        repo_id=summary.repo_id,
+        summaries=[summary],
+        budget=ContextPackBudget(),
+        task_text=task_text,
+    )
+
+    assert decisions[0].decision == "admit"
+    assert [item.id for item in pack.items] == [summary.summary_id]
+    assert any("premature_termination_risk" in warning.message for warning in pack.warnings)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "anvil_eval_s5_01_action_summary.json",
+        "anvil_eval_s5_01_en_action_summary.json",
+    ],
+)
+def test_realistic_s5_meta_seed_does_not_emit_premature_warning(filename: str) -> None:
+    summary = _load_shared_summary(filename)
+    task_text = (
+        "verify.py が通るように tool.py を修正してください。テストが通るまで確認してください。"
+    )
+
+    pack, decisions = build_context_pack(
+        request_id=f"req-quality-s5-{summary.repo_id}",
+        session_id=None,
+        repo_id=summary.repo_id,
+        summaries=[summary],
+        budget=ContextPackBudget(),
+        task_text=task_text,
+    )
+
+    assert decisions[0].decision == "admit"
+    assert [item.id for item in pack.items] == [summary.summary_id]
+    assert pack.warnings == []
+
+
+def test_realistic_s3_specific_bugfix_seed_does_not_emit_premature_warning() -> None:
+    summary = _load_shared_summary("anvil_eval_s3_01_action_summary.json")
+    task_text = (
+        "calculator.py の add 関数を修正してください。verify.py が通るまで確認してください。"
+    )
+
+    result = evaluate_summary_quality(summary, task_text)
+
+    assert result.decision == "allow"
+    assert result.warnings == ()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #103

## Summary
- Lower the premature next-hint overlap threshold to catch realistic Anvil S2-03 JP/EN tasks.
- Add PHOTON_PREMATURE_OVERLAP_THRESHOLD for runtime tuning.
- Avoid false-positive warnings for S5-01 meta/verifier seeds and S3-01 concrete code-replacement hints.

## Changed files
- photon_action_memory/context/quality_gate.py
- tests/test_context_pack.py
- dev-reports/issue-103/*

## Tests run
- python -m pytest tests/test_context_pack.py tests/test_overlap_detector.py -q
- python -m ruff format --check .
- python -m ruff check .
- python -m mypy photon_action_memory tests

## Known risks
- Full Anvil cross_lingual evaluation was not run from this repository; photon-side behavior is covered with realistic context-pack tests.

## Orchestration run ID
- 20260515-001601-orchestrate