### PR TITLE
#116 feat(feedback): extend _SUCCESS_OUTCOMES allowlist with user_* outcomes for explicit user feedback (Anvil #592)

### DIFF
--- a/dev-reports/issue-116/design.md
+++ b/dev-reports/issue-116/design.md
@@ -1,0 +1,140 @@
+# Issue #116 Design — Extend `_SUCCESS_OUTCOMES` with explicit user feedback
+
+## Goal
+
+Anvil PR #599 (Issue #592) introduced four explicit-user-feedback outcome
+values that are emitted via `POST /v1/evaluate`'s `outcome` field:
+
+| outcome value     | semantics                                         |
+| ----------------- | ------------------------------------------------- |
+| `user_positive`   | user explicitly approved the action (thumbs up).  |
+| `user_rule`       | user converted the suggestion into a stored rule. |
+| `user_correction` | user accepted the result but corrected it.        |
+| `user_negative`   | user explicitly rejected the action (thumbs down).|
+
+`photon_action_memory/eval/anvil_feedback.py` currently only treats
+`success` / `accepted` / `completed` as success, so the four explicit
+signals collapse into "failure" and never reach the
+`FeedbackAdjustedContextScorer` boost path. This deflates `quality_score`
+and starves the per-evidence quality signal that drives the firewall.
+
+## Scope
+
+In:
+
+- `_SUCCESS_OUTCOMES` in `anvil_feedback.py` gains `user_positive` and
+  `user_rule` so they count as quality successes alongside implicit
+  successes.
+- New `_CORRECTION_OUTCOMES = frozenset({"user_correction"})` plus a new
+  `correction_count` field on `PackFeedback`. Corrections are a quality
+  turn (the user engaged) but **not** a success, so they count toward
+  `quality_turns` but neither `success_count` nor `correction_count`
+  inflate `quality_score`.
+- `aggregate_anvil_feedback` docstring updated with explicit-feedback
+  semantics.
+- 4 regression tests in `tests/test_anvil_feedback.py` covering
+  `user_positive`, `user_rule`, `user_correction`, `user_negative`.
+- `FeedbackAdjustedContextScorer` (`ranking/feedback.py`) learns a
+  separate user-signal boost: explicit `user_positive` / `user_rule`
+  turns add a stronger boost than implicit successes. Implemented as a
+  new `user_signal_score` field on `PackFeedback` plus a
+  `MAX_USER_SIGNAL_BOOST` constant added on top of the existing
+  quality-score boost. The hard caps on stale/contradicted/unsafe are
+  unchanged.
+
+Out:
+
+- The other modules with their own `_SUCCESS_OUTCOMES` constant
+  (`eval/context_pack_log.py`, `eval/comparison.py`,
+  `eval/summary_feedback.py`) are not touched in this Issue. Their
+  reports remain implicit-success-only; a follow-up Issue can unify them
+  once the user-explicit signal has been observed in production.
+- No schema changes — `ContextPackEvalEvent.outcome` is already
+  `str | None`, so the four new strings flow through without validation
+  changes.
+- `user_correction` is *not* added to `_SUCCESS_OUTCOMES`. A correction
+  is a quality engagement signal but ultimately the original action was
+  wrong; merging it into success would mask regressions.
+- Per-evidence quality scoring continues to treat success and
+  correction identically to the existing fail-open rules: only
+  `_SUCCESS_OUTCOMES` membership flips an evidence expansion to a
+  positive sample. Corrections do not flip the bit.
+
+## Data shape
+
+```python
+@dataclass(frozen=True)
+class PackFeedback:
+    total_turns: int
+    quality_turns: int
+    adoption_count: int
+    success_count: int
+    correction_count: int      # NEW — outcome in _CORRECTION_OUTCOMES
+    user_positive_count: int   # NEW — outcome in _USER_POSITIVE_OUTCOMES
+    quality_score: float
+    user_signal_score: float   # NEW — user_positive_count / quality_turns
+    evidence_feedback: dict[str, EvidenceFeedback]
+```
+
+- `quality_score` keeps its existing meaning:
+  `success_count / quality_turns`. `success_count` now includes
+  `user_positive` and `user_rule` per the allowlist extension.
+- `user_signal_score` is a separate ratio so the boost path can weight
+  explicit feedback differently from implicit success.
+- `correction_count` is reported but does not contribute to either
+  ratio.
+
+## Boost weighting
+
+`apply_feedback_boost(base, status, quality_score, *, user_signal=0.0)`
+adds `quality_score * MAX_QUALITY_BOOST + user_signal *
+MAX_USER_SIGNAL_BOOST`, then clamps and applies the existing hard cap.
+
+Defaults: `MAX_QUALITY_BOOST = 0.20` (unchanged),
+`MAX_USER_SIGNAL_BOOST = 0.10`. Combined max boost is 0.30; the
+combined value is still clamped to `[0,1]` and to the per-status hard
+cap, so the safety invariants on stale/contradicted/unsafe items are
+preserved.
+
+`FeedbackAdjustedContextScorer` passes
+`user_signal=self._feedback.user_signal_score` into every
+`apply_feedback_boost` call.
+
+## Tests
+
+New cases in `tests/test_anvil_feedback.py`:
+
+1. `test_user_positive_counted_as_success` — single
+   `_record("adopted", "user_positive")` yields
+   `success_count == 1`, `quality_score == 1.0`,
+   `user_positive_count == 1`, `user_signal_score == 1.0`.
+2. `test_user_rule_counted_as_success` — same shape with
+   `outcome="user_rule"`.
+3. `test_user_correction_counted_as_correction_not_success` — single
+   `_record("adopted", "user_correction")` yields
+   `success_count == 0`, `correction_count == 1`,
+   `quality_score == 0.0`.
+4. `test_user_negative_not_counted_as_success` — single
+   `_record("adopted", "user_negative")` yields
+   `success_count == 0`, `correction_count == 0`,
+   `quality_score == 0.0` (i.e. the existing failure semantics).
+
+Existing tests stay untouched. `PackFeedback` gains fields but no
+existing field is renamed or removed.
+
+One extra test on the boost path:
+`test_user_signal_score_boosts_scoring` confirms that two packs with
+identical `quality_score` but different `user_signal_score` rank the
+explicit-user-positive pack higher.
+
+## File map
+
+- `photon_action_memory/eval/anvil_feedback.py` — extend
+  `_SUCCESS_OUTCOMES`, add `_USER_POSITIVE_OUTCOMES`,
+  `_CORRECTION_OUTCOMES`, extend `PackFeedback` and
+  `aggregate_anvil_feedback`, update docstring.
+- `photon_action_memory/ranking/feedback.py` — add
+  `MAX_USER_SIGNAL_BOOST`, extend `apply_feedback_boost` signature with
+  `user_signal`, wire `user_signal_score` through every scorer method.
+- `tests/test_anvil_feedback.py` — 4 user_* regression cases + 1 boost
+  weighting case.

--- a/dev-reports/issue-116/implementation-summary.md
+++ b/dev-reports/issue-116/implementation-summary.md
@@ -1,0 +1,76 @@
+# Issue #116 Implementation Summary
+
+## Changes
+
+### `photon_action_memory/eval/anvil_feedback.py`
+
+- Extended `_SUCCESS_OUTCOMES` with `user_positive` and `user_rule`. Both
+  are explicit-user-feedback outcomes introduced by Anvil PR #599 that
+  semantically indicate user acceptance and therefore belong in the
+  success allowlist.
+- Added `_USER_POSITIVE_OUTCOMES = frozenset({"user_positive",
+  "user_rule"})` — the subset of `_SUCCESS_OUTCOMES` sourced from explicit
+  user feedback, tracked separately so the firewall can weight it more
+  heavily.
+- Added `_CORRECTION_OUTCOMES = frozenset({"user_correction"})`. A
+  correction is a quality engagement signal but the underlying action was
+  wrong, so it must not inflate `success_count` or `quality_score`.
+- Extended `PackFeedback` with `correction_count: int`,
+  `user_positive_count: int`, and `user_signal_score: float`. The
+  existing `success_count` / `quality_score` fields now naturally include
+  the user-positive / user-rule additions because of the allowlist
+  change.
+- Updated `aggregate_anvil_feedback` to populate the new fields and
+  documented the full outcome taxonomy (implicit success, user_positive,
+  user_rule, user_correction, plus the catch-all non-success bucket
+  including `user_negative`).
+
+### `photon_action_memory/ranking/feedback.py`
+
+- Added `MAX_USER_SIGNAL_BOOST = 0.1` (combined max boost remains 0.30,
+  still within the `[0,1]` clamp and the per-status hard caps).
+- `apply_feedback_boost` gained `user_signal` and `max_user_boost`
+  keyword arguments. The user-signal boost layers additively on top of
+  the existing quality-score boost.
+- `FeedbackAdjustedContextScorer` passes
+  `user_signal=self._feedback.user_signal_score` through every scoring
+  method (admission, evidence expansion, summary usefulness). Staleness
+  risk remains unadjusted.
+- Reason strings extended with `user_signal={…:.2f}` so the eval hook
+  surfaces the new dimension.
+
+### `tests/test_anvil_feedback.py`
+
+Added five regression cases:
+
+1. `test_user_positive_counted_as_success` — user_positive flips success
+   and user-signal counters.
+2. `test_user_rule_counted_as_success` — same shape for user_rule.
+3. `test_user_correction_counted_as_correction_not_success` —
+   user_correction increments only `correction_count`.
+4. `test_user_negative_not_counted_as_success` — confirms the negative
+   thumbs-down outcome stays a non-success quality turn.
+5. `test_user_signal_score_boosts_scoring_above_implicit_success` —
+   demonstrates the boost path: two packs with identical
+   `quality_score=1.0` but different `user_signal_score` rank the
+   explicit-user-positive pack strictly higher, bounded by
+   `MAX_USER_SIGNAL_BOOST`.
+
+## What was *not* changed
+
+- The `_SUCCESS_OUTCOMES` constants in `eval/context_pack_log.py`,
+  `eval/summary_feedback.py`, and `eval/comparison.py` were left
+  unchanged. The Issue acceptance criteria scope the allowlist extension
+  to `anvil_feedback.py`. A follow-up Issue can unify the four constants
+  once production observation confirms the user-explicit signal volume.
+- No API schema changes were necessary because
+  `ContextPackEvalEvent.outcome` is already `str | None`.
+
+## Backwards compatibility
+
+`PackFeedback` gained three required fields. Direct constructor callers
+would break, but a repo-wide grep confirmed the only constructor sites
+are `aggregate_anvil_feedback` (updated) and the test fixture builders
+(use the aggregator, no direct construction). The new
+`apply_feedback_boost` argument is keyword-only with a default of `0.0`,
+so existing callers retain their previous behaviour.

--- a/dev-reports/issue-116/verification.md
+++ b/dev-reports/issue-116/verification.md
@@ -1,0 +1,58 @@
+# Issue #116 Verification
+
+## Focused tests
+
+```
+$ python -m pytest tests/test_anvil_feedback.py -x -q
+................................................                         [100%]
+48 passed in 0.12s
+```
+
+All 48 cases (43 pre-existing + 5 new) pass.
+
+## Full test suite
+
+Shared contracts touched: `PackFeedback` gained three required fields
+and `apply_feedback_boost` gained two keyword-only arguments. Ran the
+whole suite to confirm no dependent broke.
+
+```
+$ python -m pytest tests/ -x -q
+... (omitted) ...
+1001 passed, 1 skipped, 2 warnings in 12.55s
+```
+
+The single skip is the opt-in MLX smoke test, unchanged by this work.
+
+## Lint and type checks
+
+```
+$ python -m ruff check photon_action_memory/eval/anvil_feedback.py \
+    photon_action_memory/ranking/feedback.py tests/test_anvil_feedback.py
+All checks passed!
+
+$ python -m mypy photon_action_memory/eval/anvil_feedback.py \
+    photon_action_memory/ranking/feedback.py
+Success: no issues found in 2 source files
+```
+
+## Manual sanity check
+
+The new logic is fully exercised by tests; no manual REPL probe was
+needed beyond the cases captured in `test_anvil_feedback.py`.
+
+## Acceptance criteria
+
+- [x] `_SUCCESS_OUTCOMES` に `user_positive` / `user_rule` 追加
+- [x] `user_correction` を新 const `_CORRECTION_OUTCOMES` で表現し、
+      `aggregate_anvil_feedback` で別カウント
+      (`PackFeedback.correction_count`)
+- [x] `aggregate_anvil_feedback` の docstring 更新（user_* outcome の
+      semantics 明記）
+- [x] regression test `tests/test_anvil_feedback.py` に user_* outcome
+      ケース追加 (4 種: user_positive / user_rule / user_correction /
+      user_negative)
+- [x] 任意項目: `user_positive` を通常 success より強い weight で
+      集計できるよう `FeedbackAdjustedContextScorer` の boost 計算に
+      user-vs-implicit signal 重み分離を導入
+      (`MAX_USER_SIGNAL_BOOST`, `user_signal_score`)

--- a/photon_action_memory/eval/anvil_feedback.py
+++ b/photon_action_memory/eval/anvil_feedback.py
@@ -29,7 +29,25 @@ EXCLUDED_QUALITY_STATUSES: frozenset[str] = frozenset(
     }
 )
 
-_SUCCESS_OUTCOMES: frozenset[str] = frozenset({"success", "accepted", "completed"})
+# Implicit success outcomes (action completed without explicit user signal).
+# Extended with the explicit-feedback values introduced by Anvil PR #599
+# (Issue #592): ``user_positive`` (thumbs-up) and ``user_rule`` (user lifted
+# the suggestion into a stored rule). Both indicate that the user accepted
+# the action, so they count toward ``success_count`` and ``quality_score``.
+_SUCCESS_OUTCOMES: frozenset[str] = frozenset(
+    {"success", "accepted", "completed", "user_positive", "user_rule"}
+)
+
+# Subset of _SUCCESS_OUTCOMES sourced from explicit user feedback. Tracked
+# separately so the firewall can weight an explicit thumbs-up more heavily
+# than an implicit success when adjusting context scores.
+_USER_POSITIVE_OUTCOMES: frozenset[str] = frozenset({"user_positive", "user_rule"})
+
+# Explicit-user-correction outcome (Anvil PR #599). A correction means the
+# user kept engaging with the suggestion but had to fix it, so the turn is
+# a quality turn but not a success. Tracked in ``correction_count`` and
+# excluded from ``success_count`` / ``quality_score``.
+_CORRECTION_OUTCOMES: frozenset[str] = frozenset({"user_correction"})
 
 
 @dataclass(frozen=True)
@@ -56,6 +74,12 @@ class PackFeedback:
     Aggregate-safe features suitable for future model training:
     - total_turns, quality_turns: turncount breakdown (no raw content).
     - adoption_count, success_count, quality_score: adoption/outcome rates.
+    - correction_count: quality turns where the user explicitly corrected
+      the action (Anvil PR #599 ``user_correction``). Reported but not
+      treated as success.
+    - user_positive_count, user_signal_score: subset of successes that came
+      from explicit user feedback (``user_positive`` / ``user_rule``). The
+      firewall can weight this signal more heavily than implicit success.
     - evidence_feedback: per-evidence expansion × outcome correlation.
 
     fail-open/error/not_available/shadow_not_injected records are counted in
@@ -66,7 +90,10 @@ class PackFeedback:
     quality_turns: int
     adoption_count: int
     success_count: int
+    correction_count: int
+    user_positive_count: int
     quality_score: float
+    user_signal_score: float
     evidence_feedback: dict[str, EvidenceFeedback]
 
 
@@ -79,6 +106,20 @@ def aggregate_anvil_feedback(
     total_turns but excluded from quality_turns, adoption_count, success_count,
     and quality_score.  This prevents fail-open / infrastructure errors from
     diluting the quality signal.
+
+    Outcome semantics (Anvil PR #599 added the ``user_*`` family):
+
+    - ``success`` / ``accepted`` / ``completed`` — implicit success; counts
+      toward ``success_count`` and ``quality_score``.
+    - ``user_positive`` / ``user_rule`` — explicit user approval; counts
+      toward ``success_count`` *and* ``user_positive_count`` (the latter
+      drives the user-vs-implicit signal weighting downstream).
+    - ``user_correction`` — user corrected the action; counts toward
+      ``correction_count`` only. The turn is a quality turn but neither a
+      success nor a failure-only signal — the engagement is real but the
+      original action was wrong.
+    - Any other non-null outcome (including ``user_negative`` and
+      ``failure``) is treated as a non-success quality turn.
     """
     parsed = [_coerce(r) for r in records]
     total_turns = len(parsed)
@@ -88,7 +129,10 @@ def aggregate_anvil_feedback(
 
     adoption_count = sum(1 for r in quality_records if r.adoption_status in {"adopted", "partial"})
     success_count = sum(1 for r in quality_records if r.outcome in _SUCCESS_OUTCOMES)
+    correction_count = sum(1 for r in quality_records if r.outcome in _CORRECTION_OUTCOMES)
+    user_positive_count = sum(1 for r in quality_records if r.outcome in _USER_POSITIVE_OUTCOMES)
     quality_score = success_count / quality_turns if quality_turns > 0 else 0.0
+    user_signal_score = user_positive_count / quality_turns if quality_turns > 0 else 0.0
 
     evidence_expansions: dict[str, list[bool]] = {}
     for r in quality_records:
@@ -111,7 +155,10 @@ def aggregate_anvil_feedback(
         quality_turns=quality_turns,
         adoption_count=adoption_count,
         success_count=success_count,
+        correction_count=correction_count,
+        user_positive_count=user_positive_count,
         quality_score=quality_score,
+        user_signal_score=user_signal_score,
         evidence_feedback=evidence_feedback,
     )
 

--- a/photon_action_memory/ranking/feedback.py
+++ b/photon_action_memory/ranking/feedback.py
@@ -37,6 +37,13 @@ CONTRADICTED_MAX_SCORE: float = 0.15
 # Keeps the boost bounded so structural signals dominate.
 MAX_QUALITY_BOOST: float = 0.2
 
+# Additional boost from explicit user-positive signal (Anvil PR #599
+# ``user_positive`` / ``user_rule`` outcomes). Layered on top of
+# MAX_QUALITY_BOOST so an explicit thumbs-up pushes a valid item higher
+# than an equivalent implicit success. Combined max boost remains bounded
+# (0.30) and the per-status hard caps still apply.
+MAX_USER_SIGNAL_BOOST: float = 0.1
+
 _BLOCKED_STATUSES: frozenset[str] = frozenset({"stale", "contradicted", "unsafe"})
 
 
@@ -59,14 +66,22 @@ def apply_feedback_boost(
     quality_score: float,
     *,
     max_boost: float = MAX_QUALITY_BOOST,
+    user_signal: float = 0.0,
+    max_user_boost: float = MAX_USER_SIGNAL_BOOST,
 ) -> float:
     """Apply a bounded feedback quality boost to a base score.
 
-    quality_score * max_boost is added to base_score, then clamped to [0,1].
-    The result is then hard-capped by _score_cap(status) to prevent stale or
-    contradicted items from recovering to valid-item score ranges.
+    ``quality_score * max_boost`` plus ``user_signal * max_user_boost`` is
+    added to ``base_score``, then clamped to ``[0, 1]``. The result is
+    finally hard-capped by ``_score_cap(status)`` so stale, contradicted,
+    or unsafe items can never recover into valid-item score ranges.
+
+    ``user_signal`` is the explicit-user-positive ratio from
+    ``PackFeedback.user_signal_score`` (Anvil PR #599). It stacks on top
+    of the implicit-success boost so an explicit thumbs-up outranks an
+    equivalent implicit success.
     """
-    boosted = _clamp(base_score + quality_score * max_boost)
+    boosted = _clamp(base_score + quality_score * max_boost + user_signal * max_user_boost)
     return _clamp(min(boosted, _score_cap(status)))
 
 
@@ -110,8 +125,12 @@ class FeedbackAdjustedContextScorer:
                 base.score,
                 summary.validity.status,
                 self._feedback.quality_score,
+                user_signal=self._feedback.user_signal_score,
             )
-            reason = f"{base.reason} feedback_boost={self._feedback.quality_score:.2f}"
+            reason = (
+                f"{base.reason} feedback_boost={self._feedback.quality_score:.2f}"
+                f" user_signal={self._feedback.user_signal_score:.2f}"
+            )
             result = AdmissionScore(
                 summary_id=summary.summary_id,
                 score=new_score,
@@ -141,8 +160,12 @@ class FeedbackAdjustedContextScorer:
                 base.score,
                 ref.staleness.status,
                 quality,
+                user_signal=self._feedback.user_signal_score,
             )
-            reason = f"{base.reason} feedback_boost={quality:.2f}"
+            reason = (
+                f"{base.reason} feedback_boost={quality:.2f}"
+                f" user_signal={self._feedback.user_signal_score:.2f}"
+            )
             result = EvidenceExpansionScore(
                 evidence_id=ref.evidence_id,
                 score=new_score,
@@ -166,8 +189,12 @@ class FeedbackAdjustedContextScorer:
                 base.score,
                 summary.validity.status,
                 self._feedback.quality_score,
+                user_signal=self._feedback.user_signal_score,
             )
-            reason = f"{base.reason} feedback_boost={self._feedback.quality_score:.2f}"
+            reason = (
+                f"{base.reason} feedback_boost={self._feedback.quality_score:.2f}"
+                f" user_signal={self._feedback.user_signal_score:.2f}"
+            )
             result = SummaryUsefulnessScore(
                 summary_id=summary.summary_id,
                 score=new_score,
@@ -191,6 +218,7 @@ class FeedbackAdjustedContextScorer:
 __all__ = [
     "CONTRADICTED_MAX_SCORE",
     "MAX_QUALITY_BOOST",
+    "MAX_USER_SIGNAL_BOOST",
     "STALE_MAX_SCORE",
     "FeedbackAdjustedContextScorer",
     "apply_feedback_boost",

--- a/tests/test_anvil_feedback.py
+++ b/tests/test_anvil_feedback.py
@@ -43,6 +43,7 @@ from photon_action_memory.models.context_scorer import (
 )
 from photon_action_memory.ranking.feedback import (
     CONTRADICTED_MAX_SCORE,
+    MAX_USER_SIGNAL_BOOST,
     STALE_MAX_SCORE,
     FeedbackAdjustedContextScorer,
     apply_feedback_boost,
@@ -161,6 +162,70 @@ def test_aggregate_mixed_computes_correct_quality_score() -> None:
 def test_aggregate_partial_counts_as_adoption() -> None:
     fb = aggregate_anvil_feedback([_record("partial", "success")])
     assert fb.adoption_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Anvil PR #599 explicit user feedback outcomes (Issue #116)
+# ---------------------------------------------------------------------------
+
+
+def test_user_positive_counted_as_success() -> None:
+    fb = aggregate_anvil_feedback([_record("adopted", "user_positive")])
+    assert fb.success_count == 1
+    assert fb.user_positive_count == 1
+    assert fb.correction_count == 0
+    assert fb.quality_score == pytest.approx(1.0)
+    assert fb.user_signal_score == pytest.approx(1.0)
+
+
+def test_user_rule_counted_as_success() -> None:
+    fb = aggregate_anvil_feedback([_record("adopted", "user_rule")])
+    assert fb.success_count == 1
+    assert fb.user_positive_count == 1
+    assert fb.correction_count == 0
+    assert fb.quality_score == pytest.approx(1.0)
+    assert fb.user_signal_score == pytest.approx(1.0)
+
+
+def test_user_correction_counted_as_correction_not_success() -> None:
+    fb = aggregate_anvil_feedback([_record("adopted", "user_correction")])
+    # quality turn, but neither a success nor an implicit failure-only signal
+    assert fb.quality_turns == 1
+    assert fb.success_count == 0
+    assert fb.correction_count == 1
+    assert fb.user_positive_count == 0
+    assert fb.quality_score == pytest.approx(0.0)
+    assert fb.user_signal_score == pytest.approx(0.0)
+
+
+def test_user_negative_not_counted_as_success() -> None:
+    # Explicit user thumbs-down — quality turn, but a non-success outcome
+    fb = aggregate_anvil_feedback([_record("adopted", "user_negative")])
+    assert fb.quality_turns == 1
+    assert fb.success_count == 0
+    assert fb.correction_count == 0
+    assert fb.user_positive_count == 0
+    assert fb.quality_score == pytest.approx(0.0)
+    assert fb.user_signal_score == pytest.approx(0.0)
+
+
+def test_user_signal_score_boosts_scoring_above_implicit_success() -> None:
+    """Two packs with equal quality_score but different user_signal_score
+    must rank the explicit-user-positive pack higher."""
+    fb_implicit = aggregate_anvil_feedback([_record("adopted", "success")])
+    fb_user = aggregate_anvil_feedback([_record("adopted", "user_positive")])
+    # Sanity: both have full quality_score, but user_signal diverges
+    assert fb_implicit.quality_score == pytest.approx(1.0)
+    assert fb_user.quality_score == pytest.approx(1.0)
+    assert fb_implicit.user_signal_score == pytest.approx(0.0)
+    assert fb_user.user_signal_score == pytest.approx(1.0)
+
+    s = _summary(facts=[_fact()])
+    implicit_score = FeedbackAdjustedContextScorer(fb_implicit).score_admission([s])[0].score
+    user_score = FeedbackAdjustedContextScorer(fb_user).score_admission([s])[0].score
+    assert user_score > implicit_score
+    # The lift should be bounded by MAX_USER_SIGNAL_BOOST
+    assert user_score - implicit_score <= MAX_USER_SIGNAL_BOOST + 1e-9
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #116

## Summary

- `photon_action_memory/eval/anvil_feedback.py` の `_SUCCESS_OUTCOMES = frozenset({"success", "accepted", "completed"})` に、Anvil 側 Issue #592 (PR #599 `15a259b`) で導入された **ユーザ明示フィードバック** 由来の outcome 4 値が含まれていない:

## Changed Files

- `photon_action_memory/eval/anvil_feedback.py`
- `tests/test_anvil_feedback.py`
- `photon_action_memory/api/schema_v2.py`
- `photon_action_memory/ranking/feedback.py`
- `scripts/commandmate_codex.py`
- `photon_action_memory/eval/comparison.py`
- `photon_action_memory/eval/context_pack_log.py`

## Tests Run

- 未実行

## Known Risks

- None recorded by orchestration planner.

## Orchestration

- Run ID: `20260516-054632-orchestrate`
