### PR TITLE
feat(context): soften premature hint blocking

### DIFF
--- a/dev-reports/issue-107/design.md
+++ b/dev-reports/issue-107/design.md
@@ -1,0 +1,45 @@
+# Issue #107 Design
+
+## Goal
+
+When the quality gate detects `premature_termination_risk`, preserve useful
+summary facts instead of dropping the whole seed. The risky part is the
+overlapping `next_hints`, so the prompt renderer should support suppressing
+only those hints while leaving `FACT`, `HYPOTHESIS`, `FAILED`, and `AVOID`
+content available to Anvil.
+
+## Approach
+
+- Keep the existing `summary_quality_gate` warning kind and warning message
+  unchanged for Anvil compatibility.
+- Extend `SummaryQualityGateResult` with
+  `suppressed_next_hint_indices`, an internal tuple of prompt-render hint
+  indices selected by the existing premature-risk detector.
+- Extend `render_summary()` with `exclude_next_hint_indices` so callers can
+  render a summary without selected hint rows.
+- In `build_context_pack()`, render a suppressed version when the quality gate
+  reports risky hints. A quality-gate `reject` caused by those hints is treated
+  as a soft block: the summary can still pass normal admission using the
+  hint-suppressed text.
+- Keep hard rejection behavior for low-value overlap when there are no specific
+  risky hint indices to suppress.
+
+## Compatibility
+
+The API-visible warning shape remains:
+
+```text
+kind=summary_quality_gate
+message="<summary_id>: premature_termination_risk: direct next_hint overlaps current task"
+```
+
+No new ContextPack schema field is required. The only API-visible behavior
+change is that affected summaries now appear in `items` with prompt text that
+omits the risky `HINT:` rows, and their `admission_reason` notes the
+suppression.
+
+## Out of Scope
+
+- Detector threshold changes.
+- Multilingual tokenization changes.
+- Anvil-side warning filtering.

--- a/dev-reports/issue-107/implementation-summary.md
+++ b/dev-reports/issue-107/implementation-summary.md
@@ -1,0 +1,24 @@
+# Issue #107 Implementation Summary
+
+## Changes
+
+- Added selective hint suppression to `render_summary()` via
+  `exclude_next_hint_indices`.
+- Added internal `suppressed_next_hint_indices` to quality-gate results.
+- Updated context-pack assembly so `premature_termination_risk` no longer
+  forces whole-seed omission when specific risky hints can be suppressed.
+- Preserved the existing `summary_quality_gate` warning kind and message.
+- Updated admission token accounting and duplicate tracking to use the actual
+  rendered text after hint suppression.
+
+## Behavior
+
+For an S2-style seed whose facts are useful but whose `next_hints` overlap the
+current task:
+
+- Before: the entire summary could be omitted by the quality gate.
+- After: facts remain in the ContextPack; overlapping `HINT:` rows are omitted.
+
+Verification-only hints remain allowed when they are not mixed with a risky
+direct-edit hint. When a direct-edit hint and a verification hint coexist, only
+the direct-edit hint is flagged for suppression.

--- a/dev-reports/issue-107/verification.md
+++ b/dev-reports/issue-107/verification.md
@@ -1,0 +1,31 @@
+# Issue #107 Verification
+
+## Automated Checks
+
+- `python -m pytest tests/test_context_pack.py tests/test_overlap_detector.py -q`
+  - Result: `61 passed, 2 warnings`
+- `python -m pytest tests/test_anvil_eval_multilingual_seeds.py -q`
+  - Result: `59 passed`
+- `python -m pytest tests/test_context_pack.py tests/test_overlap_detector.py tests/test_anvil_eval_multilingual_seeds.py -q`
+  - Result: `120 passed, 2 warnings`
+- `python -m pytest -q`
+  - Result: `947 passed, 1 skipped, 2 warnings`
+- `python -m ruff format --check photon_action_memory/context/render.py photon_action_memory/context/admission.py photon_action_memory/context/quality_gate.py photon_action_memory/context/pack.py tests/test_context_pack.py`
+  - Result: pass
+- `python -m ruff check photon_action_memory/context/render.py photon_action_memory/context/admission.py photon_action_memory/context/quality_gate.py photon_action_memory/context/pack.py tests/test_context_pack.py`
+  - Result: pass
+- `python -m ruff format --check .`
+  - Result: pass
+- `python -m ruff check .`
+  - Result: pass
+- `python -m mypy photon_action_memory/context tests/test_context_pack.py`
+  - Result: pass
+- `python -m mypy photon_action_memory tests`
+  - Result: pass
+
+## Notes
+
+The full Anvil cross-lingual eval target from the issue was not run in this
+repository worktree. The photon-side regression coverage verifies that
+S2-style premature-risk seeds are admitted with facts preserved and risky
+`next_hints` removed from prompt-visible text.

--- a/photon_action_memory/context/admission.py
+++ b/photon_action_memory/context/admission.py
@@ -34,7 +34,12 @@ class ContextAdmissionController:
         self._tracker = tracker
         self._seen: set[str] = set()
 
-    def evaluate(self, summary: ActionSummary) -> tuple[str, str | None]:
+    def evaluate(
+        self,
+        summary: ActionSummary,
+        *,
+        rendered_text: str | None = None,
+    ) -> tuple[str, str | None]:
         """Return (decision, reason) for *summary*."""
         if summary.validity.status in _STALE_STATUSES:
             base_reason = f"summary is {summary.validity.status}"
@@ -48,7 +53,7 @@ class ContextAdmissionController:
         if not has_content:
             return "omit", "no admissible content"
 
-        text = render_summary(summary)
+        text = rendered_text if rendered_text is not None else render_summary(summary)
         normalized = text.strip().lower()
         if normalized in self._seen:
             return "omit", "duplicate content"
@@ -66,10 +71,13 @@ class ContextAdmissionController:
         summary: ActionSummary,
         decision: str,
         reason: str | None,
+        *,
+        rendered_text: str | None = None,
     ) -> ContextAdmissionDecision:
         est_tokens: int | None = None
         if decision == "admit":
-            est_tokens = estimate_tokens(render_summary(summary))
+            text = rendered_text if rendered_text is not None else render_summary(summary)
+            est_tokens = estimate_tokens(text)
         return ContextAdmissionDecision(
             schema_version=DEFAULT_SCHEMA_VERSION_V2,
             decision_id=_decision_id(summary.summary_id),

--- a/photon_action_memory/context/pack.py
+++ b/photon_action_memory/context/pack.py
@@ -90,7 +90,12 @@ def build_context_pack(
         quality = evaluate_summary_quality(summary, task_text)
         for message in quality.warnings:
             pack_warnings.append(ContextPackWarning(kind="summary_quality_gate", message=message))
-        if quality.decision == "reject":
+        suppressed_next_hint_indices = set(quality.suppressed_next_hint_indices)
+        rendered_text = render_summary(
+            summary,
+            exclude_next_hint_indices=suppressed_next_hint_indices,
+        )
+        if quality.decision == "reject" and not suppressed_next_hint_indices:
             quality_reason = quality.reason or "summary quality gate rejected"
             decisions.append(
                 ContextAdmissionDecision(
@@ -113,25 +118,34 @@ def build_context_pack(
             )
             continue
 
-        decision, reason = controller.evaluate(summary)
-        decisions.append(controller.make_decision(summary, decision, reason))
+        decision, reason = controller.evaluate(summary, rendered_text=rendered_text)
+        decisions.append(
+            controller.make_decision(
+                summary,
+                decision,
+                reason,
+                rendered_text=rendered_text,
+            )
+        )
 
         if decision == "admit":
-            text = render_summary(summary)
             raw_tokens = (
                 summary.token_cost.estimated_raw_tokens
                 if summary.token_cost
-                else estimate_tokens(text) * 10
+                else estimate_tokens(rendered_text) * 10
             )
             tracker.add_raw(raw_tokens)
             evidence_ids = [eid for f in summary.facts for eid in f.evidence_ids]
+            admission_reason = "grounded and within budget"
+            if suppressed_next_hint_indices:
+                admission_reason += "; next_hints suppressed: premature_termination_risk"
             items.append(
                 ContextPackItem(
                     kind="action_summary",
                     id=summary.summary_id,
-                    text=text,
+                    text=rendered_text,
                     evidence_ids=evidence_ids,
-                    admission_reason="grounded and within budget",
+                    admission_reason=admission_reason,
                 )
             )
         else:

--- a/photon_action_memory/context/quality_gate.py
+++ b/photon_action_memory/context/quality_gate.py
@@ -61,6 +61,7 @@ class SummaryQualityGateResult:
     warnings: tuple[str, ...] = ()
     task_overlap: float = 0.0
     novel_ratio: float = 1.0
+    suppressed_next_hint_indices: tuple[int, ...] = ()
 
 
 def evaluate_summary_quality(
@@ -91,16 +92,21 @@ def evaluate_summary_quality(
     novel_ratio = overlap_result.novel
     meta_info = _has_meta_information(summary_text)
     verification_guidance = _has_verification_guidance(summary)
-    premature_risk = _has_premature_termination_risk(summary, task_tokens, mode=mode)
+    suppressed_hint_indices = _premature_termination_next_hint_indices(
+        summary,
+        task_tokens,
+        mode=mode,
+    )
+    premature_risk = bool(suppressed_hint_indices)
 
     warnings: list[str] = []
-    if premature_risk and not (meta_info or verification_guidance):
+    if premature_risk and not meta_info:
         warnings.append(
             f"{summary.summary_id}: premature_termination_risk: "
             "direct next_hint overlaps current task"
         )
 
-    if meta_info or verification_guidance:
+    if meta_info or (verification_guidance and not premature_risk):
         return SummaryQualityGateResult(
             decision="allow",
             warnings=tuple(warnings),
@@ -124,6 +130,7 @@ def evaluate_summary_quality(
             warnings=tuple(warnings),
             task_overlap=overlap,
             novel_ratio=novel_ratio,
+            suppressed_next_hint_indices=suppressed_hint_indices,
         )
 
     return SummaryQualityGateResult(
@@ -131,6 +138,7 @@ def evaluate_summary_quality(
         warnings=tuple(warnings),
         task_overlap=overlap,
         novel_ratio=novel_ratio,
+        suppressed_next_hint_indices=suppressed_hint_indices,
     )
 
 
@@ -166,13 +174,14 @@ def _has_verification_guidance(summary: ActionSummary) -> bool:
     return False
 
 
-def _has_premature_termination_risk(
+def _premature_termination_next_hint_indices(
     summary: ActionSummary,
     task_tokens: set[str],
     *,
     mode: OverlapDetectorMode | None = None,
-) -> bool:
-    for hint in summary.next_hints:
+) -> tuple[int, ...]:
+    risky_indices: list[int] = []
+    for index, hint in enumerate(summary.next_hints):
         if hint.kind.lower() in {"verify", "test", "inspect", "read"}:
             continue
         hint_text = f"{hint.kind} {hint.target or ''} {hint.reason}"
@@ -184,8 +193,8 @@ def _has_premature_termination_risk(
         direct_action = bool(hint_tokens & _DIRECT_NEXT_ACTIONS)
         overlap = len(hint_tokens & task_tokens) / len(hint_tokens)
         if direct_action and overlap >= premature_overlap_threshold():
-            return True
-    return False
+            risky_indices.append(index)
+    return tuple(risky_indices)
 
 
 def premature_overlap_threshold() -> float:

--- a/photon_action_memory/context/render.py
+++ b/photon_action_memory/context/render.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 from photon_action_memory.api.schema_v2 import ActionSummary
 from photon_action_memory.memory.sanitizer import sanitize_text
 
@@ -12,8 +14,13 @@ def estimate_tokens(text: str) -> int:
     return max(1, len(text) // _CHARS_PER_TOKEN)
 
 
-def render_summary(summary: ActionSummary) -> str:
+def render_summary(
+    summary: ActionSummary,
+    *,
+    exclude_next_hint_indices: Iterable[int] | None = None,
+) -> str:
     """Render an ActionSummary to compact prompt-visible text."""
+    excluded_hints = set(exclude_next_hint_indices or ())
     parts: list[str] = []
     for fact in summary.facts:
         parts.append(f"FACT: {fact.text}")
@@ -23,7 +30,9 @@ def render_summary(summary: ActionSummary) -> str:
         parts.append(f"FAILED: {fa.action}")
     for av in summary.avoid:
         parts.append(f"AVOID: {av.action} - {av.reason}")
-    for nh in summary.next_hints:
+    for index, nh in enumerate(summary.next_hints):
+        if index in excluded_hints:
+            continue
         parts.append(f"HINT: {nh.kind} - {nh.reason}")
     return sanitize_text("\n".join(parts))
 

--- a/tests/test_context_pack.py
+++ b/tests/test_context_pack.py
@@ -114,6 +114,22 @@ def test_render_summary_includes_facts_and_hypotheses() -> None:
     assert "HYPOTHESIS: performance bottleneck in parser" in text
 
 
+def test_render_summary_can_exclude_selected_next_hints() -> None:
+    summary = _make_summary(
+        facts=[_fact("main route is src/routes/+page.svelte")],
+        next_hints=[
+            _hint("edit", "Add the same interactive element requested by the task."),
+            _hint("verify", "Run node verify.mjs after editing."),
+        ],
+    )
+
+    text = render_summary(summary, exclude_next_hint_indices={0})
+
+    assert "FACT: main route is src/routes/+page.svelte" in text
+    assert "Add the same interactive element" not in text
+    assert "HINT: verify - Run node verify.mjs after editing." in text
+
+
 def test_render_summary_empty_returns_empty_string() -> None:
     summary = _make_summary()
     assert render_summary(summary) == ""
@@ -427,7 +443,7 @@ def test_build_context_pack_failed_attempt_and_avoid_admitted() -> None:
     assert "AVOID:" in pack.items[0].text
 
 
-def test_build_context_pack_rejects_s2_style_task_overlap_seed() -> None:
+def test_build_context_pack_soft_blocks_s2_style_task_overlap_seed() -> None:
     task_text = (
         "Create a SvelteKit page in src/routes/+page.svelte with at least one "
         "interactive HTML element. Do not use React or Next.js."
@@ -453,17 +469,18 @@ def test_build_context_pack_rejects_s2_style_task_overlap_seed() -> None:
         task_text=task_text,
     )
 
-    assert pack.items == []
-    assert pack.omitted[0].id == "sum-s2-overlap"
-    assert "low_value task overlap" in pack.omitted[0].reason
-    assert "premature_termination_risk" in pack.omitted[0].reason
-    assert decisions[0].decision == "deny"
-    assert decisions[0].policy is not None
-    assert decisions[0].policy.detail_level == "summarize_quality_gate"
+    assert [item.id for item in pack.items] == ["sum-s2-overlap"]
+    assert pack.omitted == []
+    assert "FACT: Repo S2-03 is a SvelteKit project." in pack.items[0].text
+    assert "HINT:" not in pack.items[0].text
+    assert pack.items[0].admission_reason is not None
+    assert "next_hints suppressed: premature_termination_risk" in pack.items[0].admission_reason
+    assert decisions[0].decision == "admit"
+    assert decisions[0].policy is None
     assert pack.warnings[0].kind == "summary_quality_gate"
 
 
-def test_build_context_pack_rejects_japanese_task_english_seed_overlap() -> None:
+def test_build_context_pack_soft_blocks_japanese_task_english_seed_overlap() -> None:
     """Cross-lingual JP task + EN seed should still trip the quality gate.
 
     Regression test for Issue #97: the legacy ASCII-only detector did not
@@ -502,10 +519,11 @@ def test_build_context_pack_rejects_japanese_task_english_seed_overlap() -> None
         task_text=task_text,
     )
 
-    assert pack.items == []
-    assert pack.omitted[0].id == "sum-jp-task-en-seed"
-    assert "premature_termination_risk" in pack.omitted[0].reason
-    assert decisions[0].decision == "deny"
+    assert [item.id for item in pack.items] == ["sum-jp-task-en-seed"]
+    assert pack.omitted == []
+    assert "FACT: Repo S2-03 is a SvelteKit project." in pack.items[0].text
+    assert "HINT:" not in pack.items[0].text
+    assert decisions[0].decision == "admit"
     quality_warnings = [w for w in pack.warnings if w.kind == "summary_quality_gate"]
     assert any("premature_termination_risk" in w.message for w in quality_warnings)
 
@@ -555,10 +573,34 @@ def test_premature_overlap_threshold_can_be_overridden(monkeypatch: pytest.Monke
     assert premature_overlap_threshold() == 0.22
 
 
+def test_quality_gate_reports_suppressed_next_hint_indices() -> None:
+    task_text = (
+        "Create a SvelteKit page in src/routes/+page.svelte with at least one "
+        "interactive HTML element. Do not use React or Next.js."
+    )
+    summary = _make_summary(
+        "sum-suppress-index",
+        facts=[_fact("Repo S2-03 uses SvelteKit and verify.mjs checks the page.")],
+        next_hints=[
+            _hint("edit", "Add an interactive HTML element to the Svelte page."),
+            _hint("verify", "Run node verify.mjs after editing."),
+        ],
+    )
+
+    result = evaluate_summary_quality(summary, task_text)
+
+    assert result.warnings == (
+        "sum-suppress-index: premature_termination_risk: direct next_hint overlaps current task",
+    )
+    assert result.suppressed_next_hint_indices == (0,)
+
+
 def test_realistic_s2_japanese_task_emits_premature_warning() -> None:
     summary = _load_shared_summary("anvil_eval_s2_03_action_summary.json")
     task_text = (
-        "既存のSvelteKit画面を読み、Operations Consoleにステータス切替の操作UIを追加してください。"
+        "src/routes/+page.svelte に SvelteKit のページを作成してください。"
+        "少なくとも1つのインタラクティブな HTML 要素を含めてください。"
+        "React や Next.js は使用しないでください。"
     )
 
     pack, decisions = build_context_pack(
@@ -572,12 +614,16 @@ def test_realistic_s2_japanese_task_emits_premature_warning() -> None:
 
     assert decisions[0].decision == "admit"
     assert [item.id for item in pack.items] == [summary.summary_id]
+    assert "HINT:" not in pack.items[0].text
     assert any("premature_termination_risk" in warning.message for warning in pack.warnings)
 
 
 def test_realistic_s2_english_task_emits_premature_warning() -> None:
     summary = _load_shared_summary("anvil_eval_s2_03_en_action_summary.json")
-    task_text = "Read the existing SvelteKit page and add status toggle UI to Operations Console."
+    task_text = (
+        "Create a SvelteKit page in src/routes/+page.svelte with at least one "
+        "interactive HTML element. Do not use React or Next.js."
+    )
 
     pack, decisions = build_context_pack(
         request_id="req-quality-s2-realistic-en",
@@ -590,6 +636,7 @@ def test_realistic_s2_english_task_emits_premature_warning() -> None:
 
     assert decisions[0].decision == "admit"
     assert [item.id for item in pack.items] == [summary.summary_id]
+    assert "HINT:" not in pack.items[0].text
     assert any("premature_termination_risk" in warning.message for warning in pack.warnings)
 
 
@@ -835,7 +882,7 @@ def test_context_pack_api_auto_search_excludes_stale_and_omits_empty(
     assert omitted_ids == {"sum-empty"}
 
 
-def test_context_pack_api_reports_quality_gate_rejection(tmp_path: Path) -> None:
+def test_context_pack_api_reports_quality_gate_soft_block(tmp_path: Path) -> None:
     ss = SummaryStore(tmp_path / "summaries.sqlite")
     ss.upsert(
         _make_summary(
@@ -862,10 +909,11 @@ def test_context_pack_api_reports_quality_gate_rejection(tmp_path: Path) -> None
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["context_pack"]["items"] == []
-    assert payload["context_pack"]["omitted"][0]["id"] == "sum-s2-api"
-    assert "low_value task overlap" in payload["context_pack"]["omitted"][0]["reason"]
-    assert payload["admission_decisions"][0]["decision"] == "deny"
+    assert payload["context_pack"]["omitted"] == []
+    assert payload["context_pack"]["items"][0]["id"] == "sum-s2-api"
+    assert "FACT: Repo S2-03 is a SvelteKit project." in payload["context_pack"]["items"][0]["text"]
+    assert "HINT:" not in payload["context_pack"]["items"][0]["text"]
+    assert payload["admission_decisions"][0]["decision"] == "admit"
     assert payload["context_pack"]["warnings"][0]["kind"] == "summary_quality_gate"
 
 


### PR DESCRIPTION
## Summary
- Preserve useful summary facts when premature_termination_risk is caused by overlapping next_hints.
- Add selective next_hints exclusion to render_summary() and use hint-suppressed rendered text for admission/token accounting.
- Keep the existing summary_quality_gate warning kind/message unchanged for Anvil compatibility.

## Verification
- python -m pytest -q (947 passed, 1 skipped, 2 warnings)
- python -m ruff check .
- python -m ruff format --check .
- python -m mypy photon_action_memory tests

Refs #107