### PR TITLE
feat(context): add universal seed scope

### DIFF
--- a/dev-reports/issue-111/design.md
+++ b/dev-reports/issue-111/design.md
@@ -1,0 +1,59 @@
+# Issue #111 Design
+
+## Goal
+
+Add universal applicability scope for language/framework/tool-wide seeds that
+can be retrieved independently of repo_id and task_signature.
+
+## Schema
+
+`ActionSummary` accepts schema versions `action-memory.v0.2` and
+`action-memory.v0.3`. Existing summaries default to:
+
+```text
+applicability_scope = "repo"
+universal_metadata = None
+```
+
+Universal summaries set:
+
+```text
+applicability_scope = "universal"
+universal_metadata = { language, framework, tool, os, severity, token_budget_cap }
+```
+
+## Retrieval
+
+Universal retrieval is Stage 4 after repo-specific and common seed retrieval:
+
+1. repo + task_signature
+2. repo fallback
+3. `__common__` + task_signature
+4. universal scope filtered by detected language/framework/tool/os
+
+`detect_universal_filters()` extracts filters from task text and touched files.
+The Stage 4 selector enforces:
+
+- max 5 universal summaries,
+- max 500 estimated tokens total,
+- per-seed `universal_metadata.token_budget_cap`.
+
+Universal summaries still pass through the normal ContextPack admission and
+quality gate, including prompt-visible secret masking and next_hint suppression.
+
+## CLI
+
+`photon-seed-add` is registered as a project script and can set scope and
+metadata:
+
+```bash
+photon-seed-add \
+  --fixture tests/fixtures/shared/universal_pytest_verbose_action_summary.json \
+  --scope universal \
+  --metadata-json '{"language":["python"],"framework":["pytest"]}'
+```
+
+## Seed Set
+
+`scripts/seed_universal_seeds.sh` seeds 10 initial universal fixtures covering
+Python, Rust, Node, SvelteKit, Git, and macOS/MLX guidance.

--- a/dev-reports/issue-111/implementation-summary.md
+++ b/dev-reports/issue-111/implementation-summary.md
@@ -1,0 +1,20 @@
+# Issue #111 Implementation Summary
+
+## Changes
+
+- Extended `ActionSummary` with `applicability_scope` and
+  `universal_metadata`.
+- Added `UniversalMetadata` and `UniversalFilters` DTOs.
+- Added `SummaryStore.search_universal()` and `SummaryRetriever.search_universal()`.
+- Added Stage 4 universal retrieval in `_resolve_context_summaries()`.
+- Added keyword filter detection for language/framework/tool/os.
+- Added strict universal selection caps: 5 items and 500 estimated tokens.
+- Added `photon-seed-add` CLI support for `--scope universal` and
+  `--metadata-json`.
+- Added 10 universal seed fixtures and `scripts/seed_universal_seeds.sh`.
+
+## Tests
+
+New tests cover schema defaults, store filtering, filter detection, cross-task
+universal retrieval, item cap, per-seed token cap, CLI payload generation, and
+universal fixture/script coverage.

--- a/dev-reports/issue-111/verification.md
+++ b/dev-reports/issue-111/verification.md
@@ -1,0 +1,28 @@
+# Issue #111 Verification
+
+## Automated Checks
+
+- `python -m pytest tests/test_universal_scope.py tests/test_anvil_eval_multilingual_seeds.py -q`
+  - Result: `81 passed`
+- `python -m pytest tests/test_context_pack.py tests/test_universal_scope.py -q`
+  - Result: `62 passed`
+- `python -m pytest tests/test_anvil_context_pack_api.py tests/test_anvil_contract.py -q`
+  - Result: `27 passed`
+- `python -m pytest -q`
+  - Result: `973 passed, 1 skipped, 2 warnings`
+- `python -m ruff check photon_action_memory/api/schema_v2.py photon_action_memory/api/server.py photon_action_memory/memory/summary_store.py photon_action_memory/memory/retrieval.py photon_action_memory/cli/seed_add.py tests/test_universal_scope.py tests/test_anvil_eval_multilingual_seeds.py`
+  - Result: pass
+- `python -m ruff format --check photon_action_memory/api/schema_v2.py photon_action_memory/api/server.py photon_action_memory/memory/summary_store.py photon_action_memory/memory/retrieval.py photon_action_memory/cli/seed_add.py tests/test_universal_scope.py tests/test_anvil_eval_multilingual_seeds.py`
+  - Result: pass
+- `python -m mypy photon_action_memory/api/schema_v2.py photon_action_memory/api/server.py photon_action_memory/memory/summary_store.py photon_action_memory/memory/retrieval.py photon_action_memory/cli/seed_add.py tests/test_universal_scope.py tests/test_anvil_eval_multilingual_seeds.py`
+  - Result: pass
+- `python -m ruff check .`
+  - Result: pass
+- `python -m ruff format --check .`
+  - Result: pass
+- `python -m mypy photon_action_memory tests`
+  - Result: pass
+- `bash -n scripts/seed_universal_seeds.sh`
+  - Result: pass
+- `python -m photon_action_memory.cli.seed_add --fixture tests/fixtures/shared/universal_pytest_verbose_action_summary.json --scope universal --metadata-json '{"language":["python"],"framework":["pytest"]}' --dry-run`
+  - Result: pass

--- a/photon_action_memory/api/schema_v2.py
+++ b/photon_action_memory/api/schema_v2.py
@@ -18,7 +18,7 @@ from photon_action_memory.api.schema import (
     WorkingMemory,
 )
 
-SchemaVersionV2 = Literal["action-memory.v0.2"]
+SchemaVersionV2 = Literal["action-memory.v0.2", "action-memory.v0.3"]
 DEFAULT_SCHEMA_VERSION_V2: SchemaVersionV2 = "action-memory.v0.2"
 
 ChunkKind = Literal[
@@ -39,6 +39,8 @@ StalenessStatusKind = Literal["valid", "stale", "partial", "contradicted", "unkn
 ValidityStatusKind = Literal["valid", "stale", "partial", "contradicted"]
 ContextPackMode = Literal["summary_only", "summary_plus_evidence", "none"]
 HypothesisStatus = Literal["open", "confirmed", "rejected"]
+ApplicabilityScope = Literal["repo", "task_signature", "universal"]
+UniversalSeverity = Literal["info", "warning", "critical"]
 
 
 # ---------------------------------------------------------------------------
@@ -197,6 +199,26 @@ class Validity(SidecarModel):
     reason: str | None = None
 
 
+class UniversalMetadata(SidecarModel):
+    """Applicability metadata for universal ActionSummary seeds."""
+
+    language: list[str] | None = None
+    framework: list[str] | None = None
+    tool: list[str] | None = None
+    os: list[str] | None = None
+    severity: UniversalSeverity | str = "info"
+    token_budget_cap: int = Field(default=100, ge=0)
+
+
+class UniversalFilters(SidecarModel):
+    """Detected context filters used to retrieve universal seeds."""
+
+    language: list[str] = Field(default_factory=list)
+    framework: list[str] = Field(default_factory=list)
+    tool: list[str] = Field(default_factory=list)
+    os: list[str] = Field(default_factory=list)
+
+
 # ---------------------------------------------------------------------------
 # ActionSummary
 # ---------------------------------------------------------------------------
@@ -222,6 +244,8 @@ class ActionSummary(SidecarModel):
     next_hints: list[NextHint] = Field(default_factory=list)
     token_cost: TokenCost | None = None
     validity: Validity = Field(default_factory=Validity)
+    applicability_scope: ApplicabilityScope | str = "repo"
+    universal_metadata: UniversalMetadata | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -46,6 +47,7 @@ from photon_action_memory.api.schema_v2 import (
     SummaryValidationResult,
     TokenBudget,
     TokenCost,
+    UniversalFilters,
 )
 from photon_action_memory.context.pack import build_context_pack
 from photon_action_memory.context.raw_policy import (
@@ -53,6 +55,7 @@ from photon_action_memory.context.raw_policy import (
     evaluate_raw_item,
     has_sensitive_content,
 )
+from photon_action_memory.context.render import estimate_tokens, render_summary
 from photon_action_memory.eval.summary_fidelity import SummaryFidelityChecker
 from photon_action_memory.memory.chunks import ActionChunker
 from photon_action_memory.memory.evidence import EvidenceExpander
@@ -71,6 +74,9 @@ from photon_action_memory.memory.summary_store import SummaryStore
 from photon_action_memory.models.photon_adapter import score_suggestions_with_optional_adapter
 from photon_action_memory.ranking.fallback import build_ranked_suggestions
 from photon_action_memory.ranking.guards import fallback_warnings
+
+_UNIVERSAL_MAX_ITEMS = 5
+_UNIVERSAL_MAX_TOKENS = 500
 
 
 class SummaryUpsertRequest(SidecarModel):
@@ -763,7 +769,117 @@ def _resolve_context_summaries(
             results,
             retriever.search_common(task_signature=task_signature),
         )
+    universal = _select_universal_summaries(
+        retriever.search_universal(filters=detect_universal_filters(request))
+    )
+    results = merge_dedup_summaries(results, universal)
     return results
+
+
+def detect_universal_filters(request: ContextPackRequest) -> UniversalFilters:
+    """Detect language/framework/tool/os filters for universal seed retrieval."""
+    text = _universal_detection_text(request)
+    touched = " ".join(request.working_memory.touched_files)
+    return UniversalFilters(
+        language=sorted(_detect_languages(text, touched)),
+        framework=sorted(_detect_frameworks(text, touched)),
+        tool=sorted(_detect_tools(text, touched)),
+        os=sorted(_detect_operating_systems(text)),
+    )
+
+
+def _universal_detection_text(request: ContextPackRequest) -> str:
+    parts = [
+        request.task.user_request,
+        request.task.summary or "",
+        request.working_memory.active_task or "",
+        " ".join(request.working_memory.constraints),
+        " ".join(request.working_memory.unresolved_errors),
+        " ".join(request.working_memory.notes),
+        " ".join(request.working_memory.touched_files),
+    ]
+    return "\n".join(part for part in parts if part).lower()
+
+
+def _detect_languages(text: str, touched_files: str) -> set[str]:
+    languages: set[str] = set()
+    markers = {
+        "python": ("python", "pytest", "pydantic", "fastapi", ".py"),
+        "rust": ("rust", "cargo", "clippy", ".rs"),
+        "javascript": ("javascript", "node", "npm", "pnpm", ".js", ".jsx"),
+        "typescript": ("typescript", "tsconfig", ".ts", ".tsx"),
+        "svelte": ("svelte", "sveltekit", ".svelte"),
+    }
+    haystack = f"{text}\n{touched_files.lower()}"
+    for language, needles in markers.items():
+        if any(needle in haystack for needle in needles):
+            languages.add(language)
+    return languages
+
+
+def _detect_frameworks(text: str, touched_files: str) -> set[str]:
+    frameworks: set[str] = set()
+    haystack = f"{text}\n{touched_files.lower()}"
+    markers = {
+        "pytest": ("pytest",),
+        "fastapi": ("fastapi",),
+        "pydantic": ("pydantic",),
+        "sveltekit": ("sveltekit", ".svelte", "src/routes"),
+        "react": ("react", ".jsx", ".tsx"),
+        "nextjs": ("next.js", "nextjs"),
+    }
+    for framework, needles in markers.items():
+        if any(needle in haystack for needle in needles):
+            frameworks.add(framework)
+    return frameworks
+
+
+def _detect_tools(text: str, touched_files: str) -> set[str]:
+    tools: set[str] = set()
+    haystack = f"{text}\n{touched_files.lower()}"
+    markers = {
+        "git": ("git", ".git", "commit", "worktree"),
+        "pytest": ("pytest",),
+        "cargo": ("cargo", "clippy"),
+        "npm": ("npm", "package.json"),
+        "pnpm": ("pnpm", "pnpm-lock.yaml"),
+        "node": ("node", "package.json", ".js", ".ts", ".svelte"),
+    }
+    for tool, needles in markers.items():
+        if any(needle in haystack for needle in needles):
+            tools.add(tool)
+    return tools
+
+
+def _detect_operating_systems(text: str) -> set[str]:
+    systems: set[str] = set()
+    markers = {
+        "darwin": ("macos", "mac os", "darwin", "mlx"),
+        "linux": ("linux", "ubuntu", "debian"),
+        "windows": ("windows", "powershell", "win32"),
+    }
+    for system, needles in markers.items():
+        if any(re.search(rf"\b{re.escape(needle)}\b", text) for needle in needles):
+            systems.add(system)
+    return systems
+
+
+def _select_universal_summaries(summaries: list[ActionSummary]) -> list[ActionSummary]:
+    selected: list[ActionSummary] = []
+    total_tokens = 0
+    for summary in summaries:
+        if len(selected) >= _UNIVERSAL_MAX_ITEMS:
+            break
+        tokens = estimate_tokens(render_summary(summary))
+        metadata = summary.universal_metadata
+        per_seed_cap = metadata.token_budget_cap if metadata is not None else 100
+        if tokens > per_seed_cap:
+            continue
+        if total_tokens + tokens > _UNIVERSAL_MAX_TOKENS:
+            continue
+        selected.append(summary)
+        total_tokens += tokens
+    return selected
 
 
 def _context_repo_id(request: ContextPackRequest) -> str | None:

--- a/photon_action_memory/cli/__init__.py
+++ b/photon_action_memory/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Command line helpers for PHOTON Action Memory."""

--- a/photon_action_memory/cli/seed_add.py
+++ b/photon_action_memory/cli/seed_add.py
@@ -1,0 +1,97 @@
+"""Add or update an ActionSummary seed through the sidecar API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, cast
+
+from photon_action_memory.api.schema_v2 import ActionSummary, UniversalMetadata
+
+
+def build_seed_payload(
+    summary: dict[str, Any],
+    *,
+    request_id: str,
+    scope: str | None = None,
+    metadata_json: str | None = None,
+    repo_id: str | None = None,
+    task_signature: str | None = None,
+    summary_id: str | None = None,
+) -> dict[str, Any]:
+    """Return a validated /v1/summary/upsert payload."""
+    updates: dict[str, Any] = {}
+    if scope is not None:
+        updates["applicability_scope"] = scope
+    if metadata_json:
+        metadata = UniversalMetadata.model_validate(json.loads(metadata_json))
+        updates["universal_metadata"] = metadata.model_dump(exclude_none=True)
+    if repo_id is not None:
+        updates["repo_id"] = repo_id
+    if task_signature is not None:
+        updates["task_signature"] = task_signature
+    if summary_id is not None:
+        updates["summary_id"] = summary_id
+    candidate = {**summary, **updates}
+    validated = ActionSummary.model_validate(candidate)
+    return {
+        "schema_version": validated.schema_version,
+        "request_id": request_id,
+        "summary": validated.model_dump(mode="json", exclude_none=True),
+    }
+
+
+def _post_json(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+    data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=5) as response:
+        body = response.read().decode("utf-8")
+    return cast(dict[str, Any], json.loads(body))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", default="http://127.0.0.1:18765")
+    parser.add_argument("--fixture", type=Path, required=True)
+    parser.add_argument("--request-id", default="seed-cli-add")
+    parser.add_argument("--scope", choices=("repo", "task_signature", "universal"))
+    parser.add_argument("--metadata-json", help="UniversalMetadata JSON object")
+    parser.add_argument("--repo-id")
+    parser.add_argument("--task-signature")
+    parser.add_argument("--summary-id")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    summary = json.loads(args.fixture.read_text(encoding="utf-8"))
+    payload = build_seed_payload(
+        summary,
+        request_id=args.request_id,
+        scope=args.scope,
+        metadata_json=args.metadata_json,
+        repo_id=args.repo_id,
+        task_signature=args.task_signature,
+        summary_id=args.summary_id,
+    )
+    if args.dry_run:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return 0
+    try:
+        result = _post_json(f"{args.url.rstrip('/')}/v1/summary/upsert", payload)
+    except urllib.error.URLError as exc:
+        print(f"failed to add seed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/photon_action_memory/memory/retrieval.py
+++ b/photon_action_memory/memory/retrieval.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from photon_action_memory.api.schema_v2 import ActionSummary
+from photon_action_memory.api.schema_v2 import ActionSummary, UniversalFilters
 from photon_action_memory.memory.staleness import StalenessContext, StalenessGuard
 from photon_action_memory.memory.summary_store import SummaryStore
 
@@ -64,6 +64,17 @@ class SummaryRetriever:
             staleness_context=staleness_context,
             limit=limit,
         )
+
+    def search_universal(
+        self,
+        *,
+        filters: UniversalFilters,
+        staleness_context: StalenessContext | None = None,
+        limit: int = 50,
+    ) -> list[ActionSummary]:
+        """Search universal-scope seeds, then apply staleness filtering."""
+        summaries = self._store.search_universal(filters=filters, limit=limit)
+        return self._filter_stale(summaries, staleness_context)
 
     def _filter_stale(
         self,

--- a/photon_action_memory/memory/summary_store.py
+++ b/photon_action_memory/memory/summary_store.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 from datetime import UTC, datetime
 from pathlib import Path
 
-from photon_action_memory.api.schema_v2 import ActionSummary
+from photon_action_memory.api.schema_v2 import ActionSummary, UniversalFilters
 from photon_action_memory.eval.summary_feedback import (
     SummaryFeedbackRecord,
     classify_outcome,
@@ -120,6 +120,34 @@ class SummaryStore:
         params.append(limit)
         rows = self._connection.execute(query, params).fetchall()
         return [ActionSummary.model_validate_json(row["payload_json"]) for row in rows]
+
+    def search_universal(
+        self,
+        *,
+        filters: UniversalFilters | None = None,
+        limit: int = 50,
+    ) -> list[ActionSummary]:
+        """Return universal-scope summaries matching detected context filters."""
+        if limit < 1:
+            msg = "limit must be >= 1"
+            raise ValueError(msg)
+        rows = self._connection.execute(
+            """
+            SELECT payload_json FROM action_summaries
+            WHERE validity_status = 'valid'
+            ORDER BY updated_at DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+        summaries = [ActionSummary.model_validate_json(row["payload_json"]) for row in rows]
+        universal = [
+            summary
+            for summary in summaries
+            if summary.applicability_scope == "universal"
+            and _matches_universal_filters(summary, filters)
+        ]
+        return sorted(universal, key=_universal_sort_key)
 
     def count(self) -> int:
         row = self._connection.execute("SELECT COUNT(*) AS cnt FROM action_summaries").fetchone()
@@ -276,6 +304,42 @@ def _row_to_feedback(row: sqlite3.Row | None) -> SummaryFeedbackRecord | None:
         expand_request_count=int(row["expand_request_count"]),
         quality_turns=int(row["quality_turns"]),
     )
+
+
+def _matches_universal_filters(
+    summary: ActionSummary,
+    filters: UniversalFilters | None,
+) -> bool:
+    metadata = summary.universal_metadata
+    if metadata is None:
+        return True
+    wanted = filters or UniversalFilters()
+    fields = ("language", "framework", "tool", "os")
+    has_declared_filter = False
+    has_match = False
+    for field in fields:
+        declared = _lower_set(getattr(metadata, field) or [])
+        if not declared:
+            continue
+        has_declared_filter = True
+        requested = _lower_set(getattr(wanted, field))
+        if declared & requested:
+            has_match = True
+    if not has_declared_filter:
+        return True
+    return has_match
+
+
+def _lower_set(values: list[str]) -> set[str]:
+    return {value.strip().lower() for value in values if value.strip()}
+
+
+def _universal_sort_key(summary: ActionSummary) -> tuple[int, str]:
+    severity = "info"
+    if summary.universal_metadata is not None:
+        severity = str(summary.universal_metadata.severity).lower()
+    priority = {"critical": 0, "warning": 1, "info": 2}.get(severity, 2)
+    return (priority, summary.summary_id)
 
 
 __all__ = ["SummaryStore"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ embedding = [
 [project.urls]
 Homepage = "https://github.com/kewton/photon-action-memory"
 
+[project.scripts]
+photon-seed-add = "photon_action_memory.cli.seed_add:main"
+
 [tool.hatch.build.targets.wheel]
 packages = ["photon_action_memory"]
 

--- a/scripts/seed_expanded_eval_scenarios.sh
+++ b/scripts/seed_expanded_eval_scenarios.sh
@@ -36,3 +36,6 @@ echo "=== Done ==="
 
 echo "=== Seeding common cross-repo memories ==="
 "$SCRIPT_DIR/seed_common_seeds.sh"
+
+echo "=== Seeding universal memories ==="
+"$SCRIPT_DIR/seed_universal_seeds.sh"

--- a/scripts/seed_universal_seeds.sh
+++ b/scripts/seed_universal_seeds.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Seed universal photon memories.
+# These fixtures use applicability_scope="universal" and metadata filters.
+# Run from the photon-action-memory repo root.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FIXTURES="$SCRIPT_DIR/../tests/fixtures/shared"
+
+SEEDS=(
+  "universal_pytest_verbose_action_summary.json:seed-universal-pytest-verbose"
+  "universal_python_pathlib_action_summary.json:seed-universal-python-pathlib"
+  "universal_fastapi_pydantic_action_summary.json:seed-universal-fastapi-pydantic"
+  "universal_rust_result_action_summary.json:seed-universal-rust-result"
+  "universal_rust_clippy_action_summary.json:seed-universal-rust-clippy"
+  "universal_node_package_scripts_action_summary.json:seed-universal-node-package-scripts"
+  "universal_sveltekit_native_action_summary.json:seed-universal-sveltekit-native"
+  "universal_git_amend_published_action_summary.json:seed-universal-git-amend-published"
+  "universal_git_worktree_action_summary.json:seed-universal-git-worktree"
+  "universal_macos_mlx_action_summary.json:seed-universal-macos-mlx"
+)
+
+echo "=== Seeding universal photon memories ==="
+for entry in "${SEEDS[@]}"; do
+  fixture="${entry%%:*}"
+  request_id="${entry##*:}"
+  echo -n "  $fixture ... "
+  python3 "$SCRIPT_DIR/seed_live_injection_summary.py" \
+    --fixture "$FIXTURES/$fixture" \
+    --request-id "$request_id" \
+    | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['status'])"
+done
+echo "=== Done ==="

--- a/tests/fixtures/shared/universal_fastapi_pydantic_action_summary.json
+++ b/tests/fixtures/shared/universal_fastapi_pydantic_action_summary.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "action-memory.v0.3",
+  "summary_id": "universal-fastapi-pydantic",
+  "session_id": "universal-seed",
+  "repo_id": "__common__",
+  "summary_level": "case",
+  "applicability_scope": "universal",
+  "universal_metadata": {
+    "language": ["python"],
+    "framework": ["fastapi", "pydantic"],
+    "severity": "warning",
+    "token_budget_cap": 90
+  },
+  "facts": [
+    {
+      "text": "FastAPI request and response bodies are validated through Pydantic models.",
+      "evidence_ids": ["universal-fastapi-pydantic-ev-001"],
+      "confidence": 0.9
+    }
+  ],
+  "next_hints": [
+    {
+      "kind": "verify",
+      "target": "schema validation tests",
+      "reason": "Exercise both accepted and rejected request payloads after schema changes.",
+      "confidence": 0.8
+    }
+  ],
+  "validity": { "status": "valid" }
+}

--- a/tests/fixtures/shared/universal_git_amend_published_action_summary.json
+++ b/tests/fixtures/shared/universal_git_amend_published_action_summary.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "action-memory.v0.3",
+  "summary_id": "universal-git-amend-published",
+  "session_id": "universal-seed",
+  "repo_id": "__common__",
+  "summary_level": "case",
+  "applicability_scope": "universal",
+  "universal_metadata": {
+    "tool": ["git"],
+    "severity": "critical",
+    "token_budget_cap": 80
+  },
+  "facts": [
+    {
+      "text": "git commit --amend rewrites the current commit and should not be used on published commits without explicit coordination.",
+      "evidence_ids": ["universal-git-amend-ev-001"],
+      "confidence": 0.95
+    }
+  ],
+  "avoid": [
+    {
+      "action": "amend a commit that has already been pushed",
+      "reason": "Rewriting published history can disrupt collaborators.",
+      "evidence_ids": ["universal-git-amend-ev-001"]
+    }
+  ],
+  "validity": { "status": "valid" }
+}

--- a/tests/fixtures/shared/universal_git_worktree_action_summary.json
+++ b/tests/fixtures/shared/universal_git_worktree_action_summary.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "action-memory.v0.3",
+  "summary_id": "universal-git-worktree",
+  "session_id": "universal-seed",
+  "repo_id": "__common__",
+  "summary_level": "case",
+  "applicability_scope": "universal",
+  "universal_metadata": {
+    "tool": ["git"],
+    "severity": "info",
+    "token_budget_cap": 70
+  },
+  "facts": [
+    {
+      "text": "git worktree allows separate checkouts of different branches while sharing one repository object database.",
+      "evidence_ids": ["universal-git-worktree-ev-001"],
+      "confidence": 0.9
+    }
+  ],
+  "validity": { "status": "valid" }
+}

--- a/tests/fixtures/shared/universal_macos_mlx_action_summary.json
+++ b/tests/fixtures/shared/universal_macos_mlx_action_summary.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "action-memory.v0.3",
+  "summary_id": "universal-macos-mlx",
+  "session_id": "universal-seed",
+  "repo_id": "__common__",
+  "summary_level": "case",
+  "applicability_scope": "universal",
+  "universal_metadata": {
+    "language": ["python"],
+    "os": ["darwin"],
+    "tool": ["mlx"],
+    "severity": "warning",
+    "token_budget_cap": 90
+  },
+  "facts": [
+    {
+      "text": "MLX smoke tests are macOS-specific and should stay opt-in outside dedicated macOS workflows.",
+      "evidence_ids": ["universal-macos-mlx-ev-001"],
+      "confidence": 0.9
+    }
+  ],
+  "validity": { "status": "valid" }
+}

--- a/tests/fixtures/shared/universal_node_package_scripts_action_summary.json
+++ b/tests/fixtures/shared/universal_node_package_scripts_action_summary.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "action-memory.v0.3",
+  "summary_id": "universal-node-package-scripts",
+  "session_id": "universal-seed",
+  "repo_id": "__common__",
+  "summary_level": "case",
+  "applicability_scope": "universal",
+  "universal_metadata": {
+    "language": ["javascript", "typescript"],
+    "tool": ["node", "npm", "pnpm"],
+    "severity": "info",
+    "token_budget_cap": 80
+  },
+  "facts": [
+    {
+      "text": "package.json scripts define project-local commands; prefer the existing package manager lockfile when choosing npm or pnpm.",
+      "evidence_ids": ["universal-node-scripts-ev-001"],
+      "confidence": 0.9
+    }
+  ],
+  "validity": { "status": "valid" }
+}

--- a/tests/fixtures/shared/universal_pytest_verbose_action_summary.json
+++ b/tests/fixtures/shared/universal_pytest_verbose_action_summary.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "action-memory.v0.3",
+  "summary_id": "universal-pytest-verbose",
+  "session_id": "universal-seed",
+  "repo_id": "__common__",
+  "summary_level": "case",
+  "applicability_scope": "universal",
+  "universal_metadata": {
+    "language": ["python"],
+    "framework": ["pytest"],
+    "tool": ["pytest"],
+    "severity": "info",
+    "token_budget_cap": 80
+  },
+  "facts": [
+    {
+      "text": "pytest -v enables verbose test output, and -x stops after the first failing test.",
+      "evidence_ids": ["universal-pytest-ev-001"],
+      "confidence": 0.95
+    }
+  ],
+  "next_hints": [
+    {
+      "kind": "verify",
+      "target": "pytest -v -x",
+      "reason": "Use verbose fail-fast pytest runs when reproducing a specific failure.",
+      "confidence": 0.85
+    }
+  ],
+  "validity": { "status": "valid" }
+}

--- a/tests/fixtures/shared/universal_python_pathlib_action_summary.json
+++ b/tests/fixtures/shared/universal_python_pathlib_action_summary.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "action-memory.v0.3",
+  "summary_id": "universal-python-pathlib",
+  "session_id": "universal-seed",
+  "repo_id": "__common__",
+  "summary_level": "case",
+  "applicability_scope": "universal",
+  "universal_metadata": {
+    "language": ["python"],
+    "severity": "info",
+    "token_budget_cap": 80
+  },
+  "facts": [
+    {
+      "text": "pathlib.Path keeps path joins portable across Linux, macOS, and Windows.",
+      "evidence_ids": ["universal-python-pathlib-ev-001"],
+      "confidence": 0.9
+    }
+  ],
+  "avoid": [
+    {
+      "action": "build paths by string concatenation",
+      "reason": "Manual separators are easy to break on another operating system.",
+      "evidence_ids": ["universal-python-pathlib-ev-001"]
+    }
+  ],
+  "validity": { "status": "valid" }
+}

--- a/tests/fixtures/shared/universal_rust_clippy_action_summary.json
+++ b/tests/fixtures/shared/universal_rust_clippy_action_summary.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "action-memory.v0.3",
+  "summary_id": "universal-rust-clippy",
+  "session_id": "universal-seed",
+  "repo_id": "__common__",
+  "summary_level": "case",
+  "applicability_scope": "universal",
+  "universal_metadata": {
+    "language": ["rust"],
+    "tool": ["cargo"],
+    "severity": "info",
+    "token_budget_cap": 70
+  },
+  "facts": [
+    {
+      "text": "cargo clippy --all-targets checks library, binary, test, and example targets.",
+      "evidence_ids": ["universal-rust-clippy-ev-001"],
+      "confidence": 0.9
+    }
+  ],
+  "next_hints": [
+    {
+      "kind": "verify",
+      "target": "cargo clippy --all-targets",
+      "reason": "Run clippy broadly after changing Rust code.",
+      "confidence": 0.85
+    }
+  ],
+  "validity": { "status": "valid" }
+}

--- a/tests/fixtures/shared/universal_rust_result_action_summary.json
+++ b/tests/fixtures/shared/universal_rust_result_action_summary.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "action-memory.v0.3",
+  "summary_id": "universal-rust-result-handling",
+  "session_id": "universal-seed",
+  "repo_id": "__common__",
+  "summary_level": "case",
+  "applicability_scope": "universal",
+  "universal_metadata": {
+    "language": ["rust"],
+    "tool": ["cargo"],
+    "severity": "warning",
+    "token_budget_cap": 90
+  },
+  "facts": [
+    {
+      "text": "Rust's ? operator can only be used where the enclosing function returns Result, Option, or another compatible Try type.",
+      "evidence_ids": ["universal-rust-result-ev-001"],
+      "confidence": 0.95
+    }
+  ],
+  "avoid": [
+    {
+      "action": "replace recoverable errors with panic! in library code",
+      "reason": "Result propagation lets callers handle failure.",
+      "evidence_ids": ["universal-rust-result-ev-001"]
+    }
+  ],
+  "validity": { "status": "valid" }
+}

--- a/tests/fixtures/shared/universal_sveltekit_native_action_summary.json
+++ b/tests/fixtures/shared/universal_sveltekit_native_action_summary.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "action-memory.v0.3",
+  "summary_id": "universal-sveltekit-native",
+  "session_id": "universal-seed",
+  "repo_id": "__common__",
+  "summary_level": "case",
+  "applicability_scope": "universal",
+  "universal_metadata": {
+    "language": ["svelte"],
+    "framework": ["sveltekit"],
+    "severity": "warning",
+    "token_budget_cap": 90
+  },
+  "facts": [
+    {
+      "text": "SvelteKit route pages use .svelte files and native Svelte syntax rather than React component syntax.",
+      "evidence_ids": ["universal-sveltekit-ev-001"],
+      "confidence": 0.95
+    }
+  ],
+  "avoid": [
+    {
+      "action": "insert React or Next.js component patterns into a Svelte route",
+      "reason": "Svelte templates compile differently from JSX.",
+      "evidence_ids": ["universal-sveltekit-ev-001"]
+    }
+  ],
+  "validity": { "status": "valid" }
+}

--- a/tests/test_anvil_context_pack_api.py
+++ b/tests/test_anvil_context_pack_api.py
@@ -82,7 +82,7 @@ def test_anvil_summary_appears_in_context_pack_items(tmp_path: Path) -> None:
     summary = ActionSummary.model_validate(raw_summary)
     summary_store.upsert(summary)
 
-    body = {
+    body: dict[str, object] = {
         "schema_version": DEFAULT_SCHEMA_VERSION_V2,
         "request_id": "pack-anvil-sum-001",
         "agent": {"name": "anvil", "version": "1.0.0"},
@@ -107,7 +107,7 @@ def test_anvil_summary_appears_in_context_pack_items(tmp_path: Path) -> None:
 
 def test_anvil_unknown_candidate_summary_id_is_skipped(tmp_path: Path) -> None:
     app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"))
-    body = {
+    body: dict[str, object] = {
         "schema_version": DEFAULT_SCHEMA_VERSION_V2,
         "request_id": "pack-anvil-unknown-001",
         "agent": {"name": "anvil", "version": "1.0.0"},
@@ -141,7 +141,7 @@ def test_anvil_stale_summary_not_in_context_pack(tmp_path: Path) -> None:
     summary = summary.model_copy(update={"validity": Validity(status="stale", reason="outdated")})
     summary_store.upsert(summary)
 
-    body = {
+    body: dict[str, object] = {
         "schema_version": DEFAULT_SCHEMA_VERSION_V2,
         "request_id": "pack-anvil-stale-001",
         "agent": {"name": "anvil", "version": "1.0.0"},

--- a/tests/test_anvil_contract.py
+++ b/tests/test_anvil_contract.py
@@ -282,7 +282,7 @@ def test_anvil_summary_upsert_and_resolve_via_context_pack(tmp_path: Path) -> No
     summary_store.upsert(summary)
 
     with TestClient(create_app(event_store, summary_store)) as client:
-        body = {
+        body: dict[str, object] = {
             "schema_version": DEFAULT_SCHEMA_VERSION_V2,
             "request_id": "pack-resolve-001",
             "agent": {"name": "anvil", "version": "1.0.0"},

--- a/tests/test_anvil_eval_multilingual_seeds.py
+++ b/tests/test_anvil_eval_multilingual_seeds.py
@@ -32,6 +32,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SHARED = REPO_ROOT / "tests" / "fixtures" / "shared"
 SEED_SCRIPT = REPO_ROOT / "scripts" / "seed_expanded_eval_scenarios.sh"
 COMMON_SEED_SCRIPT = REPO_ROOT / "scripts" / "seed_common_seeds.sh"
+UNIVERSAL_SEED_SCRIPT = REPO_ROOT / "scripts" / "seed_universal_seeds.sh"
 
 SEED_FILES: tuple[str, ...] = (
     "anvil_eval_s1_02_action_summary.json",
@@ -57,6 +58,19 @@ COMMON_SEED_FILES: tuple[str, ...] = (
     "common_pytest_action_summary.json",
     "common_rust_error_handling_action_summary.json",
     "common_sveltekit_vs_react_action_summary.json",
+)
+
+UNIVERSAL_SEED_FILES: tuple[str, ...] = (
+    "universal_pytest_verbose_action_summary.json",
+    "universal_python_pathlib_action_summary.json",
+    "universal_fastapi_pydantic_action_summary.json",
+    "universal_rust_result_action_summary.json",
+    "universal_rust_clippy_action_summary.json",
+    "universal_node_package_scripts_action_summary.json",
+    "universal_sveltekit_native_action_summary.json",
+    "universal_git_amend_published_action_summary.json",
+    "universal_git_worktree_action_summary.json",
+    "universal_macos_mlx_action_summary.json",
 )
 
 JP_PHRASE_EXPECTATIONS: dict[str, tuple[str, ...]] = {
@@ -192,6 +206,7 @@ def test_seed_script_references_all_fixtures() -> None:
     for filename in SEED_FILES:
         assert filename in contents, f"seed script must reference {filename}"
     assert "seed_common_seeds.sh" in contents
+    assert "seed_universal_seeds.sh" in contents
 
 
 @pytest.mark.parametrize("filename", COMMON_SEED_FILES)
@@ -208,6 +223,23 @@ def test_common_seed_script_references_common_fixtures() -> None:
     contents = COMMON_SEED_SCRIPT.read_text(encoding="utf-8")
     for filename in COMMON_SEED_FILES:
         assert filename in contents, f"common seed script must reference {filename}"
+
+
+@pytest.mark.parametrize("filename", UNIVERSAL_SEED_FILES)
+def test_universal_seed_validates_as_action_summary(filename: str) -> None:
+    raw = _load(filename)
+    summary = ActionSummary.model_validate(raw)
+    assert summary.schema_version == "action-memory.v0.3"
+    assert summary.applicability_scope == "universal"
+    assert summary.universal_metadata is not None
+    assert summary.facts
+
+
+def test_universal_seed_script_references_universal_fixtures() -> None:
+    assert UNIVERSAL_SEED_SCRIPT.exists(), "seed_universal_seeds.sh must exist"
+    contents = UNIVERSAL_SEED_SCRIPT.read_text(encoding="utf-8")
+    for filename in UNIVERSAL_SEED_FILES:
+        assert filename in contents, f"universal seed script must reference {filename}"
 
 
 @pytest.mark.parametrize(("filename", "phrases"), JP_PHRASE_EXPECTATIONS.items())

--- a/tests/test_universal_scope.py
+++ b/tests/test_universal_scope.py
@@ -1,0 +1,213 @@
+"""Universal applicability scope tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    ActionSummary,
+    ContextPackRequest,
+    Fact,
+    UniversalFilters,
+    UniversalMetadata,
+    Validity,
+)
+from photon_action_memory.api.server import create_app, detect_universal_filters
+from photon_action_memory.cli.seed_add import build_seed_payload
+from photon_action_memory.memory.store import SQLiteEventStore
+from photon_action_memory.memory.summary_store import SummaryStore
+
+
+def _fact(text: str) -> Fact:
+    return Fact(text=text, evidence_ids=["ev-1"], confidence=0.9)
+
+
+def _summary(
+    summary_id: str,
+    *,
+    repo_id: str | None = "photon-test",
+    task_signature: str | None = None,
+    facts: list[Fact] | None = None,
+) -> ActionSummary:
+    return ActionSummary(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        summary_id=summary_id,
+        session_id="sess-universal",
+        repo_id=repo_id,
+        task_signature=task_signature,
+        facts=facts or [_fact(f"{summary_id} fact")],
+        validity=Validity(status="valid"),
+    )
+
+
+def _universal_summary(
+    summary_id: str,
+    *,
+    metadata: UniversalMetadata,
+    fact_text: str | None = None,
+) -> ActionSummary:
+    return _summary(
+        summary_id,
+        repo_id="__common__",
+        task_signature="unrelated-task",
+        facts=[_fact(fact_text or f"{summary_id} universal fact")],
+    ).model_copy(
+        update={
+            "schema_version": "action-memory.v0.3",
+            "applicability_scope": "universal",
+            "universal_metadata": metadata,
+        }
+    )
+
+
+def _pack_request(*, user_request: str, touched_files: list[str] | None = None) -> dict:  # type: ignore[type-arg]
+    return {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "req-universal",
+        "agent": {"name": "codex"},
+        "repo": {"root": "/tmp/photon-test", "name": "photon-test"},
+        "task": {
+            "user_request": user_request,
+            "mode": "act",
+            "summary": "working on unrelated task",
+            "task_signature": "different-task",
+        },
+        "working_memory": {"touched_files": touched_files or []},
+        "recent_event_ids": [],
+        "candidate_summary_ids": [],
+        "budget": {"max_memory_tokens": 800, "max_evidence_chars": 1200},
+    }
+
+
+def test_action_summary_defaults_to_repo_applicability_scope() -> None:
+    summary = _summary("sum-default")
+
+    assert summary.applicability_scope == "repo"
+    assert summary.universal_metadata is None
+
+
+def test_summary_store_search_universal_filters_metadata(tmp_path: Path) -> None:
+    store = SummaryStore(tmp_path / "summaries.sqlite")
+    python_seed = _universal_summary(
+        "universal-python",
+        metadata=UniversalMetadata(language=["python"], severity="info"),
+    )
+    git_seed = _universal_summary(
+        "universal-git",
+        metadata=UniversalMetadata(tool=["git"], severity="critical"),
+    )
+    store.upsert(python_seed)
+    store.upsert(git_seed)
+    store.upsert(_summary("repo-only", facts=[_fact("repo-only fact")]))
+
+    python_results = store.search_universal(filters=UniversalFilters(language=["python"]))
+    git_results = store.search_universal(filters=UniversalFilters(tool=["git"]))
+
+    assert [summary.summary_id for summary in python_results] == ["universal-python"]
+    assert [summary.summary_id for summary in git_results] == ["universal-git"]
+
+
+def test_detect_universal_filters_from_task_text_and_files() -> None:
+    request = ContextPackRequest.model_validate(
+        _pack_request(
+            user_request="Fix a pytest failure in a FastAPI route and commit it with git.",
+            touched_files=["app/api.py", "tests/test_api.py"],
+        )
+    )
+
+    filters = detect_universal_filters(request)
+
+    assert "python" in filters.language
+    assert "pytest" in filters.framework
+    assert "fastapi" in filters.framework
+    assert "git" in filters.tool
+
+
+def test_context_pack_injects_universal_seed_across_task_signature(tmp_path: Path) -> None:
+    store = SummaryStore(tmp_path / "summaries.sqlite")
+    store.upsert(
+        _universal_summary(
+            "universal-pytest",
+            metadata=UniversalMetadata(language=["python"], framework=["pytest"]),
+            fact_text="pytest -v -x is useful for focused failure reproduction",
+        )
+    )
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"), summary_store=store)
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/context/pack",
+            json=_pack_request(
+                user_request="Fix the failing pytest test.",
+                touched_files=["tests/test_widget.py"],
+            ),
+        )
+
+    assert response.status_code == 200
+    payload = response.json()["context_pack"]
+    assert [item["id"] for item in payload["items"]] == ["universal-pytest"]
+    assert "pytest -v -x" in payload["items"][0]["text"]
+
+
+def test_universal_seed_stage_limits_to_five_items(tmp_path: Path) -> None:
+    store = SummaryStore(tmp_path / "summaries.sqlite")
+    for index in range(6):
+        store.upsert(
+            _universal_summary(
+                f"universal-python-{index}",
+                metadata=UniversalMetadata(language=["python"], token_budget_cap=100),
+            )
+        )
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"), summary_store=store)
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/context/pack",
+            json=_pack_request(user_request="Edit Python code.", touched_files=["src/app.py"]),
+        )
+
+    assert response.status_code == 200
+    items = response.json()["context_pack"]["items"]
+    assert len(items) == 5
+
+
+def test_universal_seed_over_per_seed_token_cap_is_not_injected(tmp_path: Path) -> None:
+    store = SummaryStore(tmp_path / "summaries.sqlite")
+    store.upsert(
+        _universal_summary(
+            "universal-too-large",
+            metadata=UniversalMetadata(language=["python"], token_budget_cap=10),
+            fact_text="large universal context " * 50,
+        )
+    )
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"), summary_store=store)
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/context/pack",
+            json=_pack_request(user_request="Edit Python code.", touched_files=["src/app.py"]),
+        )
+
+    assert response.status_code == 200
+    assert response.json()["context_pack"]["items"] == []
+
+
+def test_seed_add_builds_universal_payload() -> None:
+    summary = _summary("sum-cli").model_dump(mode="json")
+
+    payload = build_seed_payload(
+        summary,
+        request_id="req-cli",
+        scope="universal",
+        metadata_json='{"language":["python"],"framework":["pytest"],"severity":"warning"}',
+        repo_id="__common__",
+        task_signature=None,
+        summary_id="sum-cli-universal",
+    )
+
+    body = payload["summary"]
+    assert payload["request_id"] == "req-cli"
+    assert body["summary_id"] == "sum-cli-universal"
+    assert body["applicability_scope"] == "universal"
+    assert body["universal_metadata"]["language"] == ["python"]
+    assert body["universal_metadata"]["severity"] == "warning"


### PR DESCRIPTION
## Summary
- Extend ActionSummary with universal applicability metadata while preserving repo-scope defaults.
- Add universal Stage 4 retrieval with language/framework/tool/os filter detection and strict item/token caps.
- Add photon-seed-add CLI support plus 10 universal seed fixtures and seed script wiring.

## Verification
- python -m pytest -q (973 passed, 1 skipped, 2 warnings)
- python -m ruff check .
- python -m ruff format --check .
- python -m mypy photon_action_memory tests
- bash -n scripts/seed_universal_seeds.sh
- python -m photon_action_memory.cli.seed_add --fixture tests/fixtures/shared/universal_pytest_verbose_action_summary.json --scope universal --metadata-json '{language:[python],framework:[pytest]}' --dry-run

Refs #111