### PR TITLE
feat(context): add common seed fallback

### DIFF
--- a/dev-reports/issue-109/design.md
+++ b/dev-reports/issue-109/design.md
@@ -1,0 +1,38 @@
+# Issue #109 Design
+
+## Goal
+
+Add a repo-agnostic common seed layer so context retrieval can return useful
+generic knowledge when a repo-specific seed is missing or too narrow.
+
+## Retrieval Order
+
+`_resolve_context_summaries()` now resolves candidates in this order:
+
+1. Explicit `candidate_summary_ids` still bypass auto search.
+2. Repo-specific `(repo_id, task_signature)` matches.
+3. Repo-specific `repo_id` matches when stage 2 found nothing.
+4. Common seeds with `repo_id="__common__"` and the same `task_signature`.
+
+The merge helper deduplicates by `summary_id` while preserving earlier results,
+so repo-specific summaries always win over common summaries. Because common
+seeds are appended after repo-specific results, normal context-pack admission
+also makes repo-specific seeds win token-budget competition.
+
+## Seed Samples
+
+Common seed fixtures are stored under `tests/fixtures/shared/`:
+
+- `common_pytest_action_summary.json`
+- `common_rust_error_handling_action_summary.json`
+- `common_sveltekit_vs_react_action_summary.json`
+
+`scripts/seed_common_seeds.sh` seeds them, and
+`scripts/seed_expanded_eval_scenarios.sh` invokes that helper after the
+existing Anvil eval seed set.
+
+## Out of Scope
+
+- Universal scope retrieval. Issue #111 adds that as Stage 4.
+- Semantic or embedding-based common retrieval.
+- Anvil A/B eval measurement. The issue tracks that as a separate phase.

--- a/dev-reports/issue-109/implementation-summary.md
+++ b/dev-reports/issue-109/implementation-summary.md
@@ -1,0 +1,20 @@
+# Issue #109 Implementation Summary
+
+## Changes
+
+- Added `COMMON_REPO_ID = "__common__"` and `SummaryRetriever.search_common()`.
+- Added `merge_dedup_summaries()` for deterministic specific-first merging.
+- Updated `_resolve_context_summaries()` to append common seeds by
+  `task_signature`.
+- Added three common seed fixtures and a common seed script.
+- Added context-pack API tests for:
+  - repo-specific + common simultaneous retrieval,
+  - common fallback when repo has no match,
+  - common seed skip under token budget pressure,
+  - summary-id dedup with specific precedence.
+
+## Compatibility
+
+Explicit candidate IDs retain the old behavior. Existing repo-specific
+retrieval keeps its order and only gains same-task common seeds after the
+specific results.

--- a/dev-reports/issue-109/verification.md
+++ b/dev-reports/issue-109/verification.md
@@ -1,0 +1,28 @@
+# Issue #109 Verification
+
+## Automated Checks
+
+- `python -m pytest tests/test_context_pack.py tests/test_anvil_eval_multilingual_seeds.py -q`
+  - Result: `118 passed`
+- `python -m pytest -q`
+  - Result: `955 passed, 1 skipped, 2 warnings`
+- `python -m ruff check photon_action_memory/api/server.py photon_action_memory/memory/retrieval.py tests/test_context_pack.py tests/test_anvil_eval_multilingual_seeds.py`
+  - Result: pass
+- `python -m ruff format --check photon_action_memory/api/server.py photon_action_memory/memory/retrieval.py tests/test_context_pack.py tests/test_anvil_eval_multilingual_seeds.py`
+  - Result: pass
+- `python -m mypy photon_action_memory/api/server.py photon_action_memory/memory/retrieval.py tests/test_context_pack.py tests/test_anvil_eval_multilingual_seeds.py`
+  - Result: pass
+- `python -m ruff check .`
+  - Result: pass
+- `python -m ruff format --check .`
+  - Result: pass
+- `python -m mypy photon_action_memory tests`
+  - Result: pass
+- `bash -n scripts/seed_common_seeds.sh`
+  - Result: pass
+
+## Notes
+
+The full Anvil A-1/A-0 differential eval was not run in this repository
+worktree; the photon-side retrieval, dedup, and token-budget behavior are
+covered by automated tests.

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -56,7 +56,10 @@ from photon_action_memory.context.raw_policy import (
 from photon_action_memory.eval.summary_fidelity import SummaryFidelityChecker
 from photon_action_memory.memory.chunks import ActionChunker
 from photon_action_memory.memory.evidence import EvidenceExpander
-from photon_action_memory.memory.retrieval import SummaryRetriever
+from photon_action_memory.memory.retrieval import (
+    SummaryRetriever,
+    merge_dedup_summaries,
+)
 from photon_action_memory.memory.sanitizer import sanitize_text_with_report
 from photon_action_memory.memory.store import SQLiteEventStore
 from photon_action_memory.memory.summaries import (
@@ -743,18 +746,24 @@ def _resolve_context_summaries(
     *,
     repo_id: str | None,
 ) -> list[ActionSummary]:
-    """Resolve summaries for a context pack without falling back across repos."""
+    """Resolve summaries with repo-specific results before common seed fallback."""
     if request.candidate_summary_ids:
         return retriever.resolve_candidates(request.candidate_summary_ids)
-    if repo_id is None:
-        return []
 
     task_signature = _context_task_signature(request)
-    if task_signature is not None:
+    results: list[ActionSummary] = []
+    if repo_id is not None and task_signature is not None:
         task_matches = retriever.search(repo_id=repo_id, task_signature=task_signature)
         if task_matches:
-            return task_matches
-    return retriever.search(repo_id=repo_id)
+            results = merge_dedup_summaries(results, task_matches)
+    if repo_id is not None and not results:
+        results = merge_dedup_summaries(results, retriever.search(repo_id=repo_id))
+    if task_signature is not None:
+        results = merge_dedup_summaries(
+            results,
+            retriever.search_common(task_signature=task_signature),
+        )
+    return results
 
 
 def _context_repo_id(request: ContextPackRequest) -> str | None:

--- a/photon_action_memory/memory/retrieval.py
+++ b/photon_action_memory/memory/retrieval.py
@@ -6,6 +6,7 @@ from photon_action_memory.api.schema_v2 import ActionSummary
 from photon_action_memory.memory.staleness import StalenessContext, StalenessGuard
 from photon_action_memory.memory.summary_store import SummaryStore
 
+COMMON_REPO_ID = "__common__"
 _STALE_STATUSES: frozenset[str] = frozenset({"stale", "contradicted"})
 
 
@@ -49,6 +50,21 @@ class SummaryRetriever:
         )
         return self._filter_stale(summaries, staleness_context)
 
+    def search_common(
+        self,
+        *,
+        task_signature: str,
+        staleness_context: StalenessContext | None = None,
+        limit: int = 50,
+    ) -> list[ActionSummary]:
+        """Search common seeds for a task signature."""
+        return self.search(
+            repo_id=COMMON_REPO_ID,
+            task_signature=task_signature,
+            staleness_context=staleness_context,
+            limit=limit,
+        )
+
     def _filter_stale(
         self,
         summaries: list[ActionSummary],
@@ -64,4 +80,19 @@ class SummaryRetriever:
         return result
 
 
-__all__ = ["SummaryRetriever"]
+def merge_dedup_summaries(
+    primary: list[ActionSummary],
+    secondary: list[ActionSummary],
+) -> list[ActionSummary]:
+    """Merge summaries by summary_id while preserving primary precedence."""
+    merged = list(primary)
+    seen = {summary.summary_id for summary in merged}
+    for summary in secondary:
+        if summary.summary_id in seen:
+            continue
+        merged.append(summary)
+        seen.add(summary.summary_id)
+    return merged
+
+
+__all__ = ["COMMON_REPO_ID", "SummaryRetriever", "merge_dedup_summaries"]

--- a/scripts/seed_common_seeds.sh
+++ b/scripts/seed_common_seeds.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Seed common cross-repo photon memories.
+# These fixtures use repo_id="__common__" and task_signature-specific retrieval.
+# Run from the photon-action-memory repo root.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FIXTURES="$SCRIPT_DIR/../tests/fixtures/shared"
+
+SEEDS=(
+  "common_pytest_action_summary.json:seed-common-pytest-verbose"
+  "common_rust_error_handling_action_summary.json:seed-common-rust-result-handling"
+  "common_sveltekit_vs_react_action_summary.json:seed-common-sveltekit-vs-react"
+)
+
+echo "=== Seeding common photon memories ==="
+for entry in "${SEEDS[@]}"; do
+  fixture="${entry%%:*}"
+  request_id="${entry##*:}"
+  echo -n "  $fixture ... "
+  python3 "$SCRIPT_DIR/seed_live_injection_summary.py" \
+    --fixture "$FIXTURES/$fixture" \
+    --request-id "$request_id" \
+    | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['status'])"
+done
+echo "=== Done ==="

--- a/scripts/seed_expanded_eval_scenarios.sh
+++ b/scripts/seed_expanded_eval_scenarios.sh
@@ -33,3 +33,6 @@ for entry in "${SEEDS[@]}"; do
     | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['status'])"
 done
 echo "=== Done ==="
+
+echo "=== Seeding common cross-repo memories ==="
+"$SCRIPT_DIR/seed_common_seeds.sh"

--- a/tests/fixtures/shared/common_pytest_action_summary.json
+++ b/tests/fixtures/shared/common_pytest_action_summary.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "action-memory.v0.2",
+  "summary_id": "photon-common-pytest-verbose",
+  "session_id": "common-seed",
+  "repo_id": "__common__",
+  "task_signature": "python-pytest-pattern",
+  "summary_level": "case",
+  "facts": [
+    {
+      "text": "pytest -v enables verbose test output, and -x stops at the first failure.",
+      "evidence_ids": ["common-pytest-ev-001"],
+      "confidence": 0.95
+    }
+  ],
+  "avoid": [
+    {
+      "action": "rerun an entire large pytest suite when a single test path is known",
+      "reason": "Targeting the failing test path is faster and produces clearer output.",
+      "evidence_ids": ["common-pytest-ev-001"]
+    }
+  ],
+  "next_hints": [
+    {
+      "kind": "verify",
+      "target": "pytest -v -x path/to/test_file.py::test_name",
+      "reason": "Use a focused verbose run to reproduce one failing pytest case.",
+      "confidence": 0.9
+    }
+  ],
+  "token_cost": {
+    "estimated_summary_tokens": 44,
+    "estimated_raw_tokens": 320,
+    "tokens_saved_vs_raw": 276
+  },
+  "validity": {
+    "status": "valid"
+  }
+}

--- a/tests/fixtures/shared/common_rust_error_handling_action_summary.json
+++ b/tests/fixtures/shared/common_rust_error_handling_action_summary.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "action-memory.v0.2",
+  "summary_id": "photon-common-rust-result-handling",
+  "session_id": "common-seed",
+  "repo_id": "__common__",
+  "task_signature": "rust-error-handling",
+  "summary_level": "case",
+  "facts": [
+    {
+      "text": "Rust's ? operator can only be used in functions that return Result, Option, or another compatible Try type.",
+      "evidence_ids": ["common-rust-ev-001"],
+      "confidence": 0.95
+    }
+  ],
+  "avoid": [
+    {
+      "action": "replace recoverable errors with panic! in library code",
+      "reason": "Result-based propagation keeps callers able to handle errors.",
+      "evidence_ids": ["common-rust-ev-001"]
+    }
+  ],
+  "next_hints": [
+    {
+      "kind": "verify",
+      "target": "cargo clippy --all-targets",
+      "reason": "Run clippy after changing Rust error-handling paths.",
+      "confidence": 0.85
+    }
+  ],
+  "token_cost": {
+    "estimated_summary_tokens": 48,
+    "estimated_raw_tokens": 360,
+    "tokens_saved_vs_raw": 312
+  },
+  "validity": {
+    "status": "valid"
+  }
+}

--- a/tests/fixtures/shared/common_sveltekit_vs_react_action_summary.json
+++ b/tests/fixtures/shared/common_sveltekit_vs_react_action_summary.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "action-memory.v0.2",
+  "summary_id": "photon-common-sveltekit-vs-react",
+  "session_id": "common-seed",
+  "repo_id": "__common__",
+  "task_signature": "sveltekit-route-edit",
+  "summary_level": "case",
+  "facts": [
+    {
+      "text": "SvelteKit route pages use .svelte files and native Svelte syntax; React and Next.js components are not interchangeable with Svelte route components.",
+      "evidence_ids": ["common-sveltekit-ev-001"],
+      "confidence": 0.95
+    }
+  ],
+  "avoid": [
+    {
+      "action": "add React or Next.js component patterns to a SvelteKit route page",
+      "reason": "SvelteKit fixtures expect native Svelte component syntax.",
+      "evidence_ids": ["common-sveltekit-ev-001"]
+    }
+  ],
+  "next_hints": [
+    {
+      "kind": "inspect",
+      "target": "src/routes/+page.svelte",
+      "reason": "Read the existing Svelte page before editing route UI.",
+      "confidence": 0.85
+    }
+  ],
+  "token_cost": {
+    "estimated_summary_tokens": 58,
+    "estimated_raw_tokens": 420,
+    "tokens_saved_vs_raw": 362
+  },
+  "validity": {
+    "status": "valid"
+  }
+}

--- a/tests/test_anvil_eval_multilingual_seeds.py
+++ b/tests/test_anvil_eval_multilingual_seeds.py
@@ -31,6 +31,7 @@ from photon_action_memory.memory.summary_store import SummaryStore
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SHARED = REPO_ROOT / "tests" / "fixtures" / "shared"
 SEED_SCRIPT = REPO_ROOT / "scripts" / "seed_expanded_eval_scenarios.sh"
+COMMON_SEED_SCRIPT = REPO_ROOT / "scripts" / "seed_common_seeds.sh"
 
 SEED_FILES: tuple[str, ...] = (
     "anvil_eval_s1_02_action_summary.json",
@@ -51,6 +52,12 @@ CROSS_LINGUAL_EN_SEEDS: dict[str, str] = {
     "anvil_eval_s3_01_en_action_summary.json": "S3-01-en",
     "anvil_eval_s5_01_en_action_summary.json": "S5-01-en",
 }
+
+COMMON_SEED_FILES: tuple[str, ...] = (
+    "common_pytest_action_summary.json",
+    "common_rust_error_handling_action_summary.json",
+    "common_sveltekit_vs_react_action_summary.json",
+)
 
 JP_PHRASE_EXPECTATIONS: dict[str, tuple[str, ...]] = {
     "anvil_eval_s1_02_action_summary.json": (
@@ -184,6 +191,23 @@ def test_seed_script_references_all_fixtures() -> None:
     contents = SEED_SCRIPT.read_text(encoding="utf-8")
     for filename in SEED_FILES:
         assert filename in contents, f"seed script must reference {filename}"
+    assert "seed_common_seeds.sh" in contents
+
+
+@pytest.mark.parametrize("filename", COMMON_SEED_FILES)
+def test_common_seed_validates_as_action_summary(filename: str) -> None:
+    raw = _load(filename)
+    summary = ActionSummary.model_validate(raw)
+    assert summary.repo_id == "__common__"
+    assert summary.task_signature
+    assert summary.facts
+
+
+def test_common_seed_script_references_common_fixtures() -> None:
+    assert COMMON_SEED_SCRIPT.exists(), "seed_common_seeds.sh must exist"
+    contents = COMMON_SEED_SCRIPT.read_text(encoding="utf-8")
+    for filename in COMMON_SEED_FILES:
+        assert filename in contents, f"common seed script must reference {filename}"
 
 
 @pytest.mark.parametrize(("filename", "phrases"), JP_PHRASE_EXPECTATIONS.items())

--- a/tests/test_context_pack.py
+++ b/tests/test_context_pack.py
@@ -38,6 +38,7 @@ from photon_action_memory.context.quality_gate import (
     premature_overlap_threshold,
 )
 from photon_action_memory.context.render import estimate_tokens, render_summary
+from photon_action_memory.memory.retrieval import COMMON_REPO_ID, merge_dedup_summaries
 from photon_action_memory.memory.sanitizer import REDACTED_SECRET
 from photon_action_memory.memory.store import SQLiteEventStore
 from photon_action_memory.memory.summary_store import SummaryStore
@@ -826,6 +827,108 @@ def test_context_pack_api_auto_search_prefers_task_signature(tmp_path: Path) -> 
     items = response.json()["context_pack"]["items"]
     assert [item["id"] for item in items] == ["sum-task"]
     assert "task-specific memory" in items[0]["text"]
+
+
+def test_common_seed_fallback_merges_after_repo_specific_task_seed(tmp_path: Path) -> None:
+    ss = SummaryStore(tmp_path / "summaries.sqlite")
+    ss.upsert(
+        _make_summary(
+            "sum-task-specific",
+            repo_id="photon-test",
+            task_signature="python-pytest-pattern",
+            facts=[_fact("repo-specific pytest convention")],
+        )
+    )
+    ss.upsert(
+        _make_summary(
+            "sum-common-pytest",
+            repo_id=COMMON_REPO_ID,
+            task_signature="python-pytest-pattern",
+            facts=[_fact("common pytest verbose flag is -v")],
+        )
+    )
+    body = _pack_request()
+    body["task"]["task_signature"] = "python-pytest-pattern"
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"), summary_store=ss)
+    with TestClient(app) as client:
+        response = client.post("/v1/context/pack", json=body)
+
+    assert response.status_code == 200
+    items = response.json()["context_pack"]["items"]
+    assert [item["id"] for item in items] == ["sum-task-specific", "sum-common-pytest"]
+    assert "repo-specific pytest convention" in items[0]["text"]
+    assert "common pytest verbose flag is -v" in items[1]["text"]
+
+
+def test_common_seed_fallback_works_when_repo_has_no_match(tmp_path: Path) -> None:
+    ss = SummaryStore(tmp_path / "summaries.sqlite")
+    ss.upsert(
+        _make_summary(
+            "sum-common-rust",
+            repo_id=COMMON_REPO_ID,
+            task_signature="rust-error-handling",
+            facts=[_fact("Rust ? operator requires Result or Option return types")],
+        )
+    )
+    body = _pack_request()
+    body["repo"]["name"] = "unseeded-repo"
+    body["task"]["task_signature"] = "rust-error-handling"
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"), summary_store=ss)
+    with TestClient(app) as client:
+        response = client.post("/v1/context/pack", json=body)
+
+    assert response.status_code == 200
+    items = response.json()["context_pack"]["items"]
+    assert [item["id"] for item in items] == ["sum-common-rust"]
+    assert "Rust ? operator" in items[0]["text"]
+
+
+def test_common_seed_loses_token_budget_competition_to_specific_seed(tmp_path: Path) -> None:
+    ss = SummaryStore(tmp_path / "summaries.sqlite")
+    ss.upsert(
+        _make_summary(
+            "sum-specific-small",
+            repo_id="photon-test",
+            task_signature="sveltekit-route-edit",
+            facts=[_fact("specific SvelteKit route fact")],
+        )
+    )
+    ss.upsert(
+        _make_summary(
+            "sum-common-large",
+            repo_id=COMMON_REPO_ID,
+            task_signature="sveltekit-route-edit",
+            facts=[_fact("common SvelteKit context " * 40)],
+        )
+    )
+    body = _pack_request(max_tokens=20)
+    body["task"]["task_signature"] = "sveltekit-route-edit"
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"), summary_store=ss)
+    with TestClient(app) as client:
+        response = client.post("/v1/context/pack", json=body)
+
+    assert response.status_code == 200
+    payload = response.json()["context_pack"]
+    assert [item["id"] for item in payload["items"]] == ["sum-specific-small"]
+    assert [item["id"] for item in payload["omitted"]] == ["sum-common-large"]
+    assert payload["omitted"][0]["reason"] == "token budget exceeded"
+
+
+def test_common_seed_merge_prefers_existing_specific_summary_id() -> None:
+    specific = _make_summary(
+        "sum-duplicate",
+        repo_id="photon-test",
+        facts=[_fact("specific wins")],
+    )
+    common = _make_summary(
+        "sum-duplicate",
+        repo_id=COMMON_REPO_ID,
+        facts=[_fact("common duplicate loses")],
+    )
+
+    merged = merge_dedup_summaries([specific], [common])
+
+    assert merged == [specific]
 
 
 def test_context_pack_api_auto_resolves_repo_from_root_basename(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add __common__ common seed retrieval by task_signature after repo-specific lookup.
- Deduplicate retrieved summaries by summary_id with specific-first precedence.
- Add common seed fixtures and seed_common_seeds.sh, wired from the expanded eval seed script.

## Verification
- python -m pytest -q (955 passed, 1 skipped, 2 warnings)
- python -m ruff check .
- python -m ruff format --check .
- python -m mypy photon_action_memory tests
- bash -n scripts/seed_common_seeds.sh

Refs #109