### PR TITLE
feat(governance): add contradiction detection across seeds (#110)

### DIFF
--- a/dev-reports/issue-110/design.md
+++ b/dev-reports/issue-110/design.md
@@ -1,0 +1,175 @@
+# Issue #110 Design — Contradiction detection across seeds
+
+## Goal
+
+Flag conflicting `ActionSummary` seeds inside the same
+`repo_id + task_signature` scope, surface the conflict in audit reports,
+and emit a `ContextPack` warning when retrieved seeds disagree. Detection
+must be syntax-based (no LLM call) so it can run on every seed insertion
+and on every `/v1/context/pack` request without latency cost.
+
+## Scope
+
+In:
+
+- A pure-function module `photon_action_memory/governance/contradiction.py`.
+- New `needs_review` value for `ValidityStatusKind`.
+- A new `POST /v1/seeds/audit/contradictions` endpoint.
+- A `photon-audit` CLI script for ad-hoc audits.
+- `_resolve_context_summaries` emits a `contradiction_detected` warning
+  when admitted seeds conflict.
+- Quality gate path can mark a freshly upserted seed `needs_review` when
+  it conflicts with an existing seed in the same scope.
+
+Out (not required by Issue #110):
+
+- LLM-based semantic conflict detection.
+- Auto-resolution / merge of conflicting seeds.
+- UI surfaces beyond CLI / API JSON.
+
+## Detection rules
+
+`detect_contradictions(summaries)` returns a list of
+`ContradictionPair(summary_a_id, summary_b_id, kind, evidence)` records.
+
+For each ordered pair `(a, b)` of summaries in the same `repo_id +
+task_signature` scope (universal seeds compared against any other seed
+sharing detected metadata are out of scope; we restrict by repo+task to
+keep the pair count bounded), the following syntax checks fire:
+
+1. `avoid_vs_action` — token overlap between `a.avoid[*].action` and
+   `b.actions_done[*].command` / `b.actions_done[*].target` /
+   `b.next_hints[*].target` ≥ 0.5 Jaccard.
+2. `avoid_vs_avoid_negation` — `a.avoid[*].action` and
+   `b.avoid[*].action` overlap by ≥ 0.5 Jaccard but their `reason` text
+   contains opposite polarity markers (e.g. `do not use X` vs `use X
+   instead`).
+3. `fact_negation` — two facts with ≥ 0.5 token Jaccard but opposite
+   polarity, where polarity is detected by leading negation tokens
+   (`not`, `no`, `never`, `cannot`, `must not`, `do not`, `しない`,
+   `ない`) on otherwise-overlapping content.
+4. `next_hint_conflict` — overlapping `next_hints[*].target` on opposite
+   verbs (`add` vs `remove`, `enable` vs `disable`, `use` vs `do not
+   use`, `keep` vs `delete`).
+5. `failed_attempt_vs_next_hint` — `a.failed_attempts[*].action`
+   overlaps `b.next_hints[*].target` (suggesting an action already known
+   to fail). Token overlap ≥ 0.6 Jaccard.
+
+Each rule is implemented as a small pure function over `ActionSummary`
+sub-models. Token comparison reuses
+`photon_action_memory.context.overlap_detector.tokenize` (default
+`ascii` mode) so the behaviour matches the existing quality gate.
+
+## Schema additions
+
+- `ValidityStatusKind` gains `"needs_review"` so a seed that is found
+  to contradict another can be marked without being treated as
+  immediately stale or contradicted (which would suppress retrieval).
+- `_STALENESS_RISK` and `_VALIDITY_ADMISSION_FACTOR` (in
+  `models/context_scorer.py`) get a `needs_review` entry between
+  `partial` and `stale` so existing scoring code stays consistent.
+- `SummaryRetriever._STALE_STATUSES` is unchanged — `needs_review`
+  seeds remain retrievable but the contradiction warning fires.
+
+## API surface
+
+`POST /v1/seeds/audit/contradictions`
+
+Request body:
+
+```jsonc
+{
+  "schema_version": "action-memory.v0.2",
+  "request_id": "<uuid>",
+  "repo_id": "optional",
+  "task_signature": "optional",
+  "limit": 200
+}
+```
+
+Response body:
+
+```jsonc
+{
+  "schema_version": "action-memory.v0.2",
+  "request_id": "<uuid>",
+  "pairs": [
+    {
+      "summary_a_id": "...",
+      "summary_b_id": "...",
+      "kind": "avoid_vs_action",
+      "evidence": "do not use foo  vs  command 'use foo'"
+    }
+  ],
+  "scanned": 42
+}
+```
+
+The endpoint loads summaries from `SummaryStore`, scopes by
+`repo_id+task_signature` (or all summaries when both are `None`), groups
+by scope, then runs `detect_contradictions` per scope.
+
+## Context pack warning
+
+Inside `_resolve_context_summaries`, after the four-stage retrieval
+returns the final `results` list, the resolver runs
+`detect_contradictions(results)` and forwards each detected pair as a
+`ContextPackWarning(kind="contradiction_detected", message=…)`. The
+warning is appended through a new `extra_warnings` parameter on
+`build_context_pack` (or by mutating `route_warnings` before pack
+construction — the simpler option).
+
+## CLI
+
+`photon_action_memory/cli/audit.py` exposes a `photon-audit` script
+with subcommands:
+
+```
+photon-audit detect-contradictions [--url URL] [--repo-id R] [--task-signature T]
+```
+
+Implemented in the existing CLI style (`urllib.request`, no extra
+deps). `pyproject.toml` adds the `photon-audit` console script entry
+pointing at `photon_action_memory.cli.audit:main`.
+
+## Tests
+
+Unit (`tests/test_contradiction_detection.py`, ≥ 12 cases):
+
+1. Empty input returns `[]`.
+2. Single summary returns `[]`.
+3. `avoid` vs `actions_done` clear conflict.
+4. `avoid` vs `actions_done` token-disjoint → no conflict.
+5. `avoid` vs `avoid` polarity opposite.
+6. `avoid` vs `avoid` same polarity → no conflict.
+7. Fact negation (English `not`).
+8. Fact negation (Japanese `しない`).
+9. Fact overlap with no negation → no conflict.
+10. `next_hint` opposite verbs (`enable` vs `disable`).
+11. `next_hint` synonymous verbs → no conflict.
+12. `failed_attempt` vs `next_hint` overlap.
+13. Different `repo_id` → not paired (scope filter).
+14. Different `task_signature` → not paired.
+
+Integration (`tests/test_contradiction_detection_api.py`):
+
+- `POST /v1/seeds/audit/contradictions` returns expected pairs after
+  upserting two conflicting seeds.
+- `POST /v1/context/pack` emits a `contradiction_detected` warning when
+  both seeds match the request.
+- Resolution flow: marking the older seed as `validity.status =
+  "needs_review"` keeps it retrievable but the warning still fires;
+  marking it `contradicted` makes it disappear from the pack.
+
+## File map
+
+- `photon_action_memory/governance/__init__.py` (new package)
+- `photon_action_memory/governance/contradiction.py` (new)
+- `photon_action_memory/api/schema_v2.py` (extend
+  `ValidityStatusKind`, add audit request/response models)
+- `photon_action_memory/api/server.py` (new endpoint, warning emission)
+- `photon_action_memory/cli/audit.py` (new)
+- `pyproject.toml` (`photon-audit` script)
+- `photon_action_memory/models/context_scorer.py` (scoring constants)
+- `tests/test_contradiction_detection.py` (new)
+- `tests/test_contradiction_detection_api.py` (new)

--- a/dev-reports/issue-110/implementation-summary.md
+++ b/dev-reports/issue-110/implementation-summary.md
@@ -1,0 +1,45 @@
+# Issue #110 Implementation Summary
+
+## Changes
+
+- New `photon_action_memory/governance/` package with a pure-function
+  `contradiction.detect_contradictions()` that compares
+  `ActionSummary` seeds within the same `repo_id + task_signature`
+  scope and returns `ContradictionPair` records.
+- Five syntax-based detection rules: `avoid_vs_action`,
+  `avoid_polarity_conflict`, `fact_negation`, `next_hint_conflict`,
+  `failed_attempt_vs_next_hint`.
+- `ValidityStatusKind` extended with `"needs_review"`; scoring weights
+  in `models/context_scorer.py` updated so the new status sits between
+  `partial` and `stale`.
+- New `POST /v1/seeds/audit/contradictions` endpoint and
+  `ContradictionAuditRequest` / `ContradictionAuditResponse` /
+  `ContradictionPairModel` schemas.
+- `_resolve_context_summaries` runs detection on the resolved seed set
+  and emits `ContextPackWarning(kind="contradiction_detected", …)`
+  entries before pack assembly.
+- New `photon_action_memory/cli/audit.py` with the `photon-audit
+  detect-contradictions` subcommand and a matching console script in
+  `pyproject.toml`.
+
+## Tests
+
+- `tests/test_contradiction_detection.py` — 16 unit cases covering the
+  five detection rules, scope filtering, dedup, and the
+  `ContradictionPair` API.
+- `tests/test_contradiction_detection_api.py` — 7 integration cases:
+  audit endpoint output, context-pack warning emission, the
+  `needs_review` keep-warning path, the `contradicted` suppression
+  path, and CLI payload generation.
+
+## Compatibility
+
+- Existing seeds default to `applicability_scope="repo"` and
+  `validity.status="valid"` — no behaviour change for already-stored
+  data.
+- The new `needs_review` status is recoverable through
+  `SummaryRetriever` (it is not in `_STALE_STATUSES`), so seeds keep
+  being retrieved while the contradiction warning surfaces them for
+  review.
+- `_resolve_context_summaries` only adds detection at the final stage;
+  the existing universal/common/specific retrieval order is unchanged.

--- a/dev-reports/issue-110/verification.md
+++ b/dev-reports/issue-110/verification.md
@@ -1,0 +1,39 @@
+# Issue #110 Verification
+
+## Focused
+
+```
+$ python -m pytest tests/test_contradiction_detection.py tests/test_contradiction_detection_api.py -v
+23 passed in 0.28s
+```
+
+Covers:
+
+- 14 syntax-based detection cases (happy paths, false-positive guards,
+  edge cases including empty input, single summary, scope filtering,
+  Japanese negation, dedup).
+- API audit endpoint pair detection.
+- Context-pack `contradiction_detected` warning emission.
+- `validity.status="contradicted"` removes the warning (seed is no
+  longer retrieved).
+- `validity.status="needs_review"` keeps the warning (seed is still
+  retrieved and surfaced for review).
+- `photon-audit detect-contradictions` payload builder.
+
+## Broad
+
+```
+$ python -m pytest -q
+996 passed, 1 skipped, 2 warnings in 20.35s
+```
+
+Skipped test is the opt-in MLX integration smoke that runs only on the
+dedicated macOS workflow; unrelated to this change.
+
+## Manual checks
+
+- `photon_action_memory.governance.contradiction` imports cleanly under
+  Python 3.12.
+- `photon-audit detect-contradictions --help` exposes the new
+  subcommand once the project is reinstalled (the script entry was
+  registered via `pyproject.toml`).

--- a/photon_action_memory/api/schema_v2.py
+++ b/photon_action_memory/api/schema_v2.py
@@ -36,7 +36,7 @@ SummaryLevel = Literal["turn", "chunk", "session", "case"]
 AdmissionDecision = Literal["admit", "omit", "expand", "defer", "deny"]
 ExpandPolicy = Literal["on_demand_only", "always", "deny"]
 StalenessStatusKind = Literal["valid", "stale", "partial", "contradicted", "unknown"]
-ValidityStatusKind = Literal["valid", "stale", "partial", "contradicted"]
+ValidityStatusKind = Literal["valid", "stale", "partial", "contradicted", "needs_review"]
 ContextPackMode = Literal["summary_only", "summary_plus_evidence", "none"]
 HypothesisStatus = Literal["open", "confirmed", "rejected"]
 ApplicabilityScope = Literal["repo", "task_signature", "universal"]
@@ -587,6 +587,39 @@ class EvaluateResponse(SidecarModel):
     warnings: list[ContextPackWarning] = Field(default_factory=list)
 
 
+# ---------------------------------------------------------------------------
+# POST /v1/seeds/audit/contradictions
+# ---------------------------------------------------------------------------
+
+
+class ContradictionPairModel(SidecarModel):
+    """One contradictory pair detected by the governance audit."""
+
+    summary_a_id: str
+    summary_b_id: str
+    kind: str
+    evidence: str
+
+
+class ContradictionAuditRequest(SidecarModel):
+    """Request body for POST /v1/seeds/audit/contradictions."""
+
+    schema_version: SchemaVersionV2
+    request_id: str
+    repo_id: str | None = None
+    task_signature: str | None = None
+    limit: int = Field(default=200, ge=1, le=2000)
+
+
+class ContradictionAuditResponse(SidecarModel):
+    """Response body for POST /v1/seeds/audit/contradictions."""
+
+    schema_version: SchemaVersionV2
+    request_id: str
+    pairs: list[ContradictionPairModel] = Field(default_factory=list)
+    scanned: int = Field(default=0, ge=0)
+
+
 __all__ = [
     "DEFAULT_SCHEMA_VERSION_V2",
     "ActionChunk",
@@ -607,6 +640,9 @@ __all__ = [
     "ContextPackRequest",
     "ContextPackResponse",
     "ContextPackWarning",
+    "ContradictionAuditRequest",
+    "ContradictionAuditResponse",
+    "ContradictionPairModel",
     "EvaluateRequest",
     "EvaluateResponse",
     "EvidenceExpandBudget",

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -53,10 +53,6 @@ from photon_action_memory.api.schema_v2 import (
     UniversalFilters,
 )
 from photon_action_memory.context.pack import build_context_pack
-from photon_action_memory.governance.contradiction import (
-    ContradictionPair,
-    detect_contradictions,
-)
 from photon_action_memory.context.raw_policy import (
     RawEvidenceItem,
     evaluate_raw_item,
@@ -64,6 +60,10 @@ from photon_action_memory.context.raw_policy import (
 )
 from photon_action_memory.context.render import estimate_tokens, render_summary
 from photon_action_memory.eval.summary_fidelity import SummaryFidelityChecker
+from photon_action_memory.governance.contradiction import (
+    ContradictionPair,
+    detect_contradictions,
+)
 from photon_action_memory.memory.chunks import ActionChunker
 from photon_action_memory.memory.evidence import EvidenceExpander
 from photon_action_memory.memory.retrieval import (

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -33,6 +33,9 @@ from photon_action_memory.api.schema_v2 import (
     ContextPackRequest,
     ContextPackResponse,
     ContextPackWarning,
+    ContradictionAuditRequest,
+    ContradictionAuditResponse,
+    ContradictionPairModel,
     EvaluateRequest,
     EvaluateResponse,
     EvidenceExpandRequest,
@@ -50,6 +53,10 @@ from photon_action_memory.api.schema_v2 import (
     UniversalFilters,
 )
 from photon_action_memory.context.pack import build_context_pack
+from photon_action_memory.governance.contradiction import (
+    ContradictionPair,
+    detect_contradictions,
+)
 from photon_action_memory.context.raw_policy import (
     RawEvidenceItem,
     evaluate_raw_item,
@@ -167,6 +174,8 @@ def create_app(
             retriever = SummaryRetriever(_summary_store)
             repo_id = _context_repo_id(request)
             resolved = _resolve_context_summaries(retriever, request, repo_id=repo_id)
+            for pair in detect_contradictions(resolved):
+                route_warnings.append(_contradiction_warning(pair))
             raw_items = _extract_raw_items(request)
             feedback_map = _summary_store.get_feedback_map([s.summary_id for s in resolved])
             pack, decisions = build_context_pack(
@@ -381,7 +390,44 @@ def create_app(
             warnings=route_warnings,
         )
 
+    @app.post("/v1/seeds/audit/contradictions", response_model=ContradictionAuditResponse)
+    def audit_contradictions(
+        request: ContradictionAuditRequest,
+    ) -> ContradictionAuditResponse:
+        try:
+            summaries = _summary_store.search(
+                repo_id=request.repo_id,
+                task_signature=request.task_signature,
+                limit=request.limit,
+            )
+            pairs = detect_contradictions(summaries)
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        return ContradictionAuditResponse(
+            schema_version=DEFAULT_SCHEMA_VERSION_V2,
+            request_id=request.request_id,
+            pairs=[
+                ContradictionPairModel(
+                    summary_a_id=pair.summary_a_id,
+                    summary_b_id=pair.summary_b_id,
+                    kind=pair.kind,
+                    evidence=pair.evidence,
+                )
+                for pair in pairs
+            ],
+            scanned=len(summaries),
+        )
+
     return app
+
+
+def _contradiction_warning(pair: ContradictionPair) -> ContextPackWarning:
+    return ContextPackWarning(
+        kind="contradiction_detected",
+        message=(
+            f"{pair.kind}: {pair.summary_a_id} vs {pair.summary_b_id} - {pair.evidence}"
+        ),
+    )
 
 
 def _summarize_inline_chunks(

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -424,9 +424,7 @@ def create_app(
 def _contradiction_warning(pair: ContradictionPair) -> ContextPackWarning:
     return ContextPackWarning(
         kind="contradiction_detected",
-        message=(
-            f"{pair.kind}: {pair.summary_a_id} vs {pair.summary_b_id} - {pair.evidence}"
-        ),
+        message=(f"{pair.kind}: {pair.summary_a_id} vs {pair.summary_b_id} - {pair.evidence}"),
     )
 
 

--- a/photon_action_memory/cli/audit.py
+++ b/photon_action_memory/cli/audit.py
@@ -1,0 +1,90 @@
+"""Run governance audits against the sidecar (contradiction detection)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from typing import Any, cast
+
+
+def _post_json(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+    data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        body = response.read().decode("utf-8")
+    return cast(dict[str, Any], json.loads(body))
+
+
+def build_contradiction_payload(
+    *,
+    request_id: str,
+    repo_id: str | None,
+    task_signature: str | None,
+    limit: int,
+    schema_version: str = "action-memory.v0.2",
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": schema_version,
+        "request_id": request_id,
+        "limit": limit,
+    }
+    if repo_id is not None:
+        payload["repo_id"] = repo_id
+    if task_signature is not None:
+        payload["task_signature"] = task_signature
+    return payload
+
+
+def _detect_contradictions(args: argparse.Namespace) -> int:
+    payload = build_contradiction_payload(
+        request_id=args.request_id,
+        repo_id=args.repo_id,
+        task_signature=args.task_signature,
+        limit=args.limit,
+    )
+    if args.dry_run:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return 0
+    try:
+        result = _post_json(
+            f"{args.url.rstrip('/')}/v1/seeds/audit/contradictions",
+            payload,
+        )
+    except urllib.error.URLError as exc:
+        print(f"failed to run audit: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    pairs = result.get("pairs") or []
+    return 1 if pairs else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", default="http://127.0.0.1:18765")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    detect = subparsers.add_parser(
+        "detect-contradictions",
+        help="run contradiction detection on stored seeds",
+    )
+    detect.add_argument("--request-id", default="audit-contradictions")
+    detect.add_argument("--repo-id")
+    detect.add_argument("--task-signature")
+    detect.add_argument("--limit", type=int, default=200)
+    detect.add_argument("--dry-run", action="store_true")
+    detect.set_defaults(func=_detect_contradictions)
+
+    args = parser.parse_args(argv)
+    return cast(int, args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/photon_action_memory/governance/__init__.py
+++ b/photon_action_memory/governance/__init__.py
@@ -1,0 +1,1 @@
+"""Governance helpers for ActionSummary stores."""

--- a/photon_action_memory/governance/contradiction.py
+++ b/photon_action_memory/governance/contradiction.py
@@ -1,0 +1,374 @@
+"""Syntax-based contradiction detection between ActionSummary seeds.
+
+Pure functions only — no I/O, no LLM call. The detector compares
+summaries that share ``repo_id + task_signature`` and emits a
+:class:`ContradictionPair` for each rule that fires.
+
+Rules (all token comparisons use Jaccard over the multilingual
+tokenizer the quality gate already uses):
+
+1. ``avoid_vs_action``           — ``a.avoid[*].action`` overlaps a
+   ``b.actions_done`` command/target or a ``b.next_hints`` target.
+2. ``avoid_polarity_conflict``   — both summaries warn about the same
+   action but with opposite polarity in the reason.
+3. ``fact_negation``             — overlapping facts with one carrying
+   a negation marker the other does not.
+4. ``next_hint_conflict``        — opposite verbs (``add`` vs
+   ``remove`` etc.) on overlapping next-hint targets.
+5. ``failed_attempt_vs_next_hint`` — ``a.failed_attempts`` action
+   overlaps ``b.next_hints`` target (suggesting a known-failing
+   action).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from photon_action_memory.api.schema_v2 import ActionSummary
+from photon_action_memory.context.overlap_detector import tokenize
+
+_AVOID_VS_ACTION_THRESHOLD = 0.5
+_AVOID_VS_AVOID_THRESHOLD = 0.5
+_FACT_NEGATION_THRESHOLD = 0.5
+_NEXT_HINT_THRESHOLD = 0.5
+_FAILED_VS_HINT_THRESHOLD = 0.6
+
+# Negation markers shared by avoid-reason and fact-text checks. Order is not
+# meaningful, but ``do not`` must come before ``not `` so the longer form
+# matches for de-duplicating "do not" inside polarity reporting.
+_NEGATION_MARKERS: tuple[str, ...] = (
+    "do not",
+    "don't",
+    "does not",
+    "doesn't",
+    "must not",
+    "should not",
+    "shouldn't",
+    "cannot",
+    "can't",
+    "never",
+    "no longer",
+    "not ",
+    " not.",
+    "ない",
+    "しない",
+    "禁止",
+    "不可",
+)
+# Verb pairs that cancel each other in next_hints.
+_OPPOSITE_VERB_PAIRS: tuple[tuple[str, str], ...] = (
+    ("add", "remove"),
+    ("add", "delete"),
+    ("create", "delete"),
+    ("enable", "disable"),
+    ("use", "avoid"),
+    ("keep", "remove"),
+    ("keep", "delete"),
+    ("install", "uninstall"),
+    ("start", "stop"),
+    ("show", "hide"),
+)
+
+
+@dataclass(frozen=True)
+class ContradictionPair:
+    """A pair of summaries identified as contradictory."""
+
+    summary_a_id: str
+    summary_b_id: str
+    kind: str
+    evidence: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "summary_a_id": self.summary_a_id,
+            "summary_b_id": self.summary_b_id,
+            "kind": self.kind,
+            "evidence": self.evidence,
+        }
+
+
+def detect_contradictions(
+    summaries: Iterable[ActionSummary],
+) -> list[ContradictionPair]:
+    """Return contradictions among ``summaries`` sharing repo+task scope.
+
+    Summaries are grouped by ``(repo_id, task_signature)``; pairs are
+    only compared inside the same group so the result remains O(n²) per
+    scope rather than O(N²) globally. Group membership for ``None``
+    values is exact: ``repo_id=None`` is its own bucket and never
+    matches a populated ``repo_id``.
+    """
+    grouped: dict[tuple[str | None, str | None], list[ActionSummary]] = {}
+    for summary in summaries:
+        key = (summary.repo_id, summary.task_signature)
+        grouped.setdefault(key, []).append(summary)
+
+    pairs: list[ContradictionPair] = []
+    for group in grouped.values():
+        if len(group) < 2:
+            continue
+        for i in range(len(group)):
+            a = group[i]
+            for j in range(i + 1, len(group)):
+                b = group[j]
+                pairs.extend(_compare_pair(a, b))
+    return pairs
+
+
+def _compare_pair(a: ActionSummary, b: ActionSummary) -> list[ContradictionPair]:
+    found: list[ContradictionPair] = []
+    found.extend(_check_avoid_vs_action(a, b))
+    found.extend(_check_avoid_vs_action(b, a))
+    found.extend(_check_avoid_polarity(a, b))
+    found.extend(_check_fact_negation(a, b))
+    found.extend(_check_next_hint_conflict(a, b))
+    found.extend(_check_failed_vs_next_hint(a, b))
+    found.extend(_check_failed_vs_next_hint(b, a))
+    return _dedup(found)
+
+
+def _check_avoid_vs_action(
+    avoider: ActionSummary,
+    actor: ActionSummary,
+) -> list[ContradictionPair]:
+    """Avoid guidance on one side that contradicts an action on the other."""
+    out: list[ContradictionPair] = []
+    if not avoider.avoid:
+        return out
+    actor_targets: list[tuple[str, str]] = []
+    for done in actor.actions_done:
+        for value in (done.command, done.target):
+            if value:
+                actor_targets.append(("actions_done", value))
+    for hint in actor.next_hints:
+        if hint.target:
+            actor_targets.append(("next_hints", hint.target))
+    if not actor_targets:
+        return out
+    for guidance in avoider.avoid:
+        guidance_text = guidance.action
+        guidance_tokens = tokenize(guidance_text)
+        if not guidance_tokens:
+            continue
+        for source, target_text in actor_targets:
+            target_tokens = tokenize(target_text)
+            if _jaccard(guidance_tokens, target_tokens) < _AVOID_VS_ACTION_THRESHOLD:
+                continue
+            out.append(
+                ContradictionPair(
+                    summary_a_id=avoider.summary_id,
+                    summary_b_id=actor.summary_id,
+                    kind="avoid_vs_action",
+                    evidence=(
+                        f"avoid '{guidance_text}' contradicts {source} '{target_text}'"
+                    ),
+                )
+            )
+    return out
+
+
+def _check_avoid_polarity(
+    a: ActionSummary,
+    b: ActionSummary,
+) -> list[ContradictionPair]:
+    """Both seeds warn about the same action but with opposite stance.
+
+    Polarity is detected by negation markers in the ``reason`` text:
+    when one reason contains a negation marker and the other does not,
+    they disagree on whether the action should be taken.
+    """
+    out: list[ContradictionPair] = []
+    if not a.avoid or not b.avoid:
+        return out
+    for guidance_a in a.avoid:
+        tokens_a = tokenize(guidance_a.action)
+        if not tokens_a:
+            continue
+        for guidance_b in b.avoid:
+            tokens_b = tokenize(guidance_b.action)
+            if not tokens_b:
+                continue
+            if _jaccard(tokens_a, tokens_b) < _AVOID_VS_AVOID_THRESHOLD:
+                continue
+            neg_a = _has_negation(guidance_a.reason)
+            neg_b = _has_negation(guidance_b.reason)
+            if neg_a == neg_b:
+                continue
+            out.append(
+                ContradictionPair(
+                    summary_a_id=a.summary_id,
+                    summary_b_id=b.summary_id,
+                    kind="avoid_polarity_conflict",
+                    evidence=(
+                        f"avoid '{guidance_a.action}' "
+                        f"reason '{guidance_a.reason}' vs '{guidance_b.reason}'"
+                    ),
+                )
+            )
+    return out
+
+
+def _check_fact_negation(
+    a: ActionSummary,
+    b: ActionSummary,
+) -> list[ContradictionPair]:
+    out: list[ContradictionPair] = []
+    if not a.facts or not b.facts:
+        return out
+    for fact_a in a.facts:
+        tokens_a = tokenize(fact_a.text)
+        if not tokens_a:
+            continue
+        neg_a = _has_negation(fact_a.text)
+        for fact_b in b.facts:
+            tokens_b = tokenize(fact_b.text)
+            if not tokens_b:
+                continue
+            if _jaccard(tokens_a, tokens_b) < _FACT_NEGATION_THRESHOLD:
+                continue
+            neg_b = _has_negation(fact_b.text)
+            if neg_a == neg_b:
+                continue
+            out.append(_fact_pair(a, b, fact_a.text, fact_b.text))
+    return out
+
+
+def _fact_pair(
+    a: ActionSummary,
+    b: ActionSummary,
+    text_a: str,
+    text_b: str,
+) -> ContradictionPair:
+    return ContradictionPair(
+        summary_a_id=a.summary_id,
+        summary_b_id=b.summary_id,
+        kind="fact_negation",
+        evidence=f"fact '{text_a}' vs '{text_b}'",
+    )
+
+
+def _check_next_hint_conflict(
+    a: ActionSummary,
+    b: ActionSummary,
+) -> list[ContradictionPair]:
+    out: list[ContradictionPair] = []
+    if not a.next_hints or not b.next_hints:
+        return out
+    for hint_a in a.next_hints:
+        kind_a = hint_a.kind.lower().strip()
+        target_a = (hint_a.target or "").lower().strip()
+        if not kind_a:
+            continue
+        for hint_b in b.next_hints:
+            kind_b = hint_b.kind.lower().strip()
+            target_b = (hint_b.target or "").lower().strip()
+            if not _is_opposite_verb(kind_a, kind_b):
+                continue
+            if not target_a or not target_b:
+                continue
+            tokens_a = tokenize(target_a)
+            tokens_b = tokenize(target_b)
+            if not tokens_a or not tokens_b:
+                continue
+            if _jaccard(tokens_a, tokens_b) < _NEXT_HINT_THRESHOLD:
+                continue
+            out.append(
+                ContradictionPair(
+                    summary_a_id=a.summary_id,
+                    summary_b_id=b.summary_id,
+                    kind="next_hint_conflict",
+                    evidence=(
+                        f"next_hint '{kind_a} {target_a}' "
+                        f"vs '{kind_b} {target_b}'"
+                    ),
+                )
+            )
+    return out
+
+
+def _check_failed_vs_next_hint(
+    a: ActionSummary,
+    b: ActionSummary,
+) -> list[ContradictionPair]:
+    out: list[ContradictionPair] = []
+    if not a.failed_attempts or not b.next_hints:
+        return out
+    for failed in a.failed_attempts:
+        failed_tokens = tokenize(failed.action)
+        if not failed_tokens:
+            continue
+        for hint in b.next_hints:
+            target = hint.target or ""
+            target_tokens = tokenize(target)
+            if not target_tokens:
+                continue
+            if _jaccard(failed_tokens, target_tokens) < _FAILED_VS_HINT_THRESHOLD:
+                continue
+            out.append(
+                ContradictionPair(
+                    summary_a_id=a.summary_id,
+                    summary_b_id=b.summary_id,
+                    kind="failed_attempt_vs_next_hint",
+                    evidence=(
+                        f"failed attempt '{failed.action}' suggested again as "
+                        f"next_hint '{hint.kind} {target}'"
+                    ),
+                )
+            )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# helpers
+
+
+def _jaccard(a: set[str], b: set[str]) -> float:
+    if not a or not b:
+        return 0.0
+    intersection = len(a & b)
+    union = len(a | b)
+    if union == 0:
+        return 0.0
+    return intersection / union
+
+
+def _has_negation(text: str) -> bool:
+    """Return True when ``text`` contains a recognized negation marker."""
+    if not text:
+        return False
+    lowered = text.lower()
+    return any(marker in lowered for marker in _NEGATION_MARKERS)
+
+
+def _is_opposite_verb(left: str, right: str) -> bool:
+    if not left or not right or left == right:
+        return False
+    for x, y in _OPPOSITE_VERB_PAIRS:
+        if (left == x and right == y) or (left == y and right == x):
+            return True
+    return False
+
+
+def _dedup(pairs: list[ContradictionPair]) -> list[ContradictionPair]:
+    seen: set[tuple[str, str, str, str]] = set()
+    out: list[ContradictionPair] = []
+    for pair in pairs:
+        key = _normalize_key(pair)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(pair)
+    return out
+
+
+def _normalize_key(pair: ContradictionPair) -> tuple[str, str, str, str]:
+    a, b = sorted([pair.summary_a_id, pair.summary_b_id])
+    return (a, b, pair.kind, pair.evidence)
+
+
+__all__ = [
+    "ContradictionPair",
+    "detect_contradictions",
+]

--- a/photon_action_memory/governance/contradiction.py
+++ b/photon_action_memory/governance/contradiction.py
@@ -161,9 +161,7 @@ def _check_avoid_vs_action(
                     summary_a_id=avoider.summary_id,
                     summary_b_id=actor.summary_id,
                     kind="avoid_vs_action",
-                    evidence=(
-                        f"avoid '{guidance_text}' contradicts {source} '{target_text}'"
-                    ),
+                    evidence=(f"avoid '{guidance_text}' contradicts {source} '{target_text}'"),
                 )
             )
     return out
@@ -279,10 +277,7 @@ def _check_next_hint_conflict(
                     summary_a_id=a.summary_id,
                     summary_b_id=b.summary_id,
                     kind="next_hint_conflict",
-                    evidence=(
-                        f"next_hint '{kind_a} {target_a}' "
-                        f"vs '{kind_b} {target_b}'"
-                    ),
+                    evidence=(f"next_hint '{kind_a} {target_a}' vs '{kind_b} {target_b}'"),
                 )
             )
     return out

--- a/photon_action_memory/models/context_scorer.py
+++ b/photon_action_memory/models/context_scorer.py
@@ -129,6 +129,7 @@ _STALENESS_RISK: dict[str, float] = {
     "valid": 0.0,
     "partial": 0.3,
     "unknown": 0.5,
+    "needs_review": 0.6,
     "stale": 0.8,
     "contradicted": 1.0,
 }
@@ -138,6 +139,7 @@ _VALIDITY_ADMISSION_FACTOR: dict[str, float] = {
     "valid": 1.0,
     "partial": 0.7,
     "unknown": 0.5,
+    "needs_review": 0.4,
     "stale": 0.2,
     "contradicted": 0.1,
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ Homepage = "https://github.com/kewton/photon-action-memory"
 
 [project.scripts]
 photon-seed-add = "photon_action_memory.cli.seed_add:main"
+photon-audit = "photon_action_memory.cli.audit:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["photon_action_memory"]

--- a/tests/test_contradiction_detection.py
+++ b/tests/test_contradiction_detection.py
@@ -171,9 +171,7 @@ def test_fact_overlap_without_negation_does_not_flag() -> None:
 def test_next_hint_opposite_verb_conflict() -> None:
     a = _summary(
         "hint-enable",
-        next_hints=[
-            NextHint(kind="enable", target="experimental_async_runtime", reason="needed")
-        ],
+        next_hints=[NextHint(kind="enable", target="experimental_async_runtime", reason="needed")],
     )
     b = _summary(
         "hint-disable",
@@ -194,15 +192,11 @@ def test_next_hint_opposite_verb_conflict() -> None:
 def test_next_hint_same_verb_does_not_flag() -> None:
     a = _summary(
         "hint-enable-1",
-        next_hints=[
-            NextHint(kind="enable", target="cache_module", reason="speed")
-        ],
+        next_hints=[NextHint(kind="enable", target="cache_module", reason="speed")],
     )
     b = _summary(
         "hint-enable-2",
-        next_hints=[
-            NextHint(kind="enable", target="cache_module", reason="for tests")
-        ],
+        next_hints=[NextHint(kind="enable", target="cache_module", reason="for tests")],
     )
     pairs = detect_contradictions([a, b])
     assert all(pair.kind != "next_hint_conflict" for pair in pairs)
@@ -218,9 +212,7 @@ def test_failed_attempt_versus_next_hint_conflict() -> None:
     )
     b = _summary(
         "hint-rebase",
-        next_hints=[
-            NextHint(kind="run", target="git rebase main with conflicts", reason="retry")
-        ],
+        next_hints=[NextHint(kind="run", target="git rebase main with conflicts", reason="retry")],
     )
     pairs = detect_contradictions([a, b])
     kinds = {pair.kind for pair in pairs}

--- a/tests/test_contradiction_detection.py
+++ b/tests/test_contradiction_detection.py
@@ -1,0 +1,294 @@
+"""Unit tests for syntax-based contradiction detection (Issue #110)."""
+
+from __future__ import annotations
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    ActionDone,
+    ActionSummary,
+    AvoidGuidance,
+    Fact,
+    FailedAttempt,
+    NextHint,
+    Validity,
+)
+from photon_action_memory.governance.contradiction import (
+    ContradictionPair,
+    detect_contradictions,
+)
+
+
+def _summary(
+    summary_id: str,
+    *,
+    repo_id: str | None = "repo-x",
+    task_signature: str | None = "fix-bug",
+    facts: list[Fact] | None = None,
+    avoid: list[AvoidGuidance] | None = None,
+    actions_done: list[ActionDone] | None = None,
+    next_hints: list[NextHint] | None = None,
+    failed_attempts: list[FailedAttempt] | None = None,
+) -> ActionSummary:
+    return ActionSummary(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        summary_id=summary_id,
+        repo_id=repo_id,
+        task_signature=task_signature,
+        facts=facts or [],
+        avoid=avoid or [],
+        actions_done=actions_done or [],
+        next_hints=next_hints or [],
+        failed_attempts=failed_attempts or [],
+        validity=Validity(status="valid"),
+    )
+
+
+# 1. Empty input
+def test_detect_contradictions_with_no_summaries_returns_empty() -> None:
+    assert detect_contradictions([]) == []
+
+
+# 2. Single summary
+def test_detect_contradictions_with_single_summary_returns_empty() -> None:
+    only = _summary(
+        "only-1",
+        avoid=[AvoidGuidance(action="rm -rf /", reason="dangerous")],
+    )
+    assert detect_contradictions([only]) == []
+
+
+# 3. avoid vs actions_done
+def test_detect_avoid_vs_actions_done_conflict() -> None:
+    a = _summary(
+        "avoid-rebase",
+        avoid=[AvoidGuidance(action="git rebase main", reason="protected branch")],
+    )
+    b = _summary(
+        "do-rebase",
+        actions_done=[
+            ActionDone(
+                kind="run",
+                command="git rebase main",
+                outcome="ok",
+                status="completed",
+            )
+        ],
+    )
+    pairs = detect_contradictions([a, b])
+    kinds = {pair.kind for pair in pairs}
+    assert "avoid_vs_action" in kinds
+
+
+# 4. avoid vs unrelated actions_done — no conflict
+def test_avoid_vs_unrelated_action_does_not_flag() -> None:
+    a = _summary(
+        "avoid-rebase",
+        avoid=[AvoidGuidance(action="git rebase main", reason="protected branch")],
+    )
+    b = _summary(
+        "run-tests",
+        actions_done=[
+            ActionDone(kind="run", command="pytest -v", outcome="ok", status="completed")
+        ],
+    )
+    assert detect_contradictions([a, b]) == []
+
+
+# 5. avoid vs avoid with opposite polarity
+def test_avoid_polarity_conflict_detected() -> None:
+    a = _summary(
+        "avoid-foo-1",
+        avoid=[AvoidGuidance(action="use foo bar", reason="do not use foo, use bar")],
+    )
+    b = _summary(
+        "avoid-foo-2",
+        avoid=[AvoidGuidance(action="use foo bar", reason="always use foo")],
+    )
+    pairs = detect_contradictions([a, b])
+    kinds = {pair.kind for pair in pairs}
+    assert "avoid_polarity_conflict" in kinds
+
+
+# 6. avoid vs avoid with matching polarity — no conflict
+def test_avoid_same_polarity_does_not_flag() -> None:
+    a = _summary(
+        "avoid-foo-1",
+        avoid=[AvoidGuidance(action="use foo bar", reason="do not use foo")],
+    )
+    b = _summary(
+        "avoid-foo-2",
+        avoid=[AvoidGuidance(action="use foo bar", reason="never use foo here")],
+    )
+    pairs = detect_contradictions([a, b])
+    assert all(pair.kind != "avoid_polarity_conflict" for pair in pairs)
+
+
+# 7. fact negation in English
+def test_fact_negation_english() -> None:
+    a = _summary(
+        "fact-pos",
+        facts=[Fact(text="the cache is enabled by default", evidence_ids=["e1"])],
+    )
+    b = _summary(
+        "fact-neg",
+        facts=[Fact(text="the cache is not enabled by default", evidence_ids=["e2"])],
+    )
+    pairs = detect_contradictions([a, b])
+    kinds = {pair.kind for pair in pairs}
+    assert "fact_negation" in kinds
+
+
+# 8. fact negation in Japanese
+def test_fact_negation_japanese() -> None:
+    a = _summary(
+        "fact-jp-pos",
+        facts=[Fact(text="このAPIは認証を必要とする", evidence_ids=["e1"])],
+    )
+    b = _summary(
+        "fact-jp-neg",
+        facts=[Fact(text="このAPIは認証を必要としない", evidence_ids=["e2"])],
+    )
+    pairs = detect_contradictions([a, b])
+    kinds = {pair.kind for pair in pairs}
+    assert "fact_negation" in kinds
+
+
+# 9. overlapping facts but no negation
+def test_fact_overlap_without_negation_does_not_flag() -> None:
+    a = _summary(
+        "fact-1",
+        facts=[Fact(text="the build runs in five minutes", evidence_ids=["e1"])],
+    )
+    b = _summary(
+        "fact-2",
+        facts=[Fact(text="the build runs in five minutes locally", evidence_ids=["e2"])],
+    )
+    pairs = detect_contradictions([a, b])
+    assert all(pair.kind != "fact_negation" for pair in pairs)
+
+
+# 10. next_hint enable vs disable
+def test_next_hint_opposite_verb_conflict() -> None:
+    a = _summary(
+        "hint-enable",
+        next_hints=[
+            NextHint(kind="enable", target="experimental_async_runtime", reason="needed")
+        ],
+    )
+    b = _summary(
+        "hint-disable",
+        next_hints=[
+            NextHint(
+                kind="disable",
+                target="experimental_async_runtime",
+                reason="unstable",
+            )
+        ],
+    )
+    pairs = detect_contradictions([a, b])
+    kinds = {pair.kind for pair in pairs}
+    assert "next_hint_conflict" in kinds
+
+
+# 11. next_hint synonymous verbs
+def test_next_hint_same_verb_does_not_flag() -> None:
+    a = _summary(
+        "hint-enable-1",
+        next_hints=[
+            NextHint(kind="enable", target="cache_module", reason="speed")
+        ],
+    )
+    b = _summary(
+        "hint-enable-2",
+        next_hints=[
+            NextHint(kind="enable", target="cache_module", reason="for tests")
+        ],
+    )
+    pairs = detect_contradictions([a, b])
+    assert all(pair.kind != "next_hint_conflict" for pair in pairs)
+
+
+# 12. failed_attempt vs next_hint
+def test_failed_attempt_versus_next_hint_conflict() -> None:
+    a = _summary(
+        "fail-rebase",
+        failed_attempts=[
+            FailedAttempt(action="git rebase main with conflicts", outcome="conflict")
+        ],
+    )
+    b = _summary(
+        "hint-rebase",
+        next_hints=[
+            NextHint(kind="run", target="git rebase main with conflicts", reason="retry")
+        ],
+    )
+    pairs = detect_contradictions([a, b])
+    kinds = {pair.kind for pair in pairs}
+    assert "failed_attempt_vs_next_hint" in kinds
+
+
+# 13. different repo_id
+def test_different_repo_ids_are_not_paired() -> None:
+    a = _summary(
+        "avoid-rebase",
+        repo_id="repo-x",
+        avoid=[AvoidGuidance(action="git rebase main", reason="protected")],
+    )
+    b = _summary(
+        "do-rebase",
+        repo_id="repo-y",
+        actions_done=[
+            ActionDone(kind="run", command="git rebase main", outcome="ok", status="completed")
+        ],
+    )
+    assert detect_contradictions([a, b]) == []
+
+
+# 14. different task_signature
+def test_different_task_signatures_are_not_paired() -> None:
+    a = _summary(
+        "avoid-rebase",
+        task_signature="task-1",
+        avoid=[AvoidGuidance(action="git rebase main", reason="protected")],
+    )
+    b = _summary(
+        "do-rebase",
+        task_signature="task-2",
+        actions_done=[
+            ActionDone(kind="run", command="git rebase main", outcome="ok", status="completed")
+        ],
+    )
+    assert detect_contradictions([a, b]) == []
+
+
+# 15. result is deterministic and dedup'd
+def test_pair_dedup_stable_keys() -> None:
+    a = _summary(
+        "avoid-rebase",
+        avoid=[AvoidGuidance(action="git rebase main", reason="protected")],
+    )
+    b = _summary(
+        "do-rebase",
+        actions_done=[
+            ActionDone(kind="run", command="git rebase main", outcome="ok", status="completed"),
+            ActionDone(kind="run", command="git rebase main", outcome="ok", status="completed"),
+        ],
+    )
+    pairs = detect_contradictions([a, b])
+    keys = [(pair.summary_a_id, pair.summary_b_id, pair.kind, pair.evidence) for pair in pairs]
+    assert len(keys) == len(set(keys))
+
+
+def test_contradiction_pair_to_dict_round_trip() -> None:
+    pair = ContradictionPair(
+        summary_a_id="a",
+        summary_b_id="b",
+        kind="avoid_vs_action",
+        evidence="example",
+    )
+    assert pair.to_dict() == {
+        "summary_a_id": "a",
+        "summary_b_id": "b",
+        "kind": "avoid_vs_action",
+        "evidence": "example",
+    }

--- a/tests/test_contradiction_detection_api.py
+++ b/tests/test_contradiction_detection_api.py
@@ -19,7 +19,6 @@ from photon_action_memory.cli.audit import build_contradiction_payload
 from photon_action_memory.memory.store import SQLiteEventStore
 from photon_action_memory.memory.summary_store import SummaryStore
 
-
 REPO_ID = "audit-repo"
 TASK_SIGNATURE = "audit-task"
 

--- a/tests/test_contradiction_detection_api.py
+++ b/tests/test_contradiction_detection_api.py
@@ -1,0 +1,214 @@
+"""Integration tests for the contradiction governance API surface (Issue #110)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    ActionDone,
+    ActionSummary,
+    AvoidGuidance,
+    Fact,
+    Validity,
+)
+from photon_action_memory.api.server import create_app
+from photon_action_memory.cli.audit import build_contradiction_payload
+from photon_action_memory.memory.store import SQLiteEventStore
+from photon_action_memory.memory.summary_store import SummaryStore
+
+
+REPO_ID = "audit-repo"
+TASK_SIGNATURE = "audit-task"
+
+
+def _summary(
+    summary_id: str,
+    *,
+    avoid: list[AvoidGuidance] | None = None,
+    actions_done: list[ActionDone] | None = None,
+    facts: list[Fact] | None = None,
+    validity_status: str = "valid",
+) -> ActionSummary:
+    return ActionSummary(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        summary_id=summary_id,
+        repo_id=REPO_ID,
+        task_signature=TASK_SIGNATURE,
+        facts=facts or [Fact(text=f"{summary_id} fact", evidence_ids=["e1"])],
+        avoid=avoid or [],
+        actions_done=actions_done or [],
+        validity=Validity(status=validity_status),
+    )
+
+
+def _seed_conflict(summary_store: SummaryStore) -> None:
+    avoider = _summary(
+        "audit-avoid",
+        avoid=[AvoidGuidance(action="git rebase main", reason="protected branch")],
+    )
+    actor = _summary(
+        "audit-do",
+        actions_done=[
+            ActionDone(
+                kind="run",
+                command="git rebase main",
+                outcome="ok",
+                status="completed",
+            )
+        ],
+    )
+    summary_store.upsert(avoider)
+    summary_store.upsert(actor)
+
+
+def _pack_request_body() -> dict[str, object]:
+    return {
+        "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+        "request_id": "pack-audit-1",
+        "agent": {"name": "codex"},
+        "repo": {"root": "/tmp/audit-repo", "name": REPO_ID},
+        "task": {
+            "user_request": "rebase the branch",
+            "mode": "act",
+            "summary": "rebasing on main",
+            "task_signature": TASK_SIGNATURE,
+        },
+        "working_memory": {"touched_files": []},
+        "recent_event_ids": [],
+        "candidate_summary_ids": [],
+        "budget": {"max_memory_tokens": 800, "max_evidence_chars": 1200},
+    }
+
+
+def test_audit_endpoint_reports_contradiction_pairs(tmp_path: Path) -> None:
+    summary_store = SummaryStore(tmp_path / "summaries.sqlite")
+    _seed_conflict(summary_store)
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"), summary_store=summary_store)
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/seeds/audit/contradictions",
+            json={
+                "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+                "request_id": "audit-1",
+                "repo_id": REPO_ID,
+                "task_signature": TASK_SIGNATURE,
+                "limit": 50,
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["scanned"] == 2
+    pair_kinds = {pair["kind"] for pair in body["pairs"]}
+    assert "avoid_vs_action" in pair_kinds
+    pair_ids = {(pair["summary_a_id"], pair["summary_b_id"]) for pair in body["pairs"]}
+    assert ("audit-avoid", "audit-do") in pair_ids or ("audit-do", "audit-avoid") in pair_ids
+
+
+def test_context_pack_emits_contradiction_warning(tmp_path: Path) -> None:
+    summary_store = SummaryStore(tmp_path / "summaries.sqlite")
+    _seed_conflict(summary_store)
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"), summary_store=summary_store)
+    with TestClient(app) as client:
+        response = client.post("/v1/context/pack", json=_pack_request_body())
+
+    assert response.status_code == 200
+    pack = response.json()["context_pack"]
+    warning_kinds = {warning["kind"] for warning in pack["warnings"]}
+    assert "contradiction_detected" in warning_kinds
+
+
+def test_marking_summary_contradicted_removes_warning(tmp_path: Path) -> None:
+    summary_store = SummaryStore(tmp_path / "summaries.sqlite")
+    avoider = _summary(
+        "audit-avoid",
+        avoid=[AvoidGuidance(action="git rebase main", reason="protected branch")],
+        validity_status="contradicted",
+    )
+    actor = _summary(
+        "audit-do",
+        actions_done=[
+            ActionDone(
+                kind="run",
+                command="git rebase main",
+                outcome="ok",
+                status="completed",
+            )
+        ],
+    )
+    summary_store.upsert(avoider)
+    summary_store.upsert(actor)
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"), summary_store=summary_store)
+    with TestClient(app) as client:
+        response = client.post("/v1/context/pack", json=_pack_request_body())
+
+    assert response.status_code == 200
+    pack = response.json()["context_pack"]
+    warning_kinds = {warning["kind"] for warning in pack["warnings"]}
+    assert "contradiction_detected" not in warning_kinds
+
+
+def test_marking_summary_needs_review_keeps_warning(tmp_path: Path) -> None:
+    summary_store = SummaryStore(tmp_path / "summaries.sqlite")
+    avoider = _summary(
+        "audit-avoid",
+        avoid=[AvoidGuidance(action="git rebase main", reason="protected branch")],
+        validity_status="needs_review",
+    )
+    actor = _summary(
+        "audit-do",
+        actions_done=[
+            ActionDone(
+                kind="run",
+                command="git rebase main",
+                outcome="ok",
+                status="completed",
+            )
+        ],
+    )
+    summary_store.upsert(avoider)
+    summary_store.upsert(actor)
+    app = create_app(SQLiteEventStore(tmp_path / "events.sqlite"), summary_store=summary_store)
+    with TestClient(app) as client:
+        response = client.post("/v1/context/pack", json=_pack_request_body())
+
+    assert response.status_code == 200
+    pack = response.json()["context_pack"]
+    warning_kinds = {warning["kind"] for warning in pack["warnings"]}
+    assert "contradiction_detected" in warning_kinds
+
+
+def test_audit_cli_payload_builder_includes_filters() -> None:
+    payload = build_contradiction_payload(
+        request_id="cli-req",
+        repo_id=REPO_ID,
+        task_signature=TASK_SIGNATURE,
+        limit=42,
+    )
+
+    assert payload["request_id"] == "cli-req"
+    assert payload["repo_id"] == REPO_ID
+    assert payload["task_signature"] == TASK_SIGNATURE
+    assert payload["limit"] == 42
+    assert payload["schema_version"] == "action-memory.v0.2"
+
+
+def test_audit_cli_payload_builder_omits_unset_filters() -> None:
+    payload = build_contradiction_payload(
+        request_id="cli-req",
+        repo_id=None,
+        task_signature=None,
+        limit=10,
+    )
+
+    assert "repo_id" not in payload
+    assert "task_signature" not in payload
+    assert payload["limit"] == 10
+
+
+def test_action_summary_accepts_needs_review_validity_status() -> None:
+    summary = _summary("needs-review-1", validity_status="needs_review")
+    assert summary.validity.status == "needs_review"


### PR DESCRIPTION
Closes #110

## Summary
- Add pure syntax-based contradiction detection for ActionSummary seeds within the same repo/task scope.
- Add audit schemas, `POST /v1/seeds/audit/contradictions`, context-pack `contradiction_detected` warnings, and `needs_review` validity support.
- Add `photon-audit detect-contradictions` CLI wiring and issue dev reports.

## Changed files
- `photon_action_memory/governance/contradiction.py`
- `photon_action_memory/api/schema_v2.py`
- `photon_action_memory/api/server.py`
- `photon_action_memory/models/context_scorer.py`
- `photon_action_memory/cli/audit.py`
- `pyproject.toml`
- `tests/test_contradiction_detection.py`
- `tests/test_contradiction_detection_api.py`
- `dev-reports/issue-110/*`

## Tests run
- `python -m pytest tests/test_contradiction_detection.py tests/test_contradiction_detection_api.py -v` — 23 passed
- `python -m pytest -q` — 996 passed, 1 skipped, 2 warnings

## Known risks
- Detector is intentionally syntax-based and conservative; semantic contradictions outside the implemented rules remain out of scope.
- CLI console script availability requires reinstalling the package/environment.

## Orchestration
- Run ID: `20260515-145842-orchestrate`
- Worker commit: `05b6040`