### PR TITLE
docs: refresh current action memory docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Live `/v1/summarize` documentation for rule-based summary generation,
+  optional LLM draft generation, and generator fallback telemetry.
+- PHOTON checkpoint scorer documentation for local checkpoint construction,
+  strict integrity verification, tiny CI fixture usage, and deterministic
+  fallback behavior.
+- Updated Anvil operations guidance for the current summarize/upsert/context
+  pack/evaluate lifecycle.
+
+### Changed
+
+- README and operations docs now describe the current sidecar implementation
+  instead of the v0.1.0 bootstrap state.
+- Active documentation now distinguishes the optional PHOTON scorer boundary
+  from the still-deterministic default HTTP context-pack ranking path.
+
 ## [0.1.0] - 2026-04-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,41 +1,59 @@
 # PHOTON Action Memory
 
-Action-oriented memory layer for coding agents, powered by PHOTON.
+Action-oriented memory and context-firewall sidecar for coding agents.
 
-PHOTON Action Memory is a local-first memory controller for coding agents. It learns from tool loops, repository exploration, test results, and past agent sessions to help agents choose the next file, command, evidence, or action.
+PHOTON Action Memory is a local-first memory controller. It learns from tool
+loops, repository exploration, test results, and previous agent sessions to
+help a coding agent choose the next file, command, evidence, or action.
 
-## Positioning
+It is not a general document RAG system. The central question is:
 
-Most memory systems for AI agents focus on storing and retrieving facts:
+> Given the current coding task, repository state, recent tool results, and
+> past sessions, what should the agent do next?
 
-- user preferences
-- past conversations
-- documents
-- knowledge graphs
-- embeddings over large corpora
+## Current Status
 
-PHOTON Action Memory focuses on a narrower problem:
+The repository now contains a working FastAPI sidecar with SQLite-backed event
+and summary storage.
 
-> Given the current coding task, repository state, recent tool results, and past sessions, what should the agent do next?
+Implemented sidecar capabilities:
 
-It is designed as an action memory layer, not a general-purpose RAG system.
+- `GET /health`
+- `POST /v1/events`
+- `POST /v1/suggest`
+- `POST /v1/summarize`
+- `POST /v1/summary/upsert`
+- `POST /v1/summary/validate`
+- `POST /v1/context/pack`
+- `POST /v1/evidence/expand`
+- `POST /v1/evaluate`
 
-## Why
+The default runtime path is deterministic and fail-open. MLX, local LLMs, and
+PHOTON checkpoints are optional; the package must import, test, and run the
+default sidecar without them installed.
 
-Coding agents spend a large amount of time on repeated exploration:
+## Core Capabilities
 
-- searching for the same symbols
-- reopening the same files
-- retrying failed commands
-- missing useful tests
-- drifting away from the original task
-- losing context between sessions
-
-PHOTON Action Memory aims to reduce that waste by turning past agent behavior into reusable action guidance.
+- Convert coding-agent event logs into `ActionChunk` and `ActionSummary`
+  records.
+- Keep prompt-visible memory behind an Action Context Firewall.
+- Deny raw stdout/stderr by default and expose only admitted summaries or
+  selected evidence snippets.
+- Store summaries locally in SQLite and retrieve them by repo/task scope.
+- Validate summaries for evidence grounding, stale or contradicted state, and
+  answer-leak risks.
+- Build `ContextPack` responses that respect a memory token budget.
+- Expand evidence on demand by `evidence_id`.
+- Log shadow/canary adoption and outcome data through `/v1/evaluate`.
+- Generate summaries with the default rule-based generator or an opt-in local
+  LLM draft generator.
+- Build and test optional PHOTON/MLX checkpoint scorers while preserving
+  deterministic fallback when a checkpoint or MLX runtime is unavailable.
 
 ## Memory Hierarchy
 
-PHOTON Action Memory is intended to sit between short-lived working memory and long-term knowledge stores.
+PHOTON Action Memory sits between short-lived working memory and long-term
+knowledge stores.
 
 ```text
 LLM
@@ -51,41 +69,90 @@ Episodic / User Memory           Main Memory
 Repo Index / Vector DB / Graph   Storage
 ```
 
-In this model, PHOTON Action Memory acts like an L3 action cache for coding agents.
+In this model, PHOTON Action Memory acts like an L3 action cache and context
+firewall for coding agents.
 
-## Core Capabilities
-
-- Predict useful next actions: read, search, edit, test, build, inspect, ask, or answer.
-- Recommend files, symbols, commands, and tests based on current task state.
-- Select evidence that should be included in the agent context.
-- Reuse successful patterns from similar past sessions.
-- Detect repeated failed attempts and suggest alternatives.
-- Warn when the current plan drifts away from the original task.
-- Adapt to repository-specific workflows over time.
-
-## Target Integrations
+## Target Integration
 
 The first target integration is Anvil, a local-first coding agent.
 
-The intended deployment model is a fail-open local sidecar:
+The deployment model is a fail-open local sidecar:
 
 ```text
 Coding Agent
   ↓
 PHOTON Action Memory Sidecar
   ↓
-Local Event Store / Memory Index
+Local Event Store / Summary Store
   ↓
-PHOTON Model
+Deterministic scorer / optional PHOTON scorer boundary
 ```
 
-The agent remains responsible for final decisions and tool execution. PHOTON Action Memory provides ranked suggestions and compact memory signals.
+The agent remains responsible for final decisions and tool execution. PHOTON
+Action Memory provides compact memory signals, evidence references, admission
+decisions, and evaluation data.
 
-Anvil operations docs:
+Primary operations docs:
 
-- `docs/photon-action-memory.md`: local sidecar startup and API smoke checks.
+- `docs/photon-action-memory.md`: sidecar startup, storage, API smoke checks,
+  optional LLM summary generation, and checkpoint scorer notes.
 - `docs/anvil-integration.md`: Anvil env/defaults, shadow/canary/rollback
   checklists, shared fixture updates, and troubleshooting ownership.
+- `workspace/anvil/summary.md`: Anvil-facing fixture and integration notes.
+- `workspace/v0.4.0/`: v0.4.0 LLM/PHOTON planning and checkpoint scorer
+  evaluation notes.
+
+## Summary Generation
+
+`POST /v1/summarize` is implemented. It builds and persists `ActionSummary`
+objects from buffered chunks, inline chunks, or firewall-checked draft
+summaries.
+
+Default behavior:
+
+```text
+event log -> ActionChunk -> rule-based ActionSummary
+```
+
+The optional LLM draft path is enabled only by configuration:
+
+```bash
+PHOTON_SUMMARY_GENERATOR=llm \
+python -m uvicorn photon_action_memory.api.server:app \
+  --host 127.0.0.1 \
+  --port 18765
+```
+
+The LLM path is a draft generator, not a source of truth. Its output must pass
+schema validation, evidence grounding, raw-leak checks, answer-leak gates, and
+summary fidelity checks. Failures fall back to the rule-based generator by
+default and are reported through `generator_used` and
+`generator_fallback_reason`.
+
+## PHOTON / MLX
+
+PHOTON/MLX support is optional.
+
+Current state:
+
+- The default sidecar uses deterministic summary generation and deterministic
+  context admission.
+- `PHOTON_SUMMARY_GENERATOR=llm` enables an opt-in MLX-backed local LLM draft
+  summary path.
+- `PHOTON_ACTION_MEMORY_CHECKPOINT=/path/to/checkpoint` is supported by the
+  `ActionMemoryPhotonScorer` factory for local scorer evaluation.
+- The committed checkpoint under
+  `tests/fixtures/photon/checkpoints/action_memory_tiny/` is a tiny CI fixture,
+  not a production model.
+- Wiring a trained PHOTON checkpoint into live `/v1/context/pack` ranking is a
+  follow-up task; the checkpoint path and fallback behavior are already covered
+  by focused tests.
+
+Install MLX extras only when working on optional local model paths:
+
+```bash
+python -m pip install -e ".[dev,mlx]"
+```
 
 ## Inputs
 
@@ -106,30 +173,15 @@ Typical inputs include:
 
 Typical outputs include:
 
+- action summaries
+- context packs
 - next action candidates
 - target file candidates
 - search query candidates
 - command/test candidates
-- relevant evidence snippets
-- similar prior cases
+- evidence references and selected snippets
 - avoid/retry guidance
-- confidence and rationale metadata
-
-## Training Data
-
-PHOTON Action Memory is trained from coding-agent trajectories rather than final assistant prose.
-
-Useful training examples include:
-
-- task state to next action
-- task state to target files
-- tool result to next command
-- error output to relevant evidence
-- failed attempt to avoid signal
-- session history to compact working memory
-- final outcome to trajectory quality
-
-The goal is not to imitate a large language model's writing style. The goal is to improve action selection inside coding-agent loops.
+- confidence, validation, and admission metadata
 
 ## Non-goals
 
@@ -143,58 +195,6 @@ PHOTON Action Memory is not intended to replace:
 - an agent runtime or orchestration framework
 
 It is a focused memory controller for coding-agent behavior.
-
-## Related Systems
-
-PHOTON Action Memory is complementary to existing memory and agent infrastructure:
-
-- Mem0: user and personalization memory
-- Zep: temporal conversation and graph memory
-- Letta: stateful agent runtime and memory blocks
-- Cognee: knowledge graph and RAG over documents/data
-
-PHOTON Action Memory focuses specifically on action-oriented memory for coding agents.
-
-## Roadmap
-
-- Define the sidecar request/response schema.
-- Build a local sidecar API for agent integrations.
-- Add an offline dataset exporter for coding-agent logs.
-- Train action, file, evidence, and failure-avoidance heads.
-- Integrate with Anvil's repo context and working memory.
-- Add shadow-mode evaluation.
-- Measure reduction in repeated exploration and tool calls.
-- Add repository-local adaptation.
-- Provide MCP / stdio adapters for broader agent compatibility.
-
-## Status
-
-This repository is in the initial design and implementation phase.
-
-The v0.1.0 development bootstrap is organized under `workspace/v0.1.0/`.
-
-## License
-
-PHOTON Action Memory is released under the MIT License. See `LICENSE`.
-
-## Release
-
-Releases are tagged as `vX.Y.Z`. Pushing a release tag triggers the GitHub
-Actions release workflow, builds the Python source distribution and wheel, and
-attaches the generated artifacts to a GitHub Release.
-
-Use the repository release command when preparing a new release:
-
-```text
-/release patch
-/release minor
-/release major
-/release 1.2.3
-```
-
-The release flow updates `pyproject.toml`, `photon_action_memory/__init__.py`,
-and `CHANGELOG.md`, opens a release PR to `main`, and creates the tag only after
-the PR is merged.
 
 ## Development
 
@@ -220,10 +220,39 @@ pytest -q
 python -m build
 ```
 
-PHOTON / MLX support is optional during v0.1.0 bootstrap:
+Run the sidecar locally:
 
 ```bash
-python -m pip install -e ".[dev,mlx]"
+python -m uvicorn photon_action_memory.api.server:app \
+  --host 127.0.0.1 \
+  --port 18765
 ```
 
-The package must continue to import and run its default tests without MLX installed.
+Smoke-check health:
+
+```bash
+curl -fsS http://127.0.0.1:18765/health
+```
+
+## Release
+
+Releases are tagged as `vX.Y.Z`. Pushing a release tag triggers the GitHub
+Actions release workflow, builds the Python source distribution and wheel, and
+attaches the generated artifacts to a GitHub Release.
+
+Use the repository release command when preparing a new release:
+
+```text
+/release patch
+/release minor
+/release major
+/release 1.2.3
+```
+
+The release flow updates `pyproject.toml`, `photon_action_memory/__init__.py`,
+and `CHANGELOG.md`, opens a release PR to `main`, and creates the tag only
+after the PR is merged.
+
+## License
+
+PHOTON Action Memory is released under the MIT License. See `LICENSE`.

--- a/configs/README.md
+++ b/configs/README.md
@@ -1,6 +1,16 @@
 # Configs
 
-Configuration files for sidecar, evaluation, and future PHOTON adapter runs will live here.
+Configuration files for sidecar, evaluation, local LLM draft generation, and
+PHOTON checkpoint scorer runs live here when they are safe to commit.
 
 Do not commit local secrets, raw dataset paths, checkpoints, or machine-specific config.
 
+Local-only paths should stay in environment variables instead:
+
+| Variable | Purpose |
+|---|---|
+| `PHOTON_ACTION_MEMORY_DB` | SQLite event store path. |
+| `PHOTON_ACTION_MEMORY_SUMMARY_DB` | SQLite summary store path. |
+| `PHOTON_SUMMARY_GENERATOR` | `rule_based` by default; `llm` for opt-in local LLM drafts. |
+| `PHOTON_SUMMARY_LLM_MODEL` | Local MLX model identifier/path for the optional draft generator. |
+| `PHOTON_ACTION_MEMORY_CHECKPOINT` | Local PHOTON checkpoint path for scorer evaluation. |

--- a/docs/anvil-integration.md
+++ b/docs/anvil-integration.md
@@ -65,7 +65,7 @@ export ANVIL_PHOTON_CANARY=true
 | Endpoint | Anvil call timing | Expected behavior |
 |---|---|---|
 | `GET /health` | Startup and diagnostics | Returns sidecar health. |
-| `POST /v1/summarize` | At a turn boundary, after chunks are assembled (v0.4.0 P1+) | Generates `ActionSummary` from the supplied `chunk_ids`. |
+| `POST /v1/summarize` | At a turn boundary, after chunks are assembled | Generates and validates `ActionSummary` records from `chunk_ids`, inline chunks, or draft summaries. |
 | `POST /v1/summary/upsert` | After `/v1/summarize` returns, or when Anvil already has a summary to persist | Stores `ActionSummary` for later retrieval. |
 | `POST /v1/context/pack` | Before prompt assembly | Returns admitted memory items and denial decisions. |
 | `POST /v1/evidence/expand` | Optional, after context pack selection | Expands selected evidence only; raw output remains denied in Anvil profile. |
@@ -78,11 +78,15 @@ Required sequence for a turn:
                        -> optional evidence_expand -> evaluate
 ```
 
-`/v1/summarize` is new in v0.4.0 P1. Until P1 ships, Anvil should skip the
-summarize step and continue from `/v1/summary/upsert` with the existing
-summary builder; the smoke runner in this repo
-(`scripts/anvil_v1_summarize_smoke.py`) records `status=summarize_stub`
-when the sidecar returns 501.
+Current `develop` sidecars implement `/v1/summarize`. Anvil should call it at
+turn boundaries when chunk data is available, then persist the returned summary
+through `/v1/summary/upsert` before requesting `/v1/context/pack`.
+
+For compatibility with old sidecars or empty local stores, Anvil may keep a
+fixture or local-builder fallback. The smoke runner in this repo
+(`scripts/anvil_v1_summarize_smoke.py`) still records fixture-fallback statuses
+when a live summary is unavailable, but 501 is no longer the expected current
+sidecar behavior.
 
 ### `/v1/summarize` Anvil-side request fields
 
@@ -97,6 +101,21 @@ when the sidecar returns 501.
 | `policy.separate_fact_and_hypothesis` | yes | Should remain `true` to keep hypothesis-as-fact pollution out of the prompt. |
 | `policy.include_failed_attempts` | yes | Should remain `true` so `failed_attempts` reaches the next turn. |
 | `policy.include_avoid_guidance` | yes | Should remain `true` so `avoid` reaches the next turn. |
+
+### `/v1/summarize` response fields Anvil should log
+
+| Field | Meaning |
+|---|---|
+| `sidecar_status` | `ok`, `degraded`, or `fail-open` style status for the call. |
+| `status` | Summarize result status; `ok` for clean live generation and `degraded` for recoverable fallback/error paths. |
+| `summary.summary_id` | Summary ID to pass to `/v1/summary/upsert` and later `candidate_summary_ids`. |
+| `validation.status` | Summary fidelity result. |
+| `generator_used` | `rule_based` or `llm`. |
+| `generator_fallback_reason` | Stable reason enum when the LLM path falls back, otherwise `null`. |
+
+`generator_used=llm` is possible only when photon-action-memory is started with
+`PHOTON_SUMMARY_GENERATOR=llm` and the local MLX model path succeeds. The
+default is `rule_based`.
 
 ### `/v1/summarize` timing
 
@@ -231,5 +250,5 @@ Then run the commands in `docs/photon-action-memory.md`:
 - `GET /health`
 - `POST /v1/context/pack`
 - `POST /v1/evaluate`
+- `POST /v1/summarize`
 - `POST /v1/summary/upsert`
-

--- a/docs/photon-action-memory.md
+++ b/docs/photon-action-memory.md
@@ -52,27 +52,19 @@ Expected startup state:
 - The sidecar is fail-open for integration routes; callers should keep their own
   turn execution path independent of this process.
 
-### Optional PHOTON Checkpoint Scorer
+### Optional PHOTON Checkpoint Scorer Boundary
 
-The default scorer is deterministic and requires no PHOTON checkpoint. To test
-the PHOTON/MLX scorer path, point the sidecar at a local runtime checkpoint:
+The HTTP sidecar currently uses deterministic context admission and feedback
+ordering by default. Issue #123 added the runtime checkpoint format and
+`ActionMemoryPhotonScorer` factory so the PHOTON/MLX scoring path can be
+tested locally before it is wired into live `/v1/context/pack` ranking.
 
-```bash
-PHOTON_ACTION_MEMORY_CHECKPOINT=/path/to/checkpoint \
-python -m uvicorn photon_action_memory.api.server:app \
-  --host 127.0.0.1 \
-  --port 18765
-```
+Set these variables when constructing or testing the scorer:
 
-For strict local verification of `state.json` and `weights.npz` hashes:
-
-```bash
-PHOTON_ACTION_MEMORY_CHECKPOINT=/path/to/checkpoint \
-PHOTON_ACTION_MEMORY_CHECKPOINT_STRICT=true \
-python -m uvicorn photon_action_memory.api.server:app \
-  --host 127.0.0.1 \
-  --port 18765
-```
+| Variable | Purpose |
+|---|---|
+| `PHOTON_ACTION_MEMORY_CHECKPOINT` | Local checkpoint directory for `make_action_memory_scorer`. |
+| `PHOTON_ACTION_MEMORY_CHECKPOINT_STRICT` | When true, verify `state.json` and `weights.npz` hashes from `integrity.json`. |
 
 Runtime checkpoint directories use this shape:
 
@@ -125,6 +117,21 @@ python scripts/build_action_memory_checkpoint.py records.json \
 The records file may be a JSON list or an object with a `records` list. Each
 record can include `kind`, `key`/`target`/`evidence_id`/`action`, and either an
 explicit `weight` or an `adopted` boolean.
+
+Focused scorer verification:
+
+```bash
+python -m pytest \
+  tests/test_action_memory_checkpoint_builder.py \
+  tests/test_action_memory_scorer.py \
+  tests/test_photon_adapter.py \
+  tests/test_checkpoint.py \
+  -q
+```
+
+Current limitation: `PHOTON_ACTION_MEMORY_CHECKPOINT` verifies the scorer
+boundary and checkpoint fallback behavior. A trained checkpoint is not yet used
+by the default HTTP context-pack ranking path.
 
 ## API Smoke Checks
 
@@ -181,12 +188,41 @@ Expected checks:
 - `logged` is `1`.
 - The stored event has `adoption_status=shadow_not_injected`.
 
-### Summarize (v0.4.0 P1 / P2)
+### Summarize
 
-`/v1/summarize` produces an `ActionSummary` from buffered chunks. It is the
-M2 stub (HTTP 501) until v0.4.0 P1 (Issue #86) lands. The integration smoke
-expects the v0.4.0 contract and is reproducible today with a graceful 501
-fallback that uses a fixture in place of the live response.
+`/v1/summarize` is implemented. It produces an `ActionSummary` from stored
+chunk IDs, inline `ActionChunk` payloads, or a prebuilt `draft_summary` that
+needs Action Context Firewall validation before reuse.
+
+The default generator is rule-based and deterministic:
+
+```text
+event log -> ActionChunk -> ActionSummary
+```
+
+The optional LLM draft path is opt-in:
+
+```bash
+PHOTON_SUMMARY_GENERATOR=llm \
+python -m uvicorn photon_action_memory.api.server:app \
+  --host 127.0.0.1 \
+  --port 18765
+```
+
+LLM draft configuration:
+
+| Variable | Default | Values / meaning |
+|---|---|---|
+| `PHOTON_SUMMARY_GENERATOR` | `rule_based` | `rule_based` or `llm`; unknown values fall back to `rule_based`. |
+| `PHOTON_SUMMARY_LLM_MODEL` | `mlx-community/Qwen2.5-7B-Instruct-4bit` | Local MLX model identifier or path. |
+| `PHOTON_SUMMARY_LLM_FALLBACK_POLICY` | `rule_based` | `rule_based` or `abort`. |
+| `PHOTON_SUMMARY_LLM_TEMPERATURE` | `0.1` | Low temperature keeps JSON output stable. |
+| `PHOTON_SUMMARY_LLM_MAX_TOKENS` | `512` | Maximum generated tokens. |
+| `PHOTON_SUMMARY_LLM_SEED` | `1729` | Optional deterministic seed. |
+
+The LLM module is lazily imported. Missing MLX, missing model files, invalid
+JSON, schema failures, quality-gate rejection, and fidelity failures all return
+to the rule-based generator unless the fallback policy is `abort`.
 
 Request envelope:
 
@@ -206,14 +242,18 @@ Request envelope:
 }
 ```
 
-Expected response (post-P1):
+Expected response:
 
 ```json
 {
   "schema_version": "action-memory.v0.2",
   "request_id": "smoke-summarize-<short>",
+  "sidecar_status": "ok",
+  "status": "ok",
   "summary": { "summary_id": "<id>", "...": "..." },
-  "validation": { "status": "valid", "score": 0.94 }
+  "validation": { "status": "valid", "score": 0.94 },
+  "generator_used": "rule_based",
+  "generator_fallback_reason": null
 }
 ```
 
@@ -225,8 +265,9 @@ python3 scripts/anvil_v1_summarize_smoke.py --scenario S3-01
 
 The runner drives the full turn lifecycle against `127.0.0.1:18765`:
 `summarize → summary/upsert → context/pack → evidence/expand → evaluate`.
-If `/v1/summarize` is the 501 stub, the runner records
-`status=summarize_stub` and continues from `/v1/summary/upsert`. Pass
+On current `develop`, a live response should be used when matching chunks are
+available. If the sidecar is old or no stored chunk is available, the runner can
+still use a fixture fallback and continue from `/v1/summary/upsert`. Pass
 `--scenario` multiple times to run a subset; omit it to run all three
 beta-gamma-light scenarios (S2-03, S3-01, S5-01).
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,7 +1,29 @@
 # Scripts
 
-Repository-local helper scripts will live here.
+Repository-local helper scripts are thin wrappers around importable package
+modules under `photon_action_memory/`.
 
-Initial implementation should prefer importable package modules under `photon_action_memory/`
-and keep scripts as thin CLI wrappers.
+## Sidecar And Anvil Smoke
 
+| Script | Purpose |
+|---|---|
+| `anvil_v1_summarize_smoke.py` | Drives `/v1/summarize -> /v1/summary/upsert -> /v1/context/pack -> /v1/evidence/expand -> /v1/evaluate` against `127.0.0.1:18765`. |
+| `seed_live_injection_summary.py` | Seeds the shared live-injection summary fixture into the local sidecar. |
+| `seed_expanded_eval_scenarios.sh` | Seeds the beta/gamma Anvil eval scenario fixtures. |
+| `seed_common_seeds.sh` | Seeds common local evaluation summaries. |
+| `seed_universal_seeds.sh` | Seeds broader reusable summary fixtures. |
+
+## PHOTON / Evaluation Utilities
+
+| Script | Purpose |
+|---|---|
+| `build_action_memory_checkpoint.py` | Builds a small Action Memory PHOTON checkpoint from normalized eval/feedback records. |
+| `cy5_success_rate_analysis.py` | Computes CY5 success-rate analysis artifacts. |
+| `cy6_gate_check.py` | Checks CY6 gate metrics from local eval logs. |
+
+## Orchestration Utilities
+
+| Script | Purpose |
+|---|---|
+| `codex_orchestrate.py` | Repository-local Codex issue orchestration helper. |
+| `commandmate_codex.py` | CommandMate/Codex adapter helper used by orchestration flows. |

--- a/workspace/anvil/summary.md
+++ b/workspace/anvil/summary.md
@@ -42,6 +42,29 @@ This file collects the Anvil-facing notes added by the Anvil integration
 issues. It includes both the evidence expansion contract from Issue #66 and
 the summary store design note from Issue #68.
 
+## Current photon-action-memory Status
+
+Current `develop` sidecars expose the full Anvil turn lifecycle:
+
+```text
+/v1/summarize -> /v1/summary/upsert -> /v1/context/pack
+              -> /v1/evidence/expand -> /v1/evaluate
+```
+
+Important defaults:
+
+| Area | Current behavior |
+|---|---|
+| Summary generation | `PHOTON_SUMMARY_GENERATOR=rule_based` by default. |
+| LLM summary draft | Opt-in with `PHOTON_SUMMARY_GENERATOR=llm`; falls back to rule-based unless abort policy is selected. |
+| PHOTON checkpoint scorer | `PHOTON_ACTION_MEMORY_CHECKPOINT` is available for scorer-boundary testing and evaluation. |
+| Context pack ranking | Still deterministic/feedback-adjusted by default; trained PHOTON checkpoint wiring is a follow-up. |
+| Raw evidence | Raw stdout/stderr remains default-deny for prompt-visible memory. |
+
+See `docs/photon-action-memory.md` for photon-side startup and smoke checks,
+and `docs/anvil-integration.md` for Anvil runtime sequencing and fallback
+ownership.
+
 ## Evidence Expansion Contract
 
 Endpoint: `POST /v1/evidence/expand`
@@ -190,9 +213,12 @@ Key modules:
 Primary docs:
 
 - `docs/photon-action-memory.md` — photon-side sidecar startup and API smoke
-  checks.
+  checks, including `/v1/summarize`, optional LLM draft generation, and
+  checkpoint scorer evaluation.
 - `docs/anvil-integration.md` — Anvil env/defaults, shadow/canary/rollback
   checklists, fixture updates, and troubleshooting ownership.
+- `workspace/v0.4.0/` — v0.4.0 LLM/PHOTON planning and checkpoint scorer
+  evaluation notes.
 
 Operational defaults stay aligned with the Anvil docs:
 

--- a/workspace/v0.1.0/README.md
+++ b/workspace/v0.1.0/README.md
@@ -1,5 +1,9 @@
 # photon-action-memory v0.1.0 Workspace
 
+> 現在の実装状況はリポジトリ root の `README.md` と `docs/` を参照すること。
+> このディレクトリは v0.1.0 初期設計の履歴資料であり、`/v1/summarize`
+> などの現行実装状態を表す source of truth ではない。
+
 このディレクトリは、`photon-action-memory` の初期開発に向けた設計・移行・運用計画をまとめる。
 
 ## 目的

--- a/workspace/v0.2.0/README.md
+++ b/workspace/v0.2.0/README.md
@@ -1,5 +1,9 @@
 # PHOTON Action Memory v0.2.0 Plan
 
+> 現在の実装状況はリポジトリ root の `README.md` と `docs/` を参照すること。
+> このディレクトリは v0.2.0 計画の履歴資料であり、現行 sidecar の endpoint
+> 実装状態や v0.4.0 LLM/PHOTON 設定の source of truth ではない。
+
 ## 目的
 
 v0.2.0 の目的は、PHOTON Action Memory を v0.1.0 の **Action Memory Sidecar** から、より強い **Action Context Firewall** へ拡張することである。

--- a/workspace/v0.3.0/anvil-eval-beta-gamma-light-result.md
+++ b/workspace/v0.3.0/anvil-eval-beta-gamma-light-result.md
@@ -1,7 +1,7 @@
 # Anvil Eval — Beta-Gamma Light Result Template
 
 作成日: 2026-05-13
-対象: v0.4.0 P2 `/v1/summarize` integration smoke (Issue #88)
+対象: `/v1/summarize` integration smoke (Issue #88)
 
 ## 目的
 
@@ -71,13 +71,15 @@ CI 連携時は `python3 scripts/anvil_v1_summarize_smoke.py` の終了コード
 | L2 |  |  | S3-01 |  |  |  |  |
 | L3 |  |  | S5-01 |  |  |  |  |
 
-`summarize status` 列は `ok` (P1 後) または `summarize_stub` (P1 前)。
+`summarize status` 列は、現行 sidecar では live response の `ok` または
+chunk 未投入時の `summary_fixture` を記録する。`summarize_stub` は旧 sidecar
+互換の記録値としてのみ残る。
 
 ## 補足
 
-- `/v1/summarize` が 501 を返す現状でも、smoke は fixture をフォールバック
-  として使い `summary_upsert` 以降を実行する。これにより P2 の手順を P1
-  着地前から検証できる。
+- 現行 `develop` の `/v1/summarize` は実装済み。smoke は live summary が
+  返らない場合だけ fixture をフォールバックとして使い、`summary_upsert`
+  以降を継続する。
 - 本ドキュメントは「light」の名の通り 3 シナリオに限定する。フルの
   expanded eval は Anvil 側 `e2e_uat_matrix.py` を別途回す。
 - S2-03 / S3-01 / S5-01 以外のシナリオ追加は、`SCENARIOS` 辞書

--- a/workspace/v0.4.0/README.md
+++ b/workspace/v0.4.0/README.md
@@ -1,0 +1,38 @@
+# PHOTON Action Memory v0.4.0 Notes
+
+v0.4.0 focuses on improving Action Memory quality without making local LLMs or
+PHOTON checkpoints mandatory.
+
+## Current Defaults
+
+| Area | Default |
+|---|---|
+| Summary generation | `rule_based` |
+| LLM draft generation | disabled unless `PHOTON_SUMMARY_GENERATOR=llm` |
+| LLM fallback policy | `rule_based` |
+| PHOTON checkpoint scorer | disabled unless a scorer is constructed with `PHOTON_ACTION_MEMORY_CHECKPOINT` |
+| HTTP context-pack ranking | deterministic/feedback-adjusted |
+
+## Implemented Pieces
+
+- `SummaryGeneratorProtocol`
+- `RuleBasedSummaryGenerator`
+- opt-in `LLMDraftSummaryGenerator`
+- summarize response telemetry: `generator_used` and `generator_fallback_reason`
+- `ActionMemoryPhotonScorer` boundary
+- PHOTON checkpoint manifest/state/integrity loader
+- tiny PHOTON checkpoint fixture for CI
+- `scripts/build_action_memory_checkpoint.py`
+
+## Documents
+
+| File | Purpose |
+|---|---|
+| `action-memory-llm-photon-improvement-plan.md` | Current v0.4.0 LLM draft summary and PHOTON checkpoint scorer plan/status. |
+| `photon-checkpoint-scorer-eval.md` | Tiny checkpoint fixture, expected ranking difference, and verification commands. |
+
+## Follow-up
+
+A production PHOTON effect requires a trained or derived checkpoint from larger
+eval/adoption logs and live wiring into `/v1/context/pack` ranking. Until that
+lands, the HTTP sidecar keeps deterministic fallback behavior.

--- a/workspace/v0.4.0/action-memory-llm-photon-improvement-plan.md
+++ b/workspace/v0.4.0/action-memory-llm-photon-improvement-plan.md
@@ -1,0 +1,161 @@
+# Action Memory LLM / PHOTON 改善計画
+
+## 目的
+
+v0.4.0 の目的は、現在の安全な rule-based 圧縮を維持したまま、任意機能として
+LLM と PHOTON/MLX の改善余地を追加すること。
+
+現在の baseline は次の決定的な変換である。
+
+```text
+event log -> ActionChunk -> ActionSummary
+```
+
+この方式は速く、再現性があり、MLX やモデル checkpoint がなくても動く。一方で、
+test failure、diff、command output、複数 topic の意味までは深く読めない。
+v0.4.0 では rule-based を fail-open baseline として残し、LLM / PHOTON は
+opt-in の品質改善レイヤとして扱う。
+
+## 現在の実装状態
+
+| 領域 | 状態 |
+|---|---|
+| `/v1/summarize` | 実装済み。stored chunk、inline chunk、draft summary firewall に対応。 |
+| default summary | `RuleBasedSummaryGenerator`。既存 `ActionSummaryBuilder` と同じ決定的経路。 |
+| LLM draft summary | `PHOTON_SUMMARY_GENERATOR=llm` のときだけ有効。MLX は lazy import。 |
+| LLM fallback | default は `rule_based`。`abort` は明示設定時のみ。 |
+| response telemetry | `generator_used` / `generator_fallback_reason` を返す。 |
+| PHOTON scorer | `ActionMemoryPhotonScorer` 境界と checkpoint loader は実装済み。 |
+| checkpoint fixture | tiny fixture を `tests/fixtures/photon/checkpoints/action_memory_tiny/` に配置済み。 |
+| live context ranking | `/v1/context/pack` はまだ deterministic/feedback-adjusted。PHOTON checkpoint の live wiring は未実装。 |
+
+## LLM Draft Summary
+
+LLM は source of truth ではなく、draft generator として使う。
+
+```text
+sanitized events
+  -> deterministic ActionChunk grouping
+  -> LLM draft ActionSummary JSON
+  -> schema validation
+  -> evidence grounding / raw leak / answer leak / fidelity gates
+  -> SummaryStore
+```
+
+LLM に任せてよいこと:
+
+- turn 内の evidence を簡潔な `facts[]` に変換する。
+- 不確かな観察を `hypotheses[]` に分離する。
+- 失敗した command / test を `failed_attempts[]` に整理する。
+- 繰り返し失敗や irrelevant search を `avoid[]` に反映する。
+- 次に読む file、実行する test、確認する symbol を `next_hints[]` にする。
+
+LLM に任せないこと:
+
+- 存在しない file、symbol、test、evidence ID を作る。
+- raw stdout/stderr、secret、home path、stack dump を prompt-visible field に入れる。
+- 不確かな主張を `facts[]` に入れる。
+- agent が作業を終了すべきかを決める。
+
+## LLM 設定
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `PHOTON_SUMMARY_GENERATOR` | `rule_based` | `llm` のときだけ LLM draft を試す。 |
+| `PHOTON_SUMMARY_LLM_MODEL` | `mlx-community/Qwen2.5-7B-Instruct-4bit` | ローカル MLX model identifier/path。 |
+| `PHOTON_SUMMARY_LLM_FALLBACK_POLICY` | `rule_based` | `rule_based` または `abort`。 |
+| `PHOTON_SUMMARY_LLM_TEMPERATURE` | `0.1` | JSON 安定性重視の低温設定。 |
+| `PHOTON_SUMMARY_LLM_MAX_TOKENS` | `512` | 生成 token 上限。 |
+| `PHOTON_SUMMARY_LLM_SEED` | `1729` | deterministic seed。 |
+
+失敗理由は closed enum として `generator_fallback_reason` に出す。prompt、
+raw model output、raw exception body はログやレスポンスに出さない。
+
+## PHOTON / MLX Scorer
+
+PHOTON checkpoint は、文書回答を生成するためではなく、Action Memory の
+summary / evidence / next action 候補を score/rank するために使う。
+
+現在実装済みのもの:
+
+- `PHOTON_ACTION_MEMORY_CHECKPOINT`
+- `PHOTON_ACTION_MEMORY_CHECKPOINT_STRICT`
+- checkpoint manifest/state/integrity loader
+- `PhotonMLXActionMemoryScorer`
+- checkpoint 欠落、破損、MLX 不在時の deterministic fallback
+- tiny checkpoint による ranking difference test
+
+checkpoint directory の形:
+
+```text
+checkpoint/
+  manifest.json
+  state.json
+  weights.npz
+  integrity.json
+```
+
+現時点の制約:
+
+- committed fixture は CI 用の小さな動作確認 checkpoint であり、本番モデルではない。
+- large checkpoint や model weights は git に入れない。
+- `PHOTON_ACTION_MEMORY_CHECKPOINT` は scorer 境界の評価に使えるが、live
+  `/v1/context/pack` ranking への接続は次の実装課題。
+
+## PHOTON らしい効果として狙うこと
+
+LLM draft は「意味のある ActionSummary を作る」ための改善で、PHOTON scorer は
+「どの記憶を次の行動に効かせるか」を選ぶための改善である。
+
+PHOTON checkpoint を live ranking に接続できると、次の効果を検証できる。
+
+- lexical overlap だけでは拾えない類似作業の summary を上げる。
+- 過去に成功した test / file / command の next hint を上げる。
+- 失敗が繰り返された探索や command を下げる。
+- evaluate feedback から、adopted / ignored / safety violation の傾向を ranking に反映する。
+- context budget 内で、より行動に直結する memory を選ぶ。
+
+## 段階導入
+
+1. default は rule-based のままにする。
+2. `PHOTON_SUMMARY_GENERATOR=llm` を shadow/eval で試す。
+3. fallback reason、summary fidelity、answer-leak warning、tokens saved を見る。
+4. eval/adoption log から checkpoint を作る。
+5. checkpoint scorer の ranking difference を fixture と実ログで確認する。
+6. `/v1/context/pack` ranking へ PHOTON scorer を注入する。
+7. shadow mode で deterministic ranking と PHOTON ranking を比較する。
+8. canary は raw leak、fail-open rate、latency が gate を満たした後に限定する。
+
+## 検証
+
+LLM draft summary:
+
+```bash
+python -m pytest \
+  tests/test_summary_generator.py \
+  tests/test_llm_draft_summary.py \
+  tests/test_summarize_endpoint.py \
+  -q
+```
+
+PHOTON checkpoint scorer:
+
+```bash
+python -m pytest \
+  tests/test_action_memory_checkpoint_builder.py \
+  tests/test_action_memory_scorer.py \
+  tests/test_photon_adapter.py \
+  tests/test_checkpoint.py \
+  -q
+```
+
+sidecar contract:
+
+```bash
+python -m pytest \
+  tests/test_anvil_contract.py \
+  tests/test_anvil_context_pack_api.py \
+  tests/test_anvil_evaluate.py \
+  tests/test_summarize_endpoint.py \
+  -q
+```


### PR DESCRIPTION
Summary: refresh README and active docs for current summarize, optional LLM draft generation, PHOTON checkpoint scorer boundary, and Anvil lifecycle. Adds v0.4.0 LLM/PHOTON plan docs and marks older workspace READMEs as historical. Verification: git diff --check.