### PR TITLE
#123 [v0.4.0] Action Memory 用 PHOTON checkpoint を作成・配置し scorer 効果を評価する

### DIFF
--- a/dev-reports/issue-123/design.md
+++ b/dev-reports/issue-123/design.md
@@ -1,0 +1,44 @@
+# Issue #123 — Design
+
+## Goal
+
+Add the missing layer after Issue #121: a concrete Action Memory PHOTON runtime
+checkpoint path that can be built, configured, smoke-tested, and compared
+against deterministic scoring.
+
+## Scope Decision
+
+This is not a final-answer generation model. It is a small scorer checkpoint for
+Action Memory candidates:
+
+- summaries
+- evidence
+- next hints
+- failed attempts
+
+The implementation stays fail-open. Missing checkpoint, broken checkpoint, or
+missing MLX must return deterministic scoring with a warning.
+
+## Plan
+
+1. Add a runtime checkpoint builder module that writes:
+   - `manifest.json`
+   - `state.json`
+   - `weights.npz`
+   - `integrity.json`
+2. Add a tiny committed checkpoint fixture for CI.
+3. Make strict scorer construction verify checkpoint integrity.
+4. Add tests for:
+   - builder state aggregation
+   - fixture validity
+   - `PHOTON_ACTION_MEMORY_CHECKPOINT` entering the PHOTON scorer path
+   - strict integrity mismatch fallback
+5. Document sidecar env setup and no-large-checkpoint policy.
+6. Record a small deterministic-vs-PHOTON ranking comparison report.
+
+## Non-goals
+
+- Do not commit production-size checkpoint weights.
+- Do not enable PHOTON scoring by default.
+- Do not wire the scorer into `/v1/context/pack` in this issue.
+- Do not add a session-aware state model.

--- a/dev-reports/issue-123/implementation-summary.md
+++ b/dev-reports/issue-123/implementation-summary.md
@@ -1,0 +1,46 @@
+# Issue #123 — Implementation Summary
+
+## What Changed
+
+- Added `photon_action_memory/models/checkpoint_builder.py`.
+  - Builds scorer state from normalized feedback/eval records.
+  - Writes a runtime checkpoint directory with manifest, state, weights, and
+    integrity files.
+- Added `scripts/build_action_memory_checkpoint.py`.
+  - CLI wrapper for building a small local checkpoint from JSON records.
+- Added tiny fixture checkpoint:
+  - `tests/fixtures/photon/checkpoints/action_memory_tiny/manifest.json`
+  - `state.json`
+  - `weights.npz`
+  - `integrity.json`
+- Strengthened strict PHOTON scorer loading.
+  - `PhotonMLXAdapter.from_checkpoint(..., strict=True)` now verifies
+    checkpoint integrity before constructing the adapter.
+  - `make_action_memory_scorer()` passes
+    `PHOTON_ACTION_MEMORY_CHECKPOINT_STRICT` through and fails open on integrity
+    errors.
+- Added tests for builder, fixture validity, PHOTON scorer path, and strict
+  fallback.
+- Documented sidecar checkpoint env configuration and no-large-artifact policy.
+- Added `workspace/v0.4.0/photon-checkpoint-scorer-eval.md` with a deterministic
+  vs PHOTON fixture ranking comparison.
+
+## Files
+
+```text
+photon_action_memory/models/checkpoint_builder.py
+photon_action_memory/models/photon_adapter.py
+photon_action_memory/models/photon_scorer.py
+scripts/build_action_memory_checkpoint.py
+tests/fixtures/photon/checkpoints/action_memory_tiny/
+tests/test_action_memory_checkpoint_builder.py
+tests/test_action_memory_scorer.py
+docs/photon-action-memory.md
+workspace/v0.4.0/photon-checkpoint-scorer-eval.md
+```
+
+## Notes
+
+The committed checkpoint is intentionally tiny and CI-only. Production
+checkpoints should be generated locally or stored in an external artifact
+location, then referenced by `PHOTON_ACTION_MEMORY_CHECKPOINT`.

--- a/dev-reports/issue-123/verification.md
+++ b/dev-reports/issue-123/verification.md
@@ -1,0 +1,84 @@
+# Issue #123 — Verification
+
+## Focused Tests
+
+```bash
+python -m pytest \
+  tests/test_action_memory_checkpoint_builder.py \
+  tests/test_action_memory_scorer.py \
+  tests/test_photon_adapter.py \
+  tests/test_checkpoint.py \
+  -q
+```
+
+Result:
+
+```text
+28 passed
+```
+
+## Type Check
+
+```bash
+python -m mypy photon_action_memory \
+  tests/test_action_memory_checkpoint_builder.py \
+  tests/test_action_memory_scorer.py \
+  tests/test_photon_adapter.py \
+  tests/test_checkpoint.py
+```
+
+Result:
+
+```text
+Success: no issues found in 66 source files
+```
+
+## Lint / Format
+
+```bash
+python -m ruff check .
+```
+
+Result:
+
+```text
+All checks passed!
+```
+
+```bash
+python -m ruff format --check .
+```
+
+Result:
+
+```text
+120 files already formatted
+```
+
+## CLI Smoke
+
+```bash
+python scripts/build_action_memory_checkpoint.py \
+  /tmp/action_memory_checkpoint_records.json \
+  --output /tmp/action-memory-checkpoint-smoke \
+  --model-version action-memory-smoke-v1
+```
+
+Result:
+
+```text
+checkpoint manifest/state/weights/integrity paths printed successfully
+```
+
+## Acceptance Criteria
+
+| Criterion | Status |
+|---|---|
+| checkpoint creation implemented or documented | Done: builder module, CLI, docs |
+| tiny fixture checkpoint without network/model download | Done |
+| valid checkpoint enters `PhotonMLXActionMemoryScorer` path | Done: scorer test with fake MLX |
+| missing/broken/MLX-unavailable fallback | Done: existing + new tests |
+| strict integrity check tested | Done |
+| deterministic vs PHOTON ranking report | Done |
+| no large checkpoint policy documented | Done |
+| sidecar env example documented | Done |

--- a/docs/photon-action-memory.md
+++ b/docs/photon-action-memory.md
@@ -52,6 +52,80 @@ Expected startup state:
 - The sidecar is fail-open for integration routes; callers should keep their own
   turn execution path independent of this process.
 
+### Optional PHOTON Checkpoint Scorer
+
+The default scorer is deterministic and requires no PHOTON checkpoint. To test
+the PHOTON/MLX scorer path, point the sidecar at a local runtime checkpoint:
+
+```bash
+PHOTON_ACTION_MEMORY_CHECKPOINT=/path/to/checkpoint \
+python -m uvicorn photon_action_memory.api.server:app \
+  --host 127.0.0.1 \
+  --port 18765
+```
+
+For strict local verification of `state.json` and `weights.npz` hashes:
+
+```bash
+PHOTON_ACTION_MEMORY_CHECKPOINT=/path/to/checkpoint \
+PHOTON_ACTION_MEMORY_CHECKPOINT_STRICT=true \
+python -m uvicorn photon_action_memory.api.server:app \
+  --host 127.0.0.1 \
+  --port 18765
+```
+
+Runtime checkpoint directories use this shape:
+
+```text
+checkpoint/
+  manifest.json
+  state.json
+  weights.npz
+  integrity.json
+```
+
+`manifest.json` carries the small Action Memory scoring state:
+
+```json
+{
+  "format": "photon-action-memory.mlx.v1",
+  "model_version": "action-memory-photon-...",
+  "state": {
+    "bias": 0.5,
+    "action_weights": {},
+    "file_weights": {},
+    "evidence_weights": {}
+  }
+}
+```
+
+Large checkpoints and model weights must stay outside git. The committed
+checkpoint under `tests/fixtures/photon/checkpoints/action_memory_tiny/` is a
+tiny CI fixture only; it is not a production model.
+
+Fallback matrix:
+
+| State | Expected behavior |
+|---|---|
+| checkpoint unset | deterministic scorer |
+| checkpoint valid + MLX available | PHOTON scorer |
+| checkpoint missing | deterministic fallback + `photon_unavailable` warning |
+| checkpoint invalid | deterministic fallback + `photon_unavailable` warning |
+| MLX unavailable | deterministic fallback + `photon_unavailable` warning |
+| strict integrity mismatch | deterministic fallback + `photon_unavailable` warning |
+
+To build a small local checkpoint from normalized eval/feedback records:
+
+```bash
+python scripts/build_action_memory_checkpoint.py records.json \
+  --output /tmp/photon-action-memory/checkpoints/local-v1 \
+  --model-version action-memory-local-v1
+```
+
+The records file may be a JSON list or an object with a `records` list. Each
+record can include `kind`, `key`/`target`/`evidence_id`/`action`, and either an
+explicit `weight` or an `adopted` boolean.
+
 ## API Smoke Checks
 
 Run these from the repository root while the sidecar is running.
@@ -249,4 +323,3 @@ mypy photon_action_memory tests
 pytest -q
 python -m build
 ```
-

--- a/photon_action_memory/models/checkpoint_builder.py
+++ b/photon_action_memory/models/checkpoint_builder.py
@@ -1,0 +1,232 @@
+"""Build small Action Memory PHOTON runtime checkpoints.
+
+The builder intentionally writes the same runtime files consumed by
+``PhotonMLXAdapter`` while staying independent from MLX and training-only code.
+It is meant for local scoring checkpoints and tiny CI fixtures, not for storing
+large model artifacts in this repository.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from photon_action_memory.models.checkpoint import (
+    ALLOWED_STATE_KEYS,
+    CHECKPOINT_FORMAT,
+    CHECKPOINT_MANIFEST,
+    INTEGRITY_FILENAME,
+    STATE_FILENAME,
+    WEIGHTS_FILENAME,
+    write_integrity_manifest,
+)
+
+WeightBucket = Literal["action_weights", "file_weights", "evidence_weights"]
+
+_KIND_BUCKETS: Mapping[str, WeightBucket] = {
+    "action": "action_weights",
+    "summary": "action_weights",
+    "next_hint": "action_weights",
+    "failed_attempt": "action_weights",
+    "file": "file_weights",
+    "evidence": "evidence_weights",
+}
+_DEFAULT_WEIGHTS_PAYLOAD = b"tiny action-memory PHOTON checkpoint placeholder\n"
+
+
+@dataclass(frozen=True)
+class ActionMemoryCheckpointPaths:
+    """Files written for a runtime Action Memory checkpoint."""
+
+    checkpoint_dir: Path
+    manifest_path: Path
+    state_path: Path
+    weights_path: Path
+    integrity_path: Path | None
+    model_version: str
+
+
+def build_action_memory_checkpoint_state(
+    records: Iterable[Mapping[str, object]],
+    *,
+    bias: float = 0.5,
+) -> dict[str, object]:
+    """Build a runtime scoring state from normalized feedback/eval records.
+
+    Each record can specify:
+
+    - ``kind`` or ``bucket``: ``summary``, ``next_hint``, ``failed_attempt``,
+      ``file``, or ``evidence``.
+    - ``key`` / ``target`` / ``evidence_id`` / ``action``: the value to weight.
+    - ``weight``: explicit numeric weight.
+    - ``adopted``: when ``weight`` is absent, true maps to ``+0.2`` and false
+      maps to ``-0.1``.
+    """
+
+    action_weights: dict[str, float] = {}
+    file_weights: dict[str, float] = {}
+    evidence_weights: dict[str, float] = {}
+    buckets: dict[WeightBucket, dict[str, float]] = {
+        "action_weights": action_weights,
+        "file_weights": file_weights,
+        "evidence_weights": evidence_weights,
+    }
+
+    for index, record in enumerate(records):
+        bucket = _bucket_from_record(record, index)
+        key = _key_from_record(record, index)
+        weight = _weight_from_record(record, index)
+        current = buckets[bucket].get(key, 0.0)
+        buckets[bucket][key] = round(current + weight, 4)
+
+    return {
+        "bias": _coerce_number(bias, "bias"),
+        "action_weights": action_weights,
+        "file_weights": file_weights,
+        "evidence_weights": evidence_weights,
+    }
+
+
+def write_action_memory_checkpoint(
+    path: str | Path,
+    *,
+    model_version: str,
+    state: Mapping[str, object],
+    training_state: Mapping[str, object] | None = None,
+    weights_payload: bytes = _DEFAULT_WEIGHTS_PAYLOAD,
+    write_integrity: bool = True,
+) -> ActionMemoryCheckpointPaths:
+    """Write a small runtime checkpoint directory.
+
+    The manifest carries scorer weights. ``state.json`` and ``weights.npz`` are
+    present so strict integrity mode can verify the checkpoint package without
+    needing to import MLX or download any model.
+    """
+
+    version = model_version.strip()
+    if not version:
+        raise ValueError("model_version must be non-empty")
+    checkpoint_dir = Path(path)
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest = {
+        "format": CHECKPOINT_FORMAT,
+        "model_version": version,
+        "state": _clean_runtime_state(state),
+    }
+    manifest_path = checkpoint_dir / CHECKPOINT_MANIFEST
+    state_path = checkpoint_dir / STATE_FILENAME
+    weights_path = checkpoint_dir / WEIGHTS_FILENAME
+
+    _atomic_write_json(manifest_path, manifest)
+    _atomic_write_json(state_path, _default_training_state() | dict(training_state or {}))
+    _atomic_write_bytes(weights_path, weights_payload)
+
+    integrity_path: Path | None = None
+    if write_integrity:
+        write_integrity_manifest(checkpoint_dir)
+        integrity_path = checkpoint_dir / INTEGRITY_FILENAME
+
+    return ActionMemoryCheckpointPaths(
+        checkpoint_dir=checkpoint_dir,
+        manifest_path=manifest_path,
+        state_path=state_path,
+        weights_path=weights_path,
+        integrity_path=integrity_path,
+        model_version=version,
+    )
+
+
+def _bucket_from_record(record: Mapping[str, object], index: int) -> WeightBucket:
+    raw_bucket = record.get("bucket")
+    if isinstance(raw_bucket, str) and raw_bucket in _KIND_BUCKETS.values():
+        return raw_bucket  # type: ignore[return-value]
+
+    raw_kind = record.get("kind")
+    if isinstance(raw_kind, str):
+        bucket = _KIND_BUCKETS.get(raw_kind.strip().lower())
+        if bucket is not None:
+            return bucket
+    raise ValueError(f"record {index} must include a supported kind or bucket")
+
+
+def _key_from_record(record: Mapping[str, object], index: int) -> str:
+    for field in ("key", "target", "evidence_id", "summary_id", "action"):
+        raw = record.get(field)
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip()
+    raise ValueError(f"record {index} must include a non-empty key/target/evidence_id/action")
+
+
+def _weight_from_record(record: Mapping[str, object], index: int) -> float:
+    raw_weight = record.get("weight")
+    if raw_weight is not None:
+        return _coerce_number(raw_weight, f"record {index} weight")
+
+    raw_adopted = record.get("adopted")
+    if isinstance(raw_adopted, bool):
+        return 0.2 if raw_adopted else -0.1
+    return 0.0
+
+
+def _clean_runtime_state(state: Mapping[str, object]) -> dict[str, object]:
+    unknown = sorted(set(state) - ALLOWED_STATE_KEYS)
+    if unknown:
+        raise ValueError(f"runtime state contains unsupported keys: {', '.join(unknown)}")
+
+    clean: dict[str, object] = {}
+    clean["bias"] = _coerce_number(state.get("bias", 0.5), "bias")
+    for bucket in ("action_weights", "file_weights", "evidence_weights"):
+        clean[bucket] = _clean_weight_mapping(state.get(bucket, {}), bucket)
+    return clean
+
+
+def _clean_weight_mapping(raw: object, label: str) -> dict[str, float]:
+    if not isinstance(raw, Mapping):
+        raise ValueError(f"{label} must be an object")
+    clean: dict[str, float] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str) or not key.strip():
+            raise ValueError(f"{label} keys must be non-empty strings")
+        clean[key.strip()] = _coerce_number(value, f"{label}.{key}")
+    return clean
+
+
+def _coerce_number(raw: object, label: str) -> float:
+    if not isinstance(raw, int | float) or isinstance(raw, bool):
+        raise ValueError(f"{label} must be numeric")
+    return round(float(raw), 4)
+
+
+def _default_training_state() -> dict[str, object]:
+    return {
+        "step": 0,
+        "best_val_loss": 0.0,
+        "best_step": 0,
+        "patience_counter": 0,
+        "train_losses": [],
+        "val_losses": [],
+    }
+
+
+def _atomic_write_json(path: Path, payload: Mapping[str, object]) -> None:
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_path, path)
+
+
+def _atomic_write_bytes(path: Path, payload: bytes) -> None:
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_bytes(payload)
+    os.replace(tmp_path, path)
+
+
+__all__ = [
+    "ActionMemoryCheckpointPaths",
+    "build_action_memory_checkpoint_state",
+    "write_action_memory_checkpoint",
+]

--- a/photon_action_memory/models/photon_adapter.py
+++ b/photon_action_memory/models/photon_adapter.py
@@ -22,6 +22,7 @@ from photon_action_memory.models.checkpoint import (
     PhotonCheckpoint,
     load_checkpoint,
     load_checkpoint_manifest,
+    verify_checkpoint_integrity,
 )
 from photon_action_memory.models.state import (
     ActionCandidate,
@@ -66,6 +67,8 @@ class PhotonMLXAdapter:
         import_module: Callable[[str], ModuleType | Any] | None = None,
     ) -> PhotonMLXAdapter:
         """Build an adapter after validating checkpoint and importing MLX lazily."""
+        if strict:
+            verify_checkpoint_integrity(_checkpoint_dir(Path(path)), strict=True)
         checkpoint = load_checkpoint_manifest(path, strict=strict)
         return cls(checkpoint=checkpoint, mlx_core=_import_mlx_core(import_module))
 
@@ -163,7 +166,7 @@ def is_model_available(
     strict = _strict_checkpoint_mode() if checkpoint_path is None else False
     try:
         PhotonMLXAdapter.from_checkpoint(path, strict=strict, import_module=import_module)
-    except (CheckpointError, PhotonAdapterError):
+    except (OSError, ValueError, CheckpointError, PhotonAdapterError):
         return False
     return True
 
@@ -187,7 +190,7 @@ def score_suggestions_with_optional_adapter(
         state = PhotonScoringState.from_sidecar_request(request, evidence=evidence)
         action_candidates = [_candidate_from_suggestion(suggestion) for suggestion in suggestions]
         scored = adapter.score_actions(state, action_candidates)
-    except (CheckpointError, PhotonAdapterError):
+    except (OSError, ValueError, CheckpointError, PhotonAdapterError):
         return None
 
     score_by_index = {index: item.score for index, item in enumerate(scored)}
@@ -212,6 +215,10 @@ def score_suggestions_with_optional_adapter(
 def _strict_checkpoint_mode() -> bool:
     raw_value = os.environ.get(CHECKPOINT_STRICT_ENV, "").strip().lower()
     return raw_value in {"1", "true", "yes", "on", "strict"}
+
+
+def _checkpoint_dir(path: Path) -> Path:
+    return path if path.is_dir() else path.parent
 
 
 def _import_mlx_core(

--- a/photon_action_memory/models/photon_scorer.py
+++ b/photon_action_memory/models/photon_scorer.py
@@ -24,6 +24,7 @@ from typing import Protocol
 from photon_action_memory.models.checkpoint import CheckpointError
 from photon_action_memory.models.photon_adapter import (
     CHECKPOINT_ENV,
+    CHECKPOINT_STRICT_ENV,
     PHOTON_MODEL_VERSION,
     PhotonAdapterError,
     PhotonMLXAdapter,
@@ -398,10 +399,18 @@ def make_action_memory_scorer(
     if not raw:
         return DeterministicActionMemoryScorer()
     try:
-        adapter = PhotonMLXAdapter.from_checkpoint(Path(raw))
-    except (CheckpointError, PhotonAdapterError):
+        adapter = PhotonMLXAdapter.from_checkpoint(
+            Path(raw),
+            strict=_strict_checkpoint_mode(environment),
+        )
+    except (OSError, ValueError, CheckpointError, PhotonAdapterError):
         return DeterministicActionMemoryScorer(warnings=("photon_unavailable",))
     return PhotonMLXActionMemoryScorer(adapter=adapter)
+
+
+def _strict_checkpoint_mode(environment: Mapping[str, str]) -> bool:
+    raw_value = environment.get(CHECKPOINT_STRICT_ENV, "").strip().lower()
+    return raw_value in {"1", "true", "yes", "on", "strict"}
 
 
 __all__ = [

--- a/scripts/build_action_memory_checkpoint.py
+++ b/scripts/build_action_memory_checkpoint.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Build a small Action Memory PHOTON runtime checkpoint from JSON records."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def main(argv: list[str] | None = None) -> int:
+    from photon_action_memory.models.checkpoint_builder import (
+        build_action_memory_checkpoint_state,
+        write_action_memory_checkpoint,
+    )
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("records", type=Path, help="JSON list or object with a records list")
+    parser.add_argument("--output", type=Path, required=True, help="Checkpoint output directory")
+    parser.add_argument("--model-version", required=True, help="Runtime checkpoint model_version")
+    parser.add_argument("--bias", type=float, default=0.5)
+    parser.add_argument("--no-integrity", action="store_true")
+    args = parser.parse_args(argv)
+
+    records = _load_records(args.records)
+    state = build_action_memory_checkpoint_state(records, bias=args.bias)
+    paths = write_action_memory_checkpoint(
+        args.output,
+        model_version=args.model_version,
+        state=state,
+        write_integrity=not args.no_integrity,
+    )
+    print(
+        json.dumps(
+            {
+                "checkpoint_dir": str(paths.checkpoint_dir),
+                "manifest": str(paths.manifest_path),
+                "state": str(paths.state_path),
+                "weights": str(paths.weights_path),
+                "integrity": str(paths.integrity_path) if paths.integrity_path else None,
+                "model_version": paths.model_version,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def _load_records(path: Path) -> list[Mapping[str, object]]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    records: Any
+    if isinstance(raw, dict):
+        records = raw.get("records")
+    else:
+        records = raw
+    if not isinstance(records, list) or not all(isinstance(item, dict) for item in records):
+        raise ValueError("records file must be a JSON list or an object with a records list")
+    return records
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/photon/checkpoints/action_memory_tiny/integrity.json
+++ b/tests/fixtures/photon/checkpoints/action_memory_tiny/integrity.json
@@ -1,0 +1,6 @@
+{
+  "created_at": "2026-05-17T00:00:00+00:00",
+  "format_version": "1",
+  "state_sha256": "004160d696ec4b1af4b8caaa1b2eba18ae21a36a11bde96b2864e993e002071c",
+  "weights_sha256": "74e3d85d3b5f47699123aa7cd6d15005580985170c07e1782c1f3468cf15d075"
+}

--- a/tests/fixtures/photon/checkpoints/action_memory_tiny/manifest.json
+++ b/tests/fixtures/photon/checkpoints/action_memory_tiny/manifest.json
@@ -1,0 +1,20 @@
+{
+  "format": "photon-action-memory.mlx.v1",
+  "model_version": "action-memory-photon-tiny-v1",
+  "state": {
+    "action_weights": {
+      "failed_attempt": 0.2,
+      "next_hint": 0.12,
+      "summary": 0.15
+    },
+    "bias": 0.1,
+    "evidence_weights": {
+      "evt_session_failure": 0.45,
+      "SessionStore failure traceback": 0.4
+    },
+    "file_weights": {
+      "SessionStore retrieval bug fix summary": 0.55,
+      "tests/test_session_store.py": 0.35
+    }
+  }
+}

--- a/tests/fixtures/photon/checkpoints/action_memory_tiny/state.json
+++ b/tests/fixtures/photon/checkpoints/action_memory_tiny/state.json
@@ -1,0 +1,12 @@
+{
+  "best_step": 1,
+  "best_val_loss": 0.0,
+  "patience_counter": 0,
+  "step": 1,
+  "train_losses": [
+    0.0
+  ],
+  "val_losses": [
+    0.0
+  ]
+}

--- a/tests/fixtures/photon/checkpoints/action_memory_tiny/weights.npz
+++ b/tests/fixtures/photon/checkpoints/action_memory_tiny/weights.npz
@@ -1,0 +1,1 @@
+tiny action-memory PHOTON checkpoint fixture

--- a/tests/test_action_memory_checkpoint_builder.py
+++ b/tests/test_action_memory_checkpoint_builder.py
@@ -1,0 +1,68 @@
+"""Issue #123 — Action Memory PHOTON checkpoint builder and fixture tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from photon_action_memory.models.checkpoint import (
+    CHECKPOINT_FORMAT,
+    load_checkpoint_manifest,
+    verify_checkpoint_integrity,
+)
+from photon_action_memory.models.checkpoint_builder import (
+    build_action_memory_checkpoint_state,
+    write_action_memory_checkpoint,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "photon" / "checkpoints" / "action_memory_tiny"
+
+
+def test_build_state_from_feedback_records() -> None:
+    state = build_action_memory_checkpoint_state(
+        [
+            {"kind": "summary", "key": "summary", "adopted": True},
+            {"kind": "file", "target": "tests/test_session_store.py", "weight": 0.35},
+            {"kind": "evidence", "evidence_id": "evt_session_failure", "weight": 0.45},
+            {"kind": "failed_attempt", "action": "failed_attempt", "adopted": False},
+        ],
+        bias=0.1,
+    )
+
+    assert state == {
+        "bias": 0.1,
+        "action_weights": {"summary": 0.2, "failed_attempt": -0.1},
+        "file_weights": {"tests/test_session_store.py": 0.35},
+        "evidence_weights": {"evt_session_failure": 0.45},
+    }
+
+
+def test_write_checkpoint_creates_manifest_runtime_files_and_integrity(tmp_path: Path) -> None:
+    state = build_action_memory_checkpoint_state(
+        [{"kind": "next_hint", "key": "next_hint", "weight": 0.12}],
+        bias=0.2,
+    )
+
+    paths = write_action_memory_checkpoint(
+        tmp_path / "checkpoint",
+        model_version="action-memory-test-v1",
+        state=state,
+    )
+
+    manifest = json.loads(paths.manifest_path.read_text(encoding="utf-8"))
+    assert manifest["format"] == CHECKPOINT_FORMAT
+    assert manifest["model_version"] == "action-memory-test-v1"
+    assert manifest["state"]["action_weights"] == {"next_hint": 0.12}
+    assert paths.state_path.exists()
+    assert paths.weights_path.exists()
+    assert paths.integrity_path is not None
+    assert verify_checkpoint_integrity(paths.checkpoint_dir, strict=True) is True
+
+
+def test_tiny_fixture_checkpoint_is_valid_and_small() -> None:
+    manifest = load_checkpoint_manifest(FIXTURE)
+
+    assert manifest.model_version == "action-memory-photon-tiny-v1"
+    assert manifest.state["bias"] == 0.1
+    assert verify_checkpoint_integrity(FIXTURE, strict=True) is True
+    assert (FIXTURE / "weights.npz").stat().st_size < 1024

--- a/tests/test_action_memory_scorer.py
+++ b/tests/test_action_memory_scorer.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
+from photon_action_memory.models.photon_adapter import CHECKPOINT_STRICT_ENV
 from photon_action_memory.models.photon_scorer import (
     DETERMINISTIC_MODEL_VERSION,
     ActionMemoryScoreResult,
@@ -11,9 +14,26 @@ from photon_action_memory.models.photon_scorer import (
     EvidenceCandidate,
     FailedAttemptCandidate,
     NextHintCandidate,
+    PhotonMLXActionMemoryScorer,
     SummaryCandidate,
     make_action_memory_scorer,
 )
+
+FIXTURE_CHECKPOINT = (
+    Path(__file__).parent / "fixtures" / "photon" / "checkpoints" / "action_memory_tiny"
+)
+
+
+class _FakeArray(list[float]):
+    def item(self) -> float:
+        return self[0]
+
+
+class _FakeMlx:
+    float32 = "float32"
+
+    def array(self, values: list[float], *, dtype: object | None = None) -> _FakeArray:
+        return _FakeArray(values)
 
 
 def _score(
@@ -124,3 +144,69 @@ class TestFactory:
             env={"PHOTON_ACTION_MEMORY_CHECKPOINT": "/path/that/does/not/exist"},
         )
         assert isinstance(scorer, DeterministicActionMemoryScorer)
+
+    def test_valid_fixture_checkpoint_enters_photon_scorer_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "photon_action_memory.models.photon_adapter.importlib.import_module",
+            lambda _name: _FakeMlx(),
+        )
+
+        scorer = make_action_memory_scorer(
+            env={"PHOTON_ACTION_MEMORY_CHECKPOINT": str(FIXTURE_CHECKPOINT)},
+        )
+
+        assert isinstance(scorer, PhotonMLXActionMemoryScorer)
+        result = scorer.score(
+            request_id="req",
+            repo_id="repo",
+            task_text="SessionStore retrieval bug",
+            candidate_summaries=[
+                SummaryCandidate(
+                    summary_id="related",
+                    text="SessionStore retrieval bug fix summary",
+                    evidence_ids=("evt_session_failure",),
+                ),
+                SummaryCandidate(summary_id="noise", text="unrelated docs update"),
+            ],
+            candidate_evidence=[
+                EvidenceCandidate(
+                    evidence_id="evt_session_failure",
+                    text="SessionStore failure traceback",
+                )
+            ],
+        )
+        assert result.model_version == "action-memory-photon-tiny-v1"
+        assert result.summary_scores[0].score > result.summary_scores[1].score
+        assert result.evidence_scores[0].score == pytest.approx(0.5)
+
+    def test_strict_integrity_failure_falls_back_with_warning(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        checkpoint = tmp_path / "checkpoint"
+        _copy_fixture_checkpoint(FIXTURE_CHECKPOINT, checkpoint)
+        (checkpoint / "state.json").write_text('{"step": 99}\n', encoding="utf-8")
+        monkeypatch.setattr(
+            "photon_action_memory.models.photon_adapter.importlib.import_module",
+            lambda _name: _FakeMlx(),
+        )
+
+        scorer = make_action_memory_scorer(
+            env={
+                "PHOTON_ACTION_MEMORY_CHECKPOINT": str(checkpoint),
+                CHECKPOINT_STRICT_ENV: "true",
+            },
+        )
+
+        assert isinstance(scorer, DeterministicActionMemoryScorer)
+        assert scorer.warnings == ("photon_unavailable",)
+
+
+def _copy_fixture_checkpoint(source: Path, target: Path) -> None:
+    target.mkdir()
+    for item in source.iterdir():
+        (target / item.name).write_bytes(item.read_bytes())

--- a/workspace/v0.4.0/photon-checkpoint-scorer-eval.md
+++ b/workspace/v0.4.0/photon-checkpoint-scorer-eval.md
@@ -1,0 +1,109 @@
+# PHOTON Checkpoint Scorer Evaluation
+
+Issue #123 adds a tiny Action Memory PHOTON runtime checkpoint so the
+`PhotonMLXActionMemoryScorer` path can be tested without network access or a
+large model artifact.
+
+## Fixture
+
+Checkpoint:
+
+```text
+tests/fixtures/photon/checkpoints/action_memory_tiny/
+```
+
+Runtime state:
+
+```json
+{
+  "bias": 0.1,
+  "action_weights": {
+    "summary": 0.15,
+    "next_hint": 0.12,
+    "failed_attempt": 0.2
+  },
+  "file_weights": {
+    "SessionStore retrieval bug fix summary": 0.55,
+    "tests/test_session_store.py": 0.35
+  },
+  "evidence_weights": {
+    "evt_session_failure": 0.45,
+    "SessionStore failure traceback": 0.4
+  }
+}
+```
+
+`weights.npz` is a tiny placeholder fixture. It is intentionally not a
+production model weight file.
+
+## Ranking Difference
+
+Task:
+
+```text
+SessionStore retrieval bug
+```
+
+Candidate summaries:
+
+| Candidate | Deterministic score | PHOTON fixture score | Notes |
+|---|---:|---:|---|
+| `SessionStore retrieval bug fix summary` | 0.65 | 0.80 | PHOTON adds learned `summary` and exact summary weight |
+| `unrelated docs update` | 0.00 | 0.25 | PHOTON fixture leaves a low global summary prior |
+
+Candidate evidence:
+
+| Candidate | PHOTON fixture score | Notes |
+|---|---:|---|
+| `SessionStore failure traceback` | 0.50 | `bias + evidence_weights[text]` |
+
+The important property is not the absolute score. It is that a checkpoint can
+encode Action Memory specific priors that lexical overlap cannot represent,
+while the sidecar keeps deterministic fallback when the checkpoint is missing,
+invalid, or unavailable.
+
+## Verification
+
+Focused tests:
+
+```bash
+python -m pytest \
+  tests/test_action_memory_checkpoint_builder.py \
+  tests/test_action_memory_scorer.py \
+  tests/test_photon_adapter.py \
+  tests/test_checkpoint.py \
+  -q
+```
+
+Expected result:
+
+```text
+28 passed
+```
+
+Type and lint:
+
+```bash
+python -m mypy photon_action_memory \
+  tests/test_action_memory_checkpoint_builder.py \
+  tests/test_action_memory_scorer.py \
+  tests/test_photon_adapter.py \
+  tests/test_checkpoint.py
+
+python -m ruff check \
+  photon_action_memory/models/checkpoint_builder.py \
+  photon_action_memory/models/photon_adapter.py \
+  photon_action_memory/models/photon_scorer.py \
+  tests/test_action_memory_checkpoint_builder.py \
+  tests/test_action_memory_scorer.py \
+  scripts/build_action_memory_checkpoint.py
+```
+
+Both checks pass.
+
+## Follow-up
+
+This issue proves the checkpoint path and scorer behavior with a tiny fixture.
+Production ranking still needs a separate task to train or derive weights from
+larger eval/adoption logs and then wire the scorer into `/v1/context/pack`
+ranking.


### PR DESCRIPTION
Closes #123

## Summary

- Issue #121 / PR #122 で、`ActionMemoryPhotonScorer` の境界と fallback 実装が入った。

## Changed Files

- `manifest.json`
- `integrity.json`
- `state.json`
- `photon_action_memory/models/photon_scorer.py`
- `photon_action_memory/models/photon_adapter.py`
- `photon_action_memory/models/checkpoint.py`
- `workspace/v0.4.0/action-memory-llm-photon-improvement-plan.md`
- `workspace/v0.4.0`
- `scripts/seed_live_injection_summary.py`

## Tests Run

- 未実行

## Known Risks

- None recorded by orchestration planner.

## Orchestration

- Run ID: `20260516-154142-orchestrate`
