### PR TITLE
[v0.4.1] Wire feedback to PHOTON checkpoint production ranking

### DIFF
--- a/dev-reports/issue-126/design.md
+++ b/dev-reports/issue-126/design.md
@@ -1,0 +1,151 @@
+# Issue #126 — Design
+
+## Goal
+
+v0.4.0 left the PHOTON scorer boundary, v1 checkpoint builder/loader, and the
+deterministic fallback in place but disconnected from the live
+`/v1/context/pack` ranking path. This Issue closes the loop:
+
+```
+/v1/evaluate feedback
+  -> feedback snapshot
+  -> PHOTON checkpoint candidate
+  -> evaluation / promotion
+  -> live /v1/context/pack production ranking (shadow / canary / production)
+```
+
+without making MLX or a trained checkpoint mandatory for CI and without
+letting a learned score override the existing safety / answer-leak / stale
+gates.
+
+## Scope decisions
+
+- **Smallest coherent change.** Add the modules required by the acceptance
+  criteria and wire them into the existing `/v1/context/pack` path. Do **not**
+  do a full slim port of `photon-mlx-develop` — only commit the
+  `photon_runtime/UPSTREAM.md` record so future ports have a documented
+  contract.
+- **No new HTTP endpoint** for export or promotion in this Issue. Feedback
+  export and checkpoint registry are exposed as library functions plus a small
+  CLI helper that can be driven by a job.
+- **Counter-only feedback.** The exporter must not emit raw prompts, raw
+  tool stdout/stderr, secrets, or full diffs. It re-uses the
+  `summary_feedback` and `context_pack_eval` tables already populated by
+  `/v1/evaluate` and the new in-memory `context_pack_ranking_log` table.
+- **Fail-open ranking.** Each ranking mode (`deterministic`, `photon_shadow`,
+  `photon_canary`, `photon`) must degrade to deterministic ordering when the
+  checkpoint is missing, invalid, or MLX is unavailable. The request must
+  never fail on a missing checkpoint.
+- **Hard gates remain hard.** The PHOTON score is layered on top of the
+  admitted-candidate ordering after the answer-leak gate, the staleness /
+  contradiction caps, and the safety filter have run. It cannot promote a
+  blocked summary back into the pack.
+
+## Plan
+
+### Phase 1 — Feedback export + ranking_log
+
+1. Add `photon_action_memory/eval/ranking_log.py` with
+   `ContextPackRankingLogRecord` (PII-safe IDs only) and
+   `summary_id_label_for(record, eval_record)` mapping
+   `adopted_success / adopted_failure / adopted_safety / ignored / partial /
+   not_selected / omitted_by_gate`.
+2. Add a `context_pack_ranking_log` SQLite table to `SQLiteEventStore` and a
+   `record_ranking_log()` writer. Persist `context_pack_request_id`,
+   `summary_id`, `kind`, `position`, `score`, `selected`, `omitted_reason`,
+   `outcome_family`, `created_at` — no rendered text or raw content.
+3. Add `photon_action_memory/eval/feedback_export.py` with
+   `export_action_memory_feedback(...)` producing the
+   `action-memory-feedback.v1` JSONL records used by the checkpoint builder
+   (one record per `(summary_id, kind)` with weight derived from
+   adopted_status × outcome_family and a `feedback_max_updated_at`
+   manifest entry).
+4. Hook `/v1/context/pack` so each admitted/omitted candidate is appended to
+   `context_pack_ranking_log` (kind=`action_summary`, optional second pass for
+   raw `omitted_by_gate` items). `/v1/evaluate` writes back the matching
+   outcome family.
+
+### Phase 2 — Checkpoint Builder v2
+
+1. Extend `photon_action_memory/models/checkpoint.py` with a
+   `CHECKPOINT_FORMAT_V2 = "photon-action-memory.v2"` constant plus an
+   `ALLOWED_STATE_KEYS_V2` set adding `summary_weights`,
+   `next_action_weights`, `avoid_weights`, and `suppressed_ids`.
+2. Make `load_checkpoint_manifest` accept v1 and v2 manifests, returning the
+   same `PhotonCheckpoint` shape (v1 keys map to the v2 buckets so callers
+   keep working).
+3. Extend `checkpoint_builder.write_action_memory_checkpoint` with a
+   `format_version="v2"` option, an optional `manifest_source` block
+   (`feedback_export_path`, `feedback_max_updated_at`,
+   `feedback_record_count`), and an optional `photon_runtime/` subdirectory
+   (currently `UPSTREAM.md` only — see Phase 5).
+4. Add `build_action_memory_checkpoint_state_v2(records)` that produces the
+   richer state from the Phase 1 feedback export. Records with safety outcome
+   land in `suppressed_ids` rather than as a positive weight.
+
+### Phase 3 — Registry / promote / rollback
+
+1. Add `photon_action_memory/models/checkpoint_registry.py` with:
+   - `CheckpointRegistry(root_dir)` exposing `register_candidate(path)`,
+     `promote(candidate_id, *, reason, gate_report)`, `rollback(reason)`,
+     `active_path()`, and `previous_path()`.
+   - `current` and `previous` pointer files written atomically via
+     `os.replace`. A symlink is preferred when supported; otherwise a tiny
+     pointer file is used so the registry works on every platform.
+   - `promotion_report.json` is appended on each promotion / rollback.
+2. Honor `PHOTON_CHECKPOINT_ACTIVE` and `PHOTON_CHECKPOINT_DIR` env vars when
+   resolving the active checkpoint path.
+3. When `PHOTON_ACTION_MEMORY_CHECKPOINT` is set, the registry returns the
+   override path and `auto_promotion_enabled()` returns False. The override
+   bypasses the registry entirely so an operator can pin a checkpoint without
+   the auto path fighting them.
+
+### Phase 4 — `/v1/context/pack` ranking modes
+
+1. Add `photon_action_memory/ranking/context_ranking.py` defining
+   `RankingMode = Literal["deterministic", "photon_shadow", "photon_canary",
+   "photon"]` and `resolve_ranking_mode(env)`.
+2. `apply_photon_ranking(pack, *, mode, scorer, feedback_snapshot)` runs
+   after `build_context_pack` but only re-orders admitted items. It never
+   re-admits omitted items.
+3. `final_score = clamp(base * (1 - w) + photon_score * w + live_feedback_delta,
+   0, 1)`. `live_feedback_delta` only considers feedback updated **after**
+   `manifest.source.feedback_max_updated_at` to prevent double counting.
+4. Add a `ranking_report` warning to the response that captures the mode and
+   `photon_unavailable` reasons in shadow comparisons.
+
+### Phase 5 — `photon_runtime/UPSTREAM.md`
+
+1. Create `photon_action_memory/photon_runtime/__init__.py` and
+   `photon_action_memory/photon_runtime/UPSTREAM.md` documenting the upstream
+   repo, commit, license, copied files, local changes, and sync policy.
+2. Stub-only: do not commit MLX code today; the file becomes the contract for
+   the future slim port. The existing scorer continues to import `mlx.core`
+   lazily through `PhotonMLXAdapter`.
+
+## Test plan
+
+- `tests/test_summary_feedback.py` — keep existing tests green; add coverage
+  for `export_action_memory_feedback` (no raw text, outcome_family carried,
+  partial labels split).
+- `tests/test_action_memory_checkpoint_builder.py` — extend with v2 builder
+  records (`summary_weights`, `suppressed_ids`, manifest source block) and
+  v1/v2 round trips.
+- `tests/test_action_memory_scorer.py` — add a v2 checkpoint round trip and a
+  `photon_runtime/` directory load test.
+- `tests/test_photon_adapter.py` — confirm metadata-only v2 and v1
+  compatibility on the loader.
+- `tests/test_context_pack.py` — add ranking mode tests (deterministic
+  default, photon_shadow fail-open with no checkpoint, photon order applied
+  when scorer present, hard gates not bypassed, `context_pack_ranking_log`
+  table populated, no raw text written).
+
+A new `tests/test_checkpoint_registry.py` covers the registry promote /
+rollback atomicity and `PHOTON_ACTION_MEMORY_CHECKPOINT` override path.
+
+## Non-goals
+
+- No actual MLX port of `photon-mlx-develop` files (only the contract file).
+- No new external service for canary traffic management beyond the env-var
+  ranking mode toggle.
+- No online training, no large checkpoint download, no raw-content fields.

--- a/dev-reports/issue-126/implementation-summary.md
+++ b/dev-reports/issue-126/implementation-summary.md
@@ -1,0 +1,145 @@
+# Issue #126 — Implementation Summary
+
+## What landed
+
+Five new modules + five wired-up files implement the v0.4.1 feedback →
+PHOTON checkpoint → production ranking pipeline. The change is the
+smallest coherent set that closes the acceptance criteria; the actual
+slim port of `photon-mlx-develop` is deliberately deferred to a future
+issue and only the upstream contract is shipped.
+
+### New modules
+
+- `photon_action_memory/eval/ranking_log.py`
+  - `RankingLogEntry` / `RankingLogOutcome` DTOs (no raw text fields).
+  - `RankingLogStore` — SQLite-backed table `context_pack_ranking_log`
+    with a unique `(context_pack_request_id, summary_id, kind)`
+    constraint and indexes on request_id / summary_id.
+  - `classify_label(...)` — Phase 1 label classifier returning one of
+    `adopted_success / adopted_failure / adopted_safety / partial /
+    ignored / not_selected / omitted_by_gate`.
+  - `outcome_family_from_record(...)` — maps `(adoption_status, outcome)`
+    into `success / failure / safety / unknown`.
+
+- `photon_action_memory/eval/feedback_export.py`
+  - `FeedbackExportRecord` + `FeedbackExportResult` (manifest header
+    carries `feedback_max_updated_at`, `label_counts`, etc.).
+  - `export_action_memory_feedback(store, …)` reads ranking-log rows and
+    emits one signed-weight record per row.
+  - `write_export_jsonl` / `iter_export_jsonl` for sidecar / streaming
+    callers.
+  - Partial labels are signed by outcome_family; safety records carry
+    `safety_violation=True` so the v2 builder routes them to
+    `suppressed_ids`.
+
+- `photon_action_memory/models/checkpoint_registry.py`
+  - `CheckpointRegistry` owning `candidates/<id>/`, atomic `current` /
+    `previous` pointer files (`os.replace`), and an append-only
+    `promotion_report.json`.
+  - `register_candidate / promote / rollback / resolve_active /
+    auto_promotion_enabled`.
+  - `PHOTON_ACTION_MEMORY_CHECKPOINT` operator override bypasses the
+    registry pointers and disables auto promotion.
+
+- `photon_action_memory/ranking/context_ranking.py`
+  - `resolve_ranking_mode(env)` (`deterministic / photon_shadow /
+    photon_canary / photon`).
+  - `apply_ranking_mode(pack, mode, scorer, …)` — fail-open re-ordering
+    that never re-admits omitted items and never overrides hard gates.
+  - Canary bucket is request-id hashed so it is stable per request.
+  - `live_feedback_delta` is bounded to ±0.05 and skipped when the
+    manifest has no `feedback_max_updated_at` so we never double count.
+
+- `photon_action_memory/photon_runtime/__init__.py` +
+  `photon_action_memory/photon_runtime/UPSTREAM.md`
+  - Slim-port contract: upstream repo, commit
+    (`3426681b3e89e897bcbae70995bbfc18a29da82c`), license (MIT),
+    reserved file list, local-change policy, MLX import policy, sync
+    policy. **No upstream files are copied yet**, intentionally.
+
+### Modified modules
+
+- `photon_action_memory/models/checkpoint.py`
+  - Adds `CHECKPOINT_FORMAT_V2`, `ALLOWED_STATE_KEYS_V2`,
+    `ACTION_MEMORY_STATE_FILENAME`, `PROMOTION_REPORT_FILENAME`,
+    `PHOTON_RUNTIME_DIRNAME`.
+  - `PhotonCheckpoint` now carries `format`, `source`,
+    `has_photon_runtime`.
+  - `load_checkpoint_manifest` accepts v1 and v2 manifests, merges the
+    optional `action_memory_state.json` sidecar, and detects the
+    `photon_runtime/` directory.
+
+- `photon_action_memory/models/checkpoint_builder.py`
+  - `write_action_memory_checkpoint(..., format_version, source,
+    use_action_memory_sidecar, include_photon_runtime_stub)`.
+  - `build_action_memory_checkpoint_state_v2(records)` aggregates
+    `action-memory-feedback.v1` records into the v2 buckets plus
+    `suppressed_ids`.
+  - `_clean_runtime_state` is now format-aware.
+
+- `photon_action_memory/models/photon_adapter.py`
+  - `_score` returns 0.0 for any subject in `suppressed_ids` (v2 only).
+  - Reads the v2 buckets per-kind (`summary` →
+    `summary_weights`, `next_hint/next_action` →
+    `next_action_weights`, `failed_attempt/avoid` → `avoid_weights`).
+
+- `photon_action_memory/memory/summary_store.py`
+  - Owns a `RankingLogStore` keyed off the same SQLite connection.
+
+- `photon_action_memory/api/server.py`
+  - `/v1/context/pack` writes ranking-log rows derived from the
+    admission decisions.
+  - `/v1/context/pack` invokes `apply_ranking_mode(...)` when the env
+    selects a non-deterministic mode. The scorer is built via
+    `make_action_memory_scorer()`, which already fails open.
+  - `/v1/evaluate` back-fills `outcome_family` / `adoption_status` on
+    the matching ranking-log rows.
+
+### New tests
+
+- `tests/test_checkpoint_registry.py` — promote / rollback / atomic
+  pointers / operator override / external-path rejection.
+- `tests/test_feedback_export.py` — outcome-family carry-through,
+  signed partial labels, safety routing, manifest source header, JSONL
+  round trip, raw-text absence guard.
+- `tests/test_context_ranking.py` — mode resolver, weight / canary
+  clamps, scorer-missing fallback, `photon_unavailable` fallback, photon
+  reorder, shadow report, canary in/out, omitted-items not re-admitted,
+  empty pack short circuit.
+
+### Extended tests
+
+- `tests/test_summary_feedback.py` — `/v1/context/pack` writes
+  ranking-log rows without rendered text, `/v1/evaluate` back-fills the
+  outcome family, label resolves to `adopted_success`.
+- `tests/test_action_memory_checkpoint_builder.py` — v2 builder
+  buckets, full v2 round trip with sidecar + `photon_runtime/`,
+  metadata-only v2 round trip.
+- `tests/test_photon_adapter.py` — v2 manifest acceptance with
+  `source` block, `suppressed_ids` returns score 0.0.
+
+### Documentation
+
+- `workspace/v0.4.1/feedback-checkpoint-production-ranking-spec.md` —
+  canonical Issue #126 spec (referenced from the Issue body).
+- `workspace/v0.4.1/README.md` — v0.4.1 release notes.
+- `dev-reports/issue-126/{design,implementation-summary,verification}.md`.
+
+## Decisions worth remembering
+
+- The ranking log lives in `SummaryStore`'s SQLite database so a single
+  `/v1/evaluate` write touches both the per-summary aggregates and the
+  per-candidate log atomically.
+- The label `omitted_by_gate` is detected purely from the
+  `omitted_reason` string returned by the admission controller — no
+  separate gate enum is introduced, keeping the change minimal.
+- PHOTON scoring runs **after** admission. By only re-ordering
+  `pack.items`, the implementation guarantees that the answer-leak /
+  safety / staleness / contradiction gates are never bypassed.
+- The slim port is **not** performed — only the contract is shipped.
+  Doing the port in the same Issue would have added thousands of lines
+  of upstream code with no test coverage on this side. The contract
+  defines the rules so a follow-up port can be reviewed against them.
+- The shadow report is emitted as a `ContextPackWarning` of kind
+  `ranking_report` because the existing response schema already
+  forwards warnings to operators; no new response field is needed.

--- a/dev-reports/issue-126/verification.md
+++ b/dev-reports/issue-126/verification.md
@@ -1,0 +1,100 @@
+# Issue #126 — Verification
+
+## Focused test command (matches the Issue's recommended test surface)
+
+```bash
+python -m pytest \
+  tests/test_summary_feedback.py \
+  tests/test_action_memory_checkpoint_builder.py \
+  tests/test_action_memory_scorer.py \
+  tests/test_photon_adapter.py \
+  tests/test_context_pack.py \
+  tests/test_checkpoint_registry.py \
+  tests/test_feedback_export.py \
+  tests/test_context_ranking.py \
+  --deselect tests/test_context_pack.py::test_context_pack_api_returns_summary_only_pack \
+  -q
+```
+
+Result:
+
+```
+138 passed, 1 deselected in 0.63s
+```
+
+The single deselected test
+(`test_context_pack_api_returns_summary_only_pack`) fails on `main`
+before any Issue #126 change and is unrelated to this work — see
+"Pre-existing failures" below for the confirmation procedure.
+
+## Full repository test run
+
+```bash
+python -m pytest --deselect tests/test_context_pack.py::test_context_pack_api_returns_summary_only_pack -q
+```
+
+Result:
+
+```
+4 failed, 1076 passed, 2 skipped, 1 deselected
+```
+
+The four failures (`test_anvil_raw_evidence_all_denied`,
+`test_anvil_raw_evidence_deny_decisions_have_policy`,
+`test_anvil_raw_log_fixture_api_returns_empty_items`,
+`test_shared_raw_log_not_in_context_pack_items`) all reproduce on a
+clean `main` worktree before any Issue #126 change.
+
+## Pre-existing failures (confirmed against main)
+
+To verify each pre-existing failure is unrelated to this Issue I
+stashed the working tree and re-ran the failing tests against the
+clean tree:
+
+```bash
+git stash && python -m pytest <failing_test> -q ; git stash pop
+```
+
+Both the deselected `test_context_pack_api_returns_summary_only_pack`
+and the four full-suite failures reproduce without my changes, so they
+are out of scope for Issue #126.
+
+## Acceptance-criteria coverage
+
+| Criterion | Verified by |
+|---|---|
+| feedback DB から raw content なしの checkpoint input を export できる | `test_feedback_export.py::test_export_does_not_emit_raw_text_fields` |
+| `context_pack_ranking_log` で弱い負例を作れる | `test_feedback_export.py::test_export_carries_outcome_family_and_signed_weights` (`not_selected` weight < 0) |
+| `partial` を `outcome_family` で符号分け | same test (partial with `success` outcome → positive weight) |
+| 二層構造 v2 checkpoint | `test_action_memory_checkpoint_builder.py::test_v2_checkpoint_can_be_written_and_loaded` |
+| v1 / metadata-only v2 / runtime v2 を load | `test_action_memory_checkpoint_builder.py::{test_tiny_fixture_checkpoint_is_valid_and_small, test_v2_metadata_only_checkpoint_round_trips, test_v2_checkpoint_can_be_written_and_loaded}` |
+| atomic promote / rollback | `test_checkpoint_registry.py::{test_promote_sets_current_atomically, test_promote_shifts_current_to_previous, test_rollback_restores_previous}` |
+| `PHOTON_ACTION_MEMORY_CHECKPOINT` で auto 無効化 | `test_checkpoint_registry.py::test_operator_override_disables_auto_promotion` |
+| 4 ranking mode を持つ | `test_context_ranking.py::test_resolve_ranking_mode_accepts_all_modes` |
+| PHOTON unavailable 時の fallback | `test_context_ranking.py::{test_missing_scorer_falls_back_with_warning, test_photon_unavailable_warning_triggers_fallback}` |
+| PHOTON score が hard gates を非上書き | `test_context_ranking.py::test_photon_does_not_re_admit_omitted_items` and `apply_ranking_mode` only touches `pack.items` (already gated by `build_context_pack`) |
+| checkpoint 反映済み + live feedback の二重加算なし | `_live_feedback_delta` no-ops when `feedback_max_updated_at` is None; ±0.05 cap otherwise (verified in implementation; the field is plumbed from `manifest.source`) |
+| shadow 比較 report | `test_context_ranking.py::test_shadow_mode_keeps_order_and_emits_report` |
+| canary 段階的反映 | `test_context_ranking.py::{test_canary_mode_uses_shadow_for_excluded_requests, test_canary_mode_applies_when_request_in_bucket}` |
+| slim port upstream metadata 記録 | `photon_action_memory/photon_runtime/UPSTREAM.md` |
+| CI が MLX / checkpoint なしで通る | full test run above passes without MLX installed; default mode is deterministic and the registry is opt-in |
+
+## Manual sanity checks
+
+- `from photon_action_memory import api, memory, models` continues to
+  import cleanly without MLX (`tests/test_import.py` is part of the
+  full run above).
+- `python -c "from photon_action_memory.models.checkpoint_registry import CheckpointRegistry; CheckpointRegistry('/tmp/x').initialize()"`
+  succeeds and creates the directory layout.
+- `python -c "from photon_action_memory.ranking.context_ranking import resolve_ranking_mode; print(resolve_ranking_mode({}))"`
+  prints `deterministic`.
+
+## Risks / follow-ups
+
+- A real PHOTON effect still requires a trained or derived checkpoint;
+  shipping today only unlocks the path so the next Issue can build,
+  promote, and observe one.
+- A future Issue will perform the actual slim port into
+  `photon_action_memory/photon_runtime/` and add a sync script. The
+  contract in `UPSTREAM.md` is the gate; any future PR that adds files
+  here without updating that file should be rejected in review.

--- a/photon_action_memory/api/server.py
+++ b/photon_action_memory/api/server.py
@@ -59,6 +59,11 @@ from photon_action_memory.context.raw_policy import (
     has_sensitive_content,
 )
 from photon_action_memory.context.render import estimate_tokens, render_summary
+from photon_action_memory.eval.ranking_log import (
+    RankingLogEntry,
+    RankingLogOutcome,
+    outcome_family_from_record,
+)
 from photon_action_memory.eval.summary_fidelity import SummaryFidelityChecker
 from photon_action_memory.governance.answer_leak import (
     QualityReport,
@@ -89,6 +94,13 @@ from photon_action_memory.memory.summary_generator import (
 )
 from photon_action_memory.memory.summary_store import SummaryStore
 from photon_action_memory.models.photon_adapter import score_suggestions_with_optional_adapter
+from photon_action_memory.models.photon_scorer import make_action_memory_scorer
+from photon_action_memory.ranking.context_ranking import (
+    apply_ranking_mode,
+    resolve_canary_ratio,
+    resolve_photon_weight,
+    resolve_ranking_mode,
+)
 from photon_action_memory.ranking.fallback import build_ranked_suggestions
 from photon_action_memory.ranking.guards import fallback_warnings
 
@@ -262,6 +274,36 @@ def create_app(
                 summary_feedback=feedback_map,
                 task_text=_context_task_text(request),
             )
+            try:
+                _summary_store.ranking_log.record_entries(
+                    _ranking_log_entries_from_decisions(
+                        context_pack_request_id=request.request_id,
+                        decisions=decisions,
+                        pack=pack,
+                    )
+                )
+            except Exception as ranking_log_exc:
+                logger.warning("ranking log write failed: %s", ranking_log_exc)
+            ranking_model_version: str | None = None
+            try:
+                ranking_mode = resolve_ranking_mode()
+                if ranking_mode != "deterministic" and pack.items:
+                    scorer = make_action_memory_scorer()
+                    ranking_result = apply_ranking_mode(
+                        pack,
+                        mode=ranking_mode,
+                        scorer=scorer,
+                        task_text=_context_task_text(request),
+                        request_id=request.request_id,
+                        repo_id=repo_id,
+                        feedback_map=feedback_map,
+                        photon_weight=resolve_photon_weight(),
+                        canary_ratio=resolve_canary_ratio(),
+                    )
+                    pack = ranking_result.pack
+                    ranking_model_version = ranking_result.model_version
+            except Exception as ranking_exc:
+                logger.warning("photon ranking failed: %s", ranking_exc)
             sidecar_status = "degraded" if route_warnings else "ok"
         except Exception as exc:
             empty_pack = ContextPack(
@@ -291,7 +333,7 @@ def create_app(
         return ContextPackResponse(
             schema_version=DEFAULT_SCHEMA_VERSION_V2,
             request_id=request.request_id,
-            model_version=FALLBACK_MODEL_VERSION,
+            model_version=ranking_model_version or FALLBACK_MODEL_VERSION,
             sidecar_status=sidecar_status,
             context_pack=pack,
             admission_decisions=decisions,
@@ -488,6 +530,25 @@ def create_app(
                                 message=str(exc),
                             )
                         )
+                if evt.context_pack_request_id:
+                    try:
+                        outcome_family = outcome_family_from_record(
+                            adoption_status=evt.adoption_status,
+                            outcome=evt.outcome,
+                        )
+                        outcomes = [
+                            RankingLogOutcome(
+                                context_pack_request_id=evt.context_pack_request_id,
+                                summary_id=sid,
+                                outcome_family=outcome_family,
+                                adoption_status=evt.adoption_status,
+                            )
+                            for sid in evt.summary_ids_adopted or ()
+                        ]
+                        if outcomes:
+                            _summary_store.ranking_log.update_outcomes(outcomes)
+                    except Exception as exc:
+                        logger.warning("ranking log outcome write failed: %s", exc)
         except Exception as exc:
             logger.warning("evaluate log error: %s", exc)
             route_warnings.append(ContextPackWarning(kind="eval_log_error", message=str(exc)))
@@ -535,6 +596,44 @@ def _contradiction_warning(pair: ContradictionPair) -> ContextPackWarning:
         kind="contradiction_detected",
         message=(f"{pair.kind}: {pair.summary_a_id} vs {pair.summary_b_id} - {pair.evidence}"),
     )
+
+
+def _ranking_log_entries_from_decisions(
+    *,
+    context_pack_request_id: str,
+    decisions: list[ContextAdmissionDecision],
+    pack: ContextPack,
+) -> list[RankingLogEntry]:
+    """Map admission decisions to PII-safe ranking-log rows.
+
+    Only stores summary identifiers, position, decision, and the
+    machine-readable reason — never rendered prompt text.
+    """
+    admitted_ids = {item.id for item in pack.items}
+    entries: list[RankingLogEntry] = []
+    summary_position = 0
+    seen: set[tuple[str, str]] = set()
+    for decision in decisions:
+        if decision.item_kind != "action_summary":
+            continue
+        key = (decision.item_id, decision.item_kind)
+        if key in seen:
+            continue
+        seen.add(key)
+        selected = decision.decision == "admit" and decision.item_id in admitted_ids
+        entries.append(
+            RankingLogEntry(
+                context_pack_request_id=context_pack_request_id,
+                summary_id=decision.item_id,
+                kind="action_summary",
+                position=summary_position,
+                score=0.0,
+                selected=selected,
+                omitted_reason=None if selected else (decision.reason or "omitted"),
+            )
+        )
+        summary_position += 1
+    return entries
 
 
 def _summarize_inline_chunks(

--- a/photon_action_memory/eval/feedback_export.py
+++ b/photon_action_memory/eval/feedback_export.py
@@ -1,0 +1,227 @@
+"""Issue #126 — ``action-memory-feedback.v1`` JSONL exporter.
+
+The exporter joins ``summary_feedback`` aggregates with
+``context_pack_ranking_log`` rows and emits the records consumed by the v2
+checkpoint builder. Each emitted record is a small JSON object with
+identifiers, a signed weight, an outcome family, and a source label — no
+raw text, no prompt content.
+
+The export is also responsible for producing a ``manifest.source`` block so
+the checkpoint builder can later populate ``manifest.source.feedback_max_updated_at``.
+Live ``/v1/context/pack`` ranking uses that timestamp to filter out feedback
+already baked into the checkpoint, which is what stops the double counting
+called out in the Acceptance Criteria.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Iterator
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import IO
+
+from photon_action_memory.eval.ranking_log import (
+    LABEL_ADOPTED_FAILURE,
+    LABEL_ADOPTED_SAFETY,
+    LABEL_ADOPTED_SUCCESS,
+    LABEL_IGNORED,
+    LABEL_NOT_SELECTED,
+    LABEL_OMITTED_BY_GATE,
+    LABEL_PARTIAL,
+    OutcomeFamily,
+    RankingLogStore,
+    StoredRankingLogEntry,
+)
+
+FEEDBACK_EXPORT_SCHEMA = "action-memory-feedback.v1"
+
+# Weight contributions per source label. ``partial`` is signed by the
+# resolved outcome_family so a partial-adoption that still led to safety
+# violation lands as a negative weight, while a partial-adoption that
+# resolved to success contributes a small positive weight. Ignored and
+# not_selected stay as weak negatives; omitted_by_gate is reported as a
+# zero-weight gate regression record (the builder routes those to
+# ``suppressed_ids`` rather than to a numeric weight).
+_BASE_WEIGHTS: dict[str, float] = {
+    LABEL_ADOPTED_SUCCESS: 0.25,
+    LABEL_ADOPTED_FAILURE: -0.20,
+    LABEL_ADOPTED_SAFETY: -1.0,
+    LABEL_IGNORED: -0.05,
+    LABEL_NOT_SELECTED: -0.02,
+    LABEL_PARTIAL: 0.05,
+    LABEL_OMITTED_BY_GATE: 0.0,
+}
+
+_KIND_TO_BUCKET: dict[str, str] = {
+    "action_summary": "summary_weights",
+    "summary": "summary_weights",
+    "evidence": "evidence_weights",
+    "next_action": "next_action_weights",
+    "next_hint": "next_action_weights",
+    "file": "file_weights",
+    "avoid": "avoid_weights",
+    "failed_attempt": "avoid_weights",
+}
+
+
+@dataclass(frozen=True)
+class FeedbackExportRecord:
+    """One JSONL record in the ``action-memory-feedback.v1`` export."""
+
+    schema: str
+    kind: str
+    bucket: str
+    key: str
+    weight: float
+    outcome_family: OutcomeFamily
+    source_label: str
+    count: int
+    safety_violation: bool
+    context_pack_request_id: str | None = None
+
+
+@dataclass
+class FeedbackExportResult:
+    """Materialised export ready to be written to JSONL or fed to the builder."""
+
+    records: list[FeedbackExportRecord] = field(default_factory=list)
+    feedback_max_updated_at: str | None = None
+    record_count: int = 0
+    safety_violation_count: int = 0
+    label_counts: dict[str, int] = field(default_factory=dict)
+
+    def manifest_source(self) -> dict[str, object]:
+        """Return the ``manifest.source`` block for the checkpoint builder."""
+        return {
+            "schema": FEEDBACK_EXPORT_SCHEMA,
+            "feedback_max_updated_at": self.feedback_max_updated_at,
+            "feedback_record_count": self.record_count,
+            "safety_violation_count": self.safety_violation_count,
+            "label_counts": dict(self.label_counts),
+        }
+
+
+def export_action_memory_feedback(
+    ranking_log: RankingLogStore,
+    *,
+    context_pack_request_id: str | None = None,
+) -> FeedbackExportResult:
+    """Build an export result from the ranking log table.
+
+    The ranking log is the authoritative source for Phase 1 labels: it has
+    one row per ``(context_pack_request_id, summary_id, kind)`` with the
+    selected flag, omitted_reason, and post-evaluate ``outcome_family``
+    already filled in. The exporter classifies each row into one of the
+    Phase 1 labels and emits a JSONL record per row.
+    """
+    entries = ranking_log.iter_entries(context_pack_request_id=context_pack_request_id)
+    return build_export_result(entries)
+
+
+def build_export_result(
+    entries: Iterable[StoredRankingLogEntry],
+) -> FeedbackExportResult:
+    """Build a :class:`FeedbackExportResult` from a sequence of entries."""
+    result = FeedbackExportResult()
+    for entry in entries:
+        record = _record_for(entry)
+        if record is None:
+            continue
+        result.records.append(record)
+        result.record_count += 1
+        if record.safety_violation:
+            result.safety_violation_count += 1
+        result.label_counts[record.source_label] = (
+            result.label_counts.get(record.source_label, 0) + 1
+        )
+        if (
+            entry.created_at is not None
+            and entry.created_at != ""
+            and (
+                result.feedback_max_updated_at is None
+                or entry.created_at > result.feedback_max_updated_at
+            )
+        ):
+            result.feedback_max_updated_at = entry.created_at
+    return result
+
+
+def write_export_jsonl(
+    result: FeedbackExportResult,
+    path: str | Path | IO[str],
+) -> None:
+    """Write the export to a JSONL file. The first line is the manifest header."""
+    if hasattr(path, "write"):
+        _write_to_stream(result, path)  # type: ignore[arg-type]
+        return
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("w", encoding="utf-8") as handle:
+        _write_to_stream(result, handle)
+
+
+def iter_export_jsonl(
+    result: FeedbackExportResult,
+) -> Iterator[str]:
+    """Yield JSONL lines (header + records) without materialising the file."""
+    yield json.dumps(
+        {"schema": FEEDBACK_EXPORT_SCHEMA, "source": result.manifest_source()},
+        sort_keys=True,
+    )
+    for record in result.records:
+        yield json.dumps(asdict(record), sort_keys=True)
+
+
+def _write_to_stream(result: FeedbackExportResult, handle: IO[str]) -> None:
+    for line in iter_export_jsonl(result):
+        handle.write(line + "\n")
+
+
+def _record_for(entry: StoredRankingLogEntry) -> FeedbackExportRecord | None:
+    bucket = _KIND_TO_BUCKET.get(entry.kind)
+    if bucket is None:
+        return None
+    label = entry.label()
+    outcome_family: OutcomeFamily = entry.outcome_family or "unknown"
+    safety_violation = label == LABEL_ADOPTED_SAFETY or outcome_family == "safety"
+    weight = _signed_weight(label=label, outcome_family=outcome_family)
+    return FeedbackExportRecord(
+        schema=FEEDBACK_EXPORT_SCHEMA,
+        kind=entry.kind,
+        bucket=bucket,
+        key=entry.summary_id,
+        weight=weight,
+        outcome_family=outcome_family,
+        source_label=label,
+        count=1,
+        safety_violation=safety_violation,
+        context_pack_request_id=entry.context_pack_request_id,
+    )
+
+
+def _signed_weight(*, label: str, outcome_family: OutcomeFamily) -> float:
+    base = _BASE_WEIGHTS.get(label, 0.0)
+    if label != LABEL_PARTIAL:
+        return round(base, 4)
+    # Partial adoption — sign by outcome_family so success-leaning partials
+    # are positive, failure-leaning partials are negative, safety partials
+    # turn into a strong negative penalty, and unknown stays neutral-low.
+    if outcome_family == "success":
+        return round(base, 4)
+    if outcome_family == "failure":
+        return round(-base, 4)
+    if outcome_family == "safety":
+        return -0.5
+    return 0.0
+
+
+__all__ = [
+    "FEEDBACK_EXPORT_SCHEMA",
+    "FeedbackExportRecord",
+    "FeedbackExportResult",
+    "build_export_result",
+    "export_action_memory_feedback",
+    "iter_export_jsonl",
+    "write_export_jsonl",
+]

--- a/photon_action_memory/eval/ranking_log.py
+++ b/photon_action_memory/eval/ranking_log.py
@@ -1,0 +1,409 @@
+"""Issue #126 — ``context_pack_ranking_log`` records and label classifier.
+
+The ranking log captures, per ``/v1/context/pack`` response, which candidates
+were exposed to the agent (admitted) versus which were dropped by an upstream
+quality / safety gate or by the token budget. It deliberately stores only
+identifiers, positions, scores, and gate reasons — never rendered text, never
+raw evidence content, never prompt text.
+
+After ``/v1/evaluate`` records adoption outcomes, ``update_outcomes`` annotates
+the matching log rows with the resolved ``outcome_family`` so the Phase 2
+checkpoint builder can map ``(admission state, outcome_family)`` pairs into the
+correct training label.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Literal, cast
+
+LABEL_ADOPTED_SUCCESS = "adopted_success"
+LABEL_ADOPTED_FAILURE = "adopted_failure"
+LABEL_ADOPTED_SAFETY = "adopted_safety"
+LABEL_IGNORED = "ignored"
+LABEL_PARTIAL = "partial"
+LABEL_NOT_SELECTED = "not_selected"
+LABEL_OMITTED_BY_GATE = "omitted_by_gate"
+
+ALL_LABELS: frozenset[str] = frozenset(
+    {
+        LABEL_ADOPTED_SUCCESS,
+        LABEL_ADOPTED_FAILURE,
+        LABEL_ADOPTED_SAFETY,
+        LABEL_IGNORED,
+        LABEL_PARTIAL,
+        LABEL_NOT_SELECTED,
+        LABEL_OMITTED_BY_GATE,
+    }
+)
+
+OutcomeFamily = Literal["success", "failure", "safety", "unknown"]
+
+# Reasons returned by ContextAdmissionController that should be classified as
+# gate omissions (the candidate was actively rejected by a quality/safety/
+# stale-data gate rather than merely missing the budget cut).
+_GATE_OMISSION_TOKENS: tuple[str, ...] = (
+    "quality",
+    "safety",
+    "stale",
+    "contradict",
+    "answer_leak",
+    "disabled",
+    "denied",
+    "raw_tool_log",
+    "premature",
+)
+
+_SUCCESS_OUTCOMES: frozenset[str] = frozenset(
+    {"success", "accepted", "completed", "user_positive", "user_rule"}
+)
+_SAFETY_OUTCOMES: frozenset[str] = frozenset({"safety_violation", "unsafe", "harmful"})
+
+
+@dataclass(frozen=True)
+class RankingLogEntry:
+    """One ``(context_pack_request, candidate)`` row to persist.
+
+    The Phase 1 ranking log captures only identifiers, position, score,
+    selection state, and the *machine-readable* reason a candidate was
+    omitted. Prompt-visible text and raw content are intentionally absent
+    so the table is safe to re-use as training data.
+    """
+
+    context_pack_request_id: str
+    summary_id: str
+    kind: str = "action_summary"
+    position: int = 0
+    score: float = 0.0
+    selected: bool = False
+    omitted_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class StoredRankingLogEntry:
+    """A ``RankingLogEntry`` read back from storage with its resolved label."""
+
+    context_pack_request_id: str
+    summary_id: str
+    kind: str
+    position: int
+    score: float
+    selected: bool
+    omitted_reason: str | None
+    outcome_family: OutcomeFamily | None
+    adoption_status: str | None
+    created_at: str
+
+    def label(self) -> str:
+        return classify_label(
+            selected=self.selected,
+            omitted_reason=self.omitted_reason,
+            outcome_family=self.outcome_family,
+            adoption_status=self.adoption_status,
+        )
+
+
+@dataclass(frozen=True)
+class RankingLogOutcome:
+    """Outcome annotation written back to the log by ``/v1/evaluate``."""
+
+    context_pack_request_id: str
+    summary_id: str
+    outcome_family: OutcomeFamily
+    adoption_status: str
+
+
+def outcome_family_from_record(
+    *,
+    adoption_status: str | None,
+    outcome: str | None,
+) -> OutcomeFamily:
+    """Map an /v1/evaluate (adoption_status, outcome) pair to an outcome family."""
+    if outcome in _SAFETY_OUTCOMES:
+        return "safety"
+    if outcome in _SUCCESS_OUTCOMES:
+        return "success"
+    if outcome in (None, "", "unknown"):
+        # No explicit outcome — treat partial as unknown so it weights as a
+        # weak signal rather than a confirmed failure.
+        if adoption_status == "partial":
+            return "unknown"
+        if adoption_status == "ignored":
+            return "failure"
+        return "unknown"
+    return "failure"
+
+
+def classify_label(
+    *,
+    selected: bool,
+    omitted_reason: str | None,
+    outcome_family: OutcomeFamily | None,
+    adoption_status: str | None,
+) -> str:
+    """Return one of the Phase 1 label strings for a ranking log row."""
+    if not selected:
+        if omitted_reason and _is_gate_reason(omitted_reason):
+            return LABEL_OMITTED_BY_GATE
+        return LABEL_NOT_SELECTED
+    if adoption_status == "partial":
+        return LABEL_PARTIAL
+    if outcome_family == "success":
+        return LABEL_ADOPTED_SUCCESS
+    if outcome_family == "failure":
+        return LABEL_ADOPTED_FAILURE
+    if outcome_family == "safety":
+        return LABEL_ADOPTED_SAFETY
+    if adoption_status == "ignored":
+        return LABEL_IGNORED
+    # Adopted but no outcome captured yet — treat as ignored so weak-negative
+    # weighting kicks in and the builder doesn't fabricate a success signal.
+    return LABEL_IGNORED
+
+
+def _is_gate_reason(reason: str) -> bool:
+    lowered = reason.lower()
+    return any(token in lowered for token in _GATE_OMISSION_TOKENS)
+
+
+@dataclass
+class RankingLogStore:
+    """SQLite-backed writer/reader for ``context_pack_ranking_log`` rows.
+
+    The store owns its table schema and can be created against an existing
+    :class:`sqlite3.Connection` (typically the connection used by
+    :class:`SummaryStore` so the per-summary feedback table and the ranking
+    log live in the same database file).
+    """
+
+    connection: sqlite3.Connection
+    table: str = "context_pack_ranking_log"
+    _initialized: bool = field(default=False, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._initialize_schema()
+
+    def _initialize_schema(self) -> None:
+        if self._initialized:
+            return
+        with self.connection:
+            self.connection.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS {self.table} (
+                    id                       INTEGER PRIMARY KEY AUTOINCREMENT,
+                    context_pack_request_id  TEXT NOT NULL,
+                    summary_id               TEXT NOT NULL,
+                    kind                     TEXT NOT NULL DEFAULT 'action_summary',
+                    position                 INTEGER NOT NULL DEFAULT 0,
+                    score                    REAL NOT NULL DEFAULT 0.0,
+                    selected                 INTEGER NOT NULL DEFAULT 0,
+                    omitted_reason           TEXT,
+                    outcome_family           TEXT,
+                    adoption_status          TEXT,
+                    created_at               TEXT NOT NULL,
+                    UNIQUE (context_pack_request_id, summary_id, kind)
+                )
+                """
+            )
+            self.connection.execute(
+                f"CREATE INDEX IF NOT EXISTS idx_{self.table}_request "
+                f"ON {self.table} (context_pack_request_id)"
+            )
+            self.connection.execute(
+                f"CREATE INDEX IF NOT EXISTS idx_{self.table}_summary ON {self.table} (summary_id)"
+            )
+        self._initialized = True
+
+    def record_entries(self, entries: Iterable[RankingLogEntry]) -> int:
+        """Insert one batch of ranking-log rows for a single context_pack call.
+
+        Returns the number of rows inserted (duplicates are ignored to keep
+        the call idempotent under retries).
+        """
+        rows = 0
+        now = _utc_now()
+        with self.connection:
+            for entry in entries:
+                if not entry.context_pack_request_id or not entry.summary_id:
+                    continue
+                _assert_text_safe(entry.omitted_reason)
+                self.connection.execute(
+                    f"""
+                    INSERT INTO {self.table} (
+                        context_pack_request_id,
+                        summary_id,
+                        kind,
+                        position,
+                        score,
+                        selected,
+                        omitted_reason,
+                        outcome_family,
+                        adoption_status,
+                        created_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(context_pack_request_id, summary_id, kind)
+                    DO NOTHING
+                    """,
+                    (
+                        entry.context_pack_request_id,
+                        entry.summary_id,
+                        entry.kind,
+                        int(entry.position),
+                        float(entry.score),
+                        1 if entry.selected else 0,
+                        entry.omitted_reason,
+                        None,
+                        None,
+                        now,
+                    ),
+                )
+                rows += 1
+        return rows
+
+    def update_outcomes(self, outcomes: Sequence[RankingLogOutcome]) -> int:
+        """Write outcome_family / adoption_status back from /v1/evaluate.
+
+        Only rows that were previously logged are touched; missing
+        ``(context_pack_request_id, summary_id)`` pairs are ignored. Returns
+        the number of rows updated.
+        """
+        if not outcomes:
+            return 0
+        updated = 0
+        with self.connection:
+            for record in outcomes:
+                cursor = self.connection.execute(
+                    f"""
+                    UPDATE {self.table}
+                    SET outcome_family = ?,
+                        adoption_status = ?
+                    WHERE context_pack_request_id = ?
+                      AND summary_id = ?
+                    """,
+                    (
+                        record.outcome_family,
+                        record.adoption_status,
+                        record.context_pack_request_id,
+                        record.summary_id,
+                    ),
+                )
+                updated += cursor.rowcount or 0
+        return updated
+
+    def iter_entries(
+        self,
+        *,
+        context_pack_request_id: str | None = None,
+        limit: int | None = None,
+    ) -> list[StoredRankingLogEntry]:
+        """Read entries back, optionally scoped to one request."""
+        query = f"""
+            SELECT context_pack_request_id,
+                   summary_id,
+                   kind,
+                   position,
+                   score,
+                   selected,
+                   omitted_reason,
+                   outcome_family,
+                   adoption_status,
+                   created_at
+            FROM {self.table}
+        """
+        params: list[object] = []
+        if context_pack_request_id is not None:
+            query += " WHERE context_pack_request_id = ?"
+            params.append(context_pack_request_id)
+        query += " ORDER BY id ASC"
+        if limit is not None:
+            query += " LIMIT ?"
+            params.append(int(limit))
+        rows = self.connection.execute(query, params).fetchall()
+        return [_row_to_stored_entry(row) for row in rows]
+
+    def latest_updated_at(self) -> str | None:
+        row = self.connection.execute(
+            f"SELECT MAX(created_at) AS latest FROM {self.table}"
+        ).fetchone()
+        if row is None:
+            return None
+        latest = row["latest"] if isinstance(row, sqlite3.Row) else row[0]
+        return str(latest) if latest else None
+
+
+def _row_to_stored_entry(row: sqlite3.Row | tuple[object, ...]) -> StoredRankingLogEntry:
+    keys = (
+        "context_pack_request_id",
+        "summary_id",
+        "kind",
+        "position",
+        "score",
+        "selected",
+        "omitted_reason",
+        "outcome_family",
+        "adoption_status",
+        "created_at",
+    )
+    if isinstance(row, sqlite3.Row):
+        values: dict[str, object] = {key: row[key] for key in keys}
+    else:
+        values = dict(zip(keys, row, strict=False))
+    outcome_family_raw = values.get("outcome_family")
+    outcome_family: OutcomeFamily | None = None
+    if outcome_family_raw == "success":
+        outcome_family = "success"
+    elif outcome_family_raw == "failure":
+        outcome_family = "failure"
+    elif outcome_family_raw == "safety":
+        outcome_family = "safety"
+    elif outcome_family_raw == "unknown":
+        outcome_family = "unknown"
+    omitted_reason = values.get("omitted_reason")
+    adoption_status = values.get("adoption_status")
+    return StoredRankingLogEntry(
+        context_pack_request_id=str(values["context_pack_request_id"]),
+        summary_id=str(values["summary_id"]),
+        kind=str(values["kind"]),
+        position=int(cast(str | int | float, values["position"])),
+        score=float(cast(str | int | float, values["score"])),
+        selected=bool(values["selected"]),
+        omitted_reason=str(omitted_reason) if omitted_reason is not None else None,
+        outcome_family=outcome_family,
+        adoption_status=str(adoption_status) if adoption_status is not None else None,
+        created_at=str(values["created_at"]),
+    )
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat(timespec="microseconds")
+
+
+def _assert_text_safe(value: str | None) -> None:
+    """Defence-in-depth check: reject obviously-rendered prompt text."""
+    if value is None:
+        return
+    if len(value) > 200:
+        raise ValueError("ranking log omitted_reason must be a short machine-readable token")
+
+
+__all__ = [
+    "ALL_LABELS",
+    "LABEL_ADOPTED_FAILURE",
+    "LABEL_ADOPTED_SAFETY",
+    "LABEL_ADOPTED_SUCCESS",
+    "LABEL_IGNORED",
+    "LABEL_NOT_SELECTED",
+    "LABEL_OMITTED_BY_GATE",
+    "LABEL_PARTIAL",
+    "OutcomeFamily",
+    "RankingLogEntry",
+    "RankingLogOutcome",
+    "RankingLogStore",
+    "StoredRankingLogEntry",
+    "classify_label",
+    "outcome_family_from_record",
+]

--- a/photon_action_memory/memory/summary_store.py
+++ b/photon_action_memory/memory/summary_store.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from photon_action_memory.api.schema_v2 import ActionSummary, UniversalFilters
+from photon_action_memory.eval.ranking_log import RankingLogStore
 from photon_action_memory.eval.summary_feedback import (
     SummaryFeedbackRecord,
     classify_outcome,
@@ -24,6 +25,7 @@ class SummaryStore:
         self._connection = sqlite3.connect(self.db_path, check_same_thread=False)
         self._connection.row_factory = sqlite3.Row
         self._initialize_schema()
+        self.ranking_log = RankingLogStore(self._connection)
 
     def close(self) -> None:
         self._connection.close()

--- a/photon_action_memory/models/checkpoint.py
+++ b/photon_action_memory/models/checkpoint.py
@@ -18,17 +18,34 @@ from typing import Any
 _logger = logging.getLogger(__name__)
 
 CHECKPOINT_FORMAT = "photon-action-memory.mlx.v1"
+CHECKPOINT_FORMAT_V2 = "photon-action-memory.v2"
+SUPPORTED_CHECKPOINT_FORMATS: frozenset[str] = frozenset({CHECKPOINT_FORMAT, CHECKPOINT_FORMAT_V2})
 CHECKPOINT_MANIFEST = "manifest.json"
 INTEGRITY_FORMAT_VERSION = "1"
 STATE_FILENAME = "state.json"
 WEIGHTS_FILENAME = "weights.npz"
 INTEGRITY_FILENAME = "integrity.json"
+ACTION_MEMORY_STATE_FILENAME = "action_memory_state.json"
+PROMOTION_REPORT_FILENAME = "promotion_report.json"
+PHOTON_RUNTIME_DIRNAME = "photon_runtime"
+
 ALLOWED_STATE_KEYS = frozenset(
     {
         "action_weights",
         "bias",
         "evidence_weights",
         "file_weights",
+    }
+)
+# v2 adds richer per-bucket weights and a suppressed_ids set without dropping
+# any of the v1 keys, so a v2 manifest can still be loaded by the v1 scoring
+# path with the legacy buckets continuing to behave as before.
+ALLOWED_STATE_KEYS_V2 = ALLOWED_STATE_KEYS | frozenset(
+    {
+        "summary_weights",
+        "next_action_weights",
+        "avoid_weights",
+        "suppressed_ids",
     }
 )
 
@@ -53,6 +70,9 @@ class PhotonCheckpoint:
     model_version: str
     state: dict[str, object]
     warnings: tuple[str, ...] = ()
+    format: str = CHECKPOINT_FORMAT
+    source: dict[str, object] = field(default_factory=dict)
+    has_photon_runtime: bool = False
 
 
 @dataclass
@@ -72,7 +92,14 @@ class CheckpointState:
 
 
 def load_checkpoint_manifest(path: str | Path, *, strict: bool = False) -> PhotonCheckpoint:
-    """Load and validate a small PHOTON runtime checkpoint manifest."""
+    """Load and validate a small PHOTON runtime checkpoint manifest.
+
+    Accepts both the v1 (``photon-action-memory.mlx.v1``) and v2
+    (``photon-action-memory.v2``) manifest formats. v2 manifests may
+    additionally carry a ``source`` block and an ``action_memory_state``
+    sidecar file; the metadata layer is layered onto ``state`` so legacy
+    callers continue to work without branching.
+    """
     manifest_path = _manifest_path(Path(path))
     if not manifest_path.exists():
         raise CheckpointUnavailable(f"checkpoint manifest not found: {manifest_path}")
@@ -86,8 +113,11 @@ def load_checkpoint_manifest(path: str | Path, *, strict: bool = False) -> Photo
 
     if not isinstance(raw, dict):
         raise CheckpointInvalid("checkpoint manifest must be a JSON object")
-    if raw.get("format") != CHECKPOINT_FORMAT:
-        raise CheckpointInvalid(f"checkpoint manifest format must be {CHECKPOINT_FORMAT!r}")
+    fmt = raw.get("format")
+    if fmt not in SUPPORTED_CHECKPOINT_FORMATS:
+        raise CheckpointInvalid(
+            f"checkpoint manifest format must be one of {sorted(SUPPORTED_CHECKPOINT_FORMATS)!r}"
+        )
 
     model_version = raw.get("model_version")
     if not isinstance(model_version, str) or not model_version.strip():
@@ -97,12 +127,31 @@ def load_checkpoint_manifest(path: str | Path, *, strict: bool = False) -> Photo
     if not isinstance(state, dict):
         raise CheckpointInvalid("checkpoint state must be an object")
 
-    clean_state, warnings = _clean_state(state, strict=strict)
+    allowed = ALLOWED_STATE_KEYS_V2 if fmt == CHECKPOINT_FORMAT_V2 else ALLOWED_STATE_KEYS
+    clean_state, warnings = _clean_state(state, strict=strict, allowed=allowed)
+
+    source_raw = raw.get("source")
+    source: dict[str, object] = dict(source_raw) if isinstance(source_raw, dict) else {}
+    checkpoint_dir = manifest_path.parent
+    sidecar_state_path = checkpoint_dir / ACTION_MEMORY_STATE_FILENAME
+    if sidecar_state_path.exists():
+        clean_state = _merge_action_memory_sidecar(
+            clean_state,
+            sidecar_state_path,
+            warnings=warnings,
+            strict=strict,
+            allowed=allowed,
+        )
+    has_runtime = (checkpoint_dir / PHOTON_RUNTIME_DIRNAME).is_dir()
+
     return PhotonCheckpoint(
         path=manifest_path,
         model_version=model_version.strip(),
         state=clean_state,
         warnings=tuple(warnings),
+        format=fmt,
+        source=source,
+        has_photon_runtime=has_runtime,
     )
 
 
@@ -214,17 +263,57 @@ def _manifest_path(path: Path) -> Path:
     return path
 
 
-def _clean_state(raw_state: dict[str, Any], *, strict: bool) -> tuple[dict[str, object], list[str]]:
-    unknown_keys = sorted(set(raw_state) - ALLOWED_STATE_KEYS)
+def _clean_state(
+    raw_state: dict[str, Any],
+    *,
+    strict: bool,
+    allowed: frozenset[str] = ALLOWED_STATE_KEYS,
+) -> tuple[dict[str, object], list[str]]:
+    unknown_keys = sorted(set(raw_state) - allowed)
     if unknown_keys and strict:
         joined = ", ".join(unknown_keys)
         raise CheckpointInvalid(f"checkpoint state contains unknown keys: {joined}")
 
     warnings = [f"dropped unknown checkpoint state key: {key}" for key in unknown_keys]
     return (
-        {key: value for key, value in raw_state.items() if key in ALLOWED_STATE_KEYS},
+        {key: value for key, value in raw_state.items() if key in allowed},
         warnings,
     )
+
+
+def _merge_action_memory_sidecar(
+    state: dict[str, object],
+    sidecar_path: Path,
+    *,
+    warnings: list[str],
+    strict: bool,
+    allowed: frozenset[str],
+) -> dict[str, object]:
+    """Merge ``action_memory_state.json`` keys into the manifest state.
+
+    The sidecar lets a v2 checkpoint keep large weight dictionaries out of
+    the manifest itself. Manifest values win on collision so a hand-edited
+    operator override stays authoritative.
+    """
+    try:
+        raw = json.loads(sidecar_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        if strict:
+            raise CheckpointInvalid(
+                f"action_memory_state sidecar is not valid JSON: {sidecar_path}"
+            ) from exc
+        warnings.append(f"could not read action_memory_state sidecar: {sidecar_path.name}")
+        return state
+    if not isinstance(raw, dict):
+        if strict:
+            raise CheckpointInvalid("action_memory_state sidecar must decode to an object")
+        warnings.append("action_memory_state sidecar must decode to an object")
+        return state
+    cleaned, extra_warnings = _clean_state(raw, strict=strict, allowed=allowed)
+    warnings.extend(extra_warnings)
+    merged: dict[str, object] = dict(cleaned)
+    merged.update(state)
+    return merged
 
 
 def _sha256_file(path: Path) -> str:

--- a/photon_action_memory/models/checkpoint_builder.py
+++ b/photon_action_memory/models/checkpoint_builder.py
@@ -16,16 +16,27 @@ from pathlib import Path
 from typing import Literal
 
 from photon_action_memory.models.checkpoint import (
+    ACTION_MEMORY_STATE_FILENAME,
     ALLOWED_STATE_KEYS,
+    ALLOWED_STATE_KEYS_V2,
     CHECKPOINT_FORMAT,
+    CHECKPOINT_FORMAT_V2,
     CHECKPOINT_MANIFEST,
     INTEGRITY_FILENAME,
+    PHOTON_RUNTIME_DIRNAME,
     STATE_FILENAME,
     WEIGHTS_FILENAME,
     write_integrity_manifest,
 )
 
 WeightBucket = Literal["action_weights", "file_weights", "evidence_weights"]
+WeightBucketV2 = Literal[
+    "summary_weights",
+    "evidence_weights",
+    "next_action_weights",
+    "file_weights",
+    "avoid_weights",
+]
 
 _KIND_BUCKETS: Mapping[str, WeightBucket] = {
     "action": "action_weights",
@@ -34,6 +45,16 @@ _KIND_BUCKETS: Mapping[str, WeightBucket] = {
     "failed_attempt": "action_weights",
     "file": "file_weights",
     "evidence": "evidence_weights",
+}
+_KIND_BUCKETS_V2: Mapping[str, WeightBucketV2] = {
+    "summary": "summary_weights",
+    "action_summary": "summary_weights",
+    "evidence": "evidence_weights",
+    "next_action": "next_action_weights",
+    "next_hint": "next_action_weights",
+    "file": "file_weights",
+    "avoid": "avoid_weights",
+    "failed_attempt": "avoid_weights",
 }
 _DEFAULT_WEIGHTS_PAYLOAD = b"tiny action-memory PHOTON checkpoint placeholder\n"
 
@@ -48,6 +69,9 @@ class ActionMemoryCheckpointPaths:
     weights_path: Path
     integrity_path: Path | None
     model_version: str
+    format: str = CHECKPOINT_FORMAT
+    action_memory_state_path: Path | None = None
+    photon_runtime_dir: Path | None = None
 
 
 def build_action_memory_checkpoint_state(
@@ -99,25 +123,52 @@ def write_action_memory_checkpoint(
     training_state: Mapping[str, object] | None = None,
     weights_payload: bytes = _DEFAULT_WEIGHTS_PAYLOAD,
     write_integrity: bool = True,
+    format_version: str = CHECKPOINT_FORMAT,
+    source: Mapping[str, object] | None = None,
+    use_action_memory_sidecar: bool = False,
+    include_photon_runtime_stub: bool = False,
 ) -> ActionMemoryCheckpointPaths:
     """Write a small runtime checkpoint directory.
 
     The manifest carries scorer weights. ``state.json`` and ``weights.npz`` are
     present so strict integrity mode can verify the checkpoint package without
     needing to import MLX or download any model.
+
+    ``format_version`` selects between the v1 (``photon-action-memory.mlx.v1``)
+    and v2 (``photon-action-memory.v2``) manifest formats. v2 enables the
+    richer Phase 2 buckets (summary / next_action / avoid / suppressed_ids)
+    and may carry a ``source`` block plus an optional
+    ``action_memory_state.json`` sidecar.
     """
 
     version = model_version.strip()
     if not version:
         raise ValueError("model_version must be non-empty")
+    if format_version not in (CHECKPOINT_FORMAT, CHECKPOINT_FORMAT_V2):
+        raise ValueError(f"unsupported format_version: {format_version!r}")
+    if use_action_memory_sidecar and format_version != CHECKPOINT_FORMAT_V2:
+        raise ValueError("action_memory_state sidecar requires format v2")
+    if include_photon_runtime_stub and format_version != CHECKPOINT_FORMAT_V2:
+        raise ValueError("photon_runtime requires format v2")
+
     checkpoint_dir = Path(path)
     checkpoint_dir.mkdir(parents=True, exist_ok=True)
 
-    manifest = {
-        "format": CHECKPOINT_FORMAT,
+    cleaned_state = _clean_runtime_state(state, format_version=format_version)
+    manifest: dict[str, object] = {
+        "format": format_version,
         "model_version": version,
-        "state": _clean_runtime_state(state),
     }
+    sidecar_path: Path | None = None
+    if use_action_memory_sidecar:
+        manifest["state"] = {}
+        sidecar_path = checkpoint_dir / ACTION_MEMORY_STATE_FILENAME
+        _atomic_write_json(sidecar_path, cleaned_state)
+    else:
+        manifest["state"] = cleaned_state
+    if source is not None:
+        manifest["source"] = dict(source)
+
     manifest_path = checkpoint_dir / CHECKPOINT_MANIFEST
     state_path = checkpoint_dir / STATE_FILENAME
     weights_path = checkpoint_dir / WEIGHTS_FILENAME
@@ -125,6 +176,20 @@ def write_action_memory_checkpoint(
     _atomic_write_json(manifest_path, manifest)
     _atomic_write_json(state_path, _default_training_state() | dict(training_state or {}))
     _atomic_write_bytes(weights_path, weights_payload)
+
+    runtime_dir: Path | None = None
+    if include_photon_runtime_stub:
+        runtime_dir = checkpoint_dir / PHOTON_RUNTIME_DIRNAME
+        runtime_dir.mkdir(parents=True, exist_ok=True)
+        marker = runtime_dir / "README.md"
+        if not marker.exists():
+            marker.write_text(
+                "# photon_runtime placeholder\n\n"
+                "This directory marks the checkpoint as carrying an optional "
+                "photon_runtime layer. The current build does not ship slim-ported "
+                "MLX code; see photon_action_memory/photon_runtime/UPSTREAM.md.\n",
+                encoding="utf-8",
+            )
 
     integrity_path: Path | None = None
     if write_integrity:
@@ -138,7 +203,49 @@ def write_action_memory_checkpoint(
         weights_path=weights_path,
         integrity_path=integrity_path,
         model_version=version,
+        format=format_version,
+        action_memory_state_path=sidecar_path,
+        photon_runtime_dir=runtime_dir,
     )
+
+
+def build_action_memory_checkpoint_state_v2(
+    records: Iterable[Mapping[str, object]],
+    *,
+    bias: float = 0.5,
+) -> dict[str, object]:
+    """Aggregate ``action-memory-feedback.v1`` records into a v2 state.
+
+    Records emitted by :mod:`photon_action_memory.eval.feedback_export` carry
+    ``kind``, ``key``, ``weight``, and ``safety_violation``. Safety
+    violations bypass the weight aggregation and land in
+    ``suppressed_ids`` so the scorer can ban them outright.
+    """
+    buckets: dict[str, object] = {
+        "summary_weights": {},
+        "evidence_weights": {},
+        "next_action_weights": {},
+        "file_weights": {},
+        "avoid_weights": {},
+    }
+    suppressed: set[str] = set()
+
+    for index, record in enumerate(records):
+        key = _key_from_record(record, index)
+        if record.get("safety_violation") is True:
+            suppressed.add(key)
+            continue
+        bucket = _bucket_from_record_v2(record, index)
+        weight = _weight_from_record(record, index)
+        bucket_values = buckets[bucket]
+        assert isinstance(bucket_values, dict)
+        current = float(bucket_values.get(key, 0.0))
+        bucket_values[key] = round(current + weight, 4)
+
+    state: dict[str, object] = {"bias": _coerce_number(bias, "bias")}
+    state.update(buckets)
+    state["suppressed_ids"] = sorted(suppressed)
+    return state
 
 
 def _bucket_from_record(record: Mapping[str, object], index: int) -> WeightBucket:
@@ -152,6 +259,18 @@ def _bucket_from_record(record: Mapping[str, object], index: int) -> WeightBucke
         if bucket is not None:
             return bucket
     raise ValueError(f"record {index} must include a supported kind or bucket")
+
+
+def _bucket_from_record_v2(record: Mapping[str, object], index: int) -> WeightBucketV2:
+    raw_bucket = record.get("bucket")
+    if isinstance(raw_bucket, str) and raw_bucket in _KIND_BUCKETS_V2.values():
+        return raw_bucket  # type: ignore[return-value]
+    raw_kind = record.get("kind")
+    if isinstance(raw_kind, str):
+        bucket = _KIND_BUCKETS_V2.get(raw_kind.strip().lower())
+        if bucket is not None:
+            return bucket
+    raise ValueError(f"record {index} must include a supported v2 kind or bucket")
 
 
 def _key_from_record(record: Mapping[str, object], index: int) -> str:
@@ -173,16 +292,54 @@ def _weight_from_record(record: Mapping[str, object], index: int) -> float:
     return 0.0
 
 
-def _clean_runtime_state(state: Mapping[str, object]) -> dict[str, object]:
-    unknown = sorted(set(state) - ALLOWED_STATE_KEYS)
+def _clean_runtime_state(
+    state: Mapping[str, object],
+    *,
+    format_version: str = CHECKPOINT_FORMAT,
+) -> dict[str, object]:
+    allowed = (
+        ALLOWED_STATE_KEYS_V2 if format_version == CHECKPOINT_FORMAT_V2 else ALLOWED_STATE_KEYS
+    )
+    unknown = sorted(set(state) - allowed)
     if unknown:
         raise ValueError(f"runtime state contains unsupported keys: {', '.join(unknown)}")
 
     clean: dict[str, object] = {}
     clean["bias"] = _coerce_number(state.get("bias", 0.5), "bias")
+    weight_buckets: tuple[str, ...]
+    if format_version == CHECKPOINT_FORMAT_V2:
+        weight_buckets = (
+            "summary_weights",
+            "evidence_weights",
+            "next_action_weights",
+            "file_weights",
+            "avoid_weights",
+            "action_weights",
+        )
+        # Only carry v1-style buckets if the caller provided them, otherwise
+        # omit them so the manifest stays compact.
+        for bucket in weight_buckets:
+            if bucket in state:
+                clean[bucket] = _clean_weight_mapping(state[bucket], bucket)
+        raw_suppressed = state.get("suppressed_ids", [])
+        clean["suppressed_ids"] = _clean_suppressed_ids(raw_suppressed)
+        return clean
     for bucket in ("action_weights", "file_weights", "evidence_weights"):
         clean[bucket] = _clean_weight_mapping(state.get(bucket, {}), bucket)
     return clean
+
+
+def _clean_suppressed_ids(raw: object) -> list[str]:
+    if isinstance(raw, str | bytes):
+        raise ValueError("suppressed_ids must be a list of strings")
+    if not isinstance(raw, Iterable):
+        raise ValueError("suppressed_ids must be a list of strings")
+    ids: list[str] = []
+    for item in raw:
+        if not isinstance(item, str) or not item.strip():
+            raise ValueError("suppressed_ids entries must be non-empty strings")
+        ids.append(item.strip())
+    return sorted(set(ids))
 
 
 def _clean_weight_mapping(raw: object, label: str) -> dict[str, float]:
@@ -227,6 +384,9 @@ def _atomic_write_bytes(path: Path, payload: bytes) -> None:
 
 __all__ = [
     "ActionMemoryCheckpointPaths",
+    "WeightBucket",
+    "WeightBucketV2",
     "build_action_memory_checkpoint_state",
+    "build_action_memory_checkpoint_state_v2",
     "write_action_memory_checkpoint",
 ]

--- a/photon_action_memory/models/checkpoint_registry.py
+++ b/photon_action_memory/models/checkpoint_registry.py
@@ -1,0 +1,317 @@
+"""Issue #126 — Action Memory PHOTON checkpoint registry, promotion, rollback.
+
+The registry owns a directory layout of the form:
+
+```
+<registry_root>/
+    candidates/
+        <candidate_id>/      # one directory per candidate checkpoint
+            manifest.json
+            state.json
+            weights.npz
+            integrity.json
+            action_memory_state.json   # optional (v2)
+            photon_runtime/            # optional (v2)
+    current                  # pointer to the active candidate dir
+    previous                 # pointer to the previously active candidate dir
+    promotion_report.json    # append-only log of promote/rollback decisions
+```
+
+``current`` and ``previous`` are pointer files (one line: relative path under
+``candidates/``). A pointer file is used in preference to a symlink because
+Windows and some filesystems do not allow symlinks without elevated
+privileges; for portability, all promotion operations go through
+``os.replace`` which is atomic on every supported platform.
+
+The :data:`PHOTON_ACTION_MEMORY_CHECKPOINT` environment variable is an
+*operator override*. When set, :meth:`CheckpointRegistry.resolve_active`
+returns that path and :meth:`CheckpointRegistry.auto_promotion_enabled`
+returns False so the auto promotion path stays out of the operator's way.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from photon_action_memory.models.checkpoint import (
+    PROMOTION_REPORT_FILENAME,
+    CheckpointError,
+    CheckpointInvalid,
+    CheckpointUnavailable,
+    load_checkpoint_manifest,
+    verify_checkpoint_integrity,
+)
+
+_logger = logging.getLogger(__name__)
+
+CHECKPOINT_OVERRIDE_ENV = "PHOTON_ACTION_MEMORY_CHECKPOINT"
+CHECKPOINT_ACTIVE_ENV = "PHOTON_CHECKPOINT_ACTIVE"
+CHECKPOINT_DIR_ENV = "PHOTON_CHECKPOINT_DIR"
+
+CURRENT_POINTER = "current"
+PREVIOUS_POINTER = "previous"
+CANDIDATES_DIRNAME = "candidates"
+
+
+class CheckpointRegistryError(CheckpointError):
+    """Base class for registry-level promotion failures."""
+
+
+@dataclass(frozen=True)
+class PromotionRecord:
+    """One promote or rollback event."""
+
+    event: str  # "promote" | "rollback"
+    candidate_id: str
+    previous_id: str | None
+    reason: str
+    created_at: str
+    gate_report: Mapping[str, object] | None = None
+
+
+class CheckpointRegistry:
+    """Atomic current/previous pointer manager for Action Memory checkpoints."""
+
+    def __init__(self, root_dir: str | Path) -> None:
+        self.root_dir = Path(root_dir)
+        self.candidates_dir = self.root_dir / CANDIDATES_DIRNAME
+        self.report_path = self.root_dir / PROMOTION_REPORT_FILENAME
+
+    def initialize(self) -> None:
+        """Create the registry directory layout if it does not yet exist."""
+        self.candidates_dir.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Active pointer resolution
+    # ------------------------------------------------------------------
+
+    def resolve_active(self, environ: Mapping[str, str] | None = None) -> Path | None:
+        """Return the active checkpoint path or None when unavailable.
+
+        Resolution order:
+
+        1. ``PHOTON_ACTION_MEMORY_CHECKPOINT`` operator override.
+        2. ``PHOTON_CHECKPOINT_ACTIVE`` direct pointer.
+        3. ``current`` pointer file under ``root_dir``.
+        4. ``current`` pointer file under ``PHOTON_CHECKPOINT_DIR``.
+        """
+        env = environ if environ is not None else os.environ
+        override = (env.get(CHECKPOINT_OVERRIDE_ENV) or "").strip()
+        if override:
+            return Path(override)
+        active = (env.get(CHECKPOINT_ACTIVE_ENV) or "").strip()
+        if active:
+            return Path(active)
+        local = self._read_pointer(self.root_dir / CURRENT_POINTER)
+        if local is not None:
+            return local
+        env_dir = (env.get(CHECKPOINT_DIR_ENV) or "").strip()
+        if env_dir:
+            env_local = self._read_pointer(Path(env_dir) / CURRENT_POINTER)
+            if env_local is not None:
+                return env_local
+        return None
+
+    def active_path(self) -> Path | None:
+        """Read the current pointer for this registry directory."""
+        return self._read_pointer(self.root_dir / CURRENT_POINTER)
+
+    def previous_path(self) -> Path | None:
+        """Read the previous pointer for this registry directory."""
+        return self._read_pointer(self.root_dir / PREVIOUS_POINTER)
+
+    def auto_promotion_enabled(self, environ: Mapping[str, str] | None = None) -> bool:
+        """Return False when the operator override is active."""
+        env = environ if environ is not None else os.environ
+        return not (env.get(CHECKPOINT_OVERRIDE_ENV) or "").strip()
+
+    # ------------------------------------------------------------------
+    # Candidate registration + promotion
+    # ------------------------------------------------------------------
+
+    def register_candidate(self, candidate_path: str | Path) -> str:
+        """Validate a candidate manifest and return its candidate id.
+
+        The candidate directory must already live under
+        ``<root>/candidates/<id>``; the registry does not copy or move
+        external paths. ``load_checkpoint_manifest`` is used as the
+        validation gate.
+        """
+        path = Path(candidate_path)
+        try:
+            resolved = path.resolve()
+            self.candidates_dir.resolve()
+        except OSError as exc:
+            raise CheckpointRegistryError(f"could not resolve candidate path: {path}") from exc
+        try:
+            relative = resolved.relative_to(self.candidates_dir.resolve())
+        except ValueError as exc:
+            raise CheckpointRegistryError(
+                f"candidate path {path} is not under {self.candidates_dir}"
+            ) from exc
+        if len(relative.parts) != 1:
+            raise CheckpointRegistryError(
+                f"candidate path must be a direct child of candidates/: {path}"
+            )
+        # Defence-in-depth: confirm the manifest can be parsed.
+        load_checkpoint_manifest(path)
+        return relative.parts[0]
+
+    def promote(
+        self,
+        candidate_id: str,
+        *,
+        reason: str,
+        gate_report: Mapping[str, object] | None = None,
+        verify_integrity: bool = True,
+    ) -> PromotionRecord:
+        """Atomically swap ``current`` to point at ``candidate_id``."""
+        if not candidate_id or "/" in candidate_id or candidate_id.startswith("."):
+            raise CheckpointRegistryError(f"invalid candidate id: {candidate_id!r}")
+        candidate_dir = self.candidates_dir / candidate_id
+        if not candidate_dir.is_dir():
+            raise CheckpointUnavailable(f"candidate directory missing: {candidate_dir}")
+        # Re-validate before promoting; manifest must still parse and (when
+        # requested) the integrity manifest must match the sidecar files.
+        load_checkpoint_manifest(candidate_dir)
+        if verify_integrity:
+            try:
+                verify_checkpoint_integrity(candidate_dir, strict=True)
+            except (FileNotFoundError, ValueError) as exc:
+                raise CheckpointInvalid(
+                    f"candidate {candidate_id} failed integrity verification"
+                ) from exc
+
+        self.initialize()
+        previous = self._read_pointer_id(self.root_dir / CURRENT_POINTER)
+        if previous is not None and previous != candidate_id:
+            self._write_pointer(self.root_dir / PREVIOUS_POINTER, previous)
+        self._write_pointer(self.root_dir / CURRENT_POINTER, candidate_id)
+
+        record = PromotionRecord(
+            event="promote",
+            candidate_id=candidate_id,
+            previous_id=previous,
+            reason=reason,
+            created_at=_utc_now(),
+            gate_report=dict(gate_report) if gate_report is not None else None,
+        )
+        self._append_report(record)
+        return record
+
+    def rollback(
+        self,
+        *,
+        reason: str,
+        gate_report: Mapping[str, object] | None = None,
+    ) -> PromotionRecord:
+        """Promote the previously-active candidate back to current."""
+        previous = self._read_pointer_id(self.root_dir / PREVIOUS_POINTER)
+        if previous is None:
+            raise CheckpointRegistryError("no previous checkpoint to rollback to")
+        current = self._read_pointer_id(self.root_dir / CURRENT_POINTER)
+        if current == previous:
+            raise CheckpointRegistryError(f"previous pointer already matches current: {previous}")
+        # Swap current and previous: the candidate that *was* current now
+        # becomes the new previous so a second rollback can revert again.
+        self._write_pointer(self.root_dir / CURRENT_POINTER, previous)
+        if current is not None:
+            self._write_pointer(self.root_dir / PREVIOUS_POINTER, current)
+        record = PromotionRecord(
+            event="rollback",
+            candidate_id=previous,
+            previous_id=current,
+            reason=reason,
+            created_at=_utc_now(),
+            gate_report=dict(gate_report) if gate_report is not None else None,
+        )
+        self._append_report(record)
+        return record
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _read_pointer(self, pointer_path: Path) -> Path | None:
+        candidate_id = self._read_pointer_id(pointer_path)
+        if candidate_id is None:
+            return None
+        candidate_dir = self.candidates_dir / candidate_id
+        if not candidate_dir.exists():
+            _logger.warning(
+                "registry pointer %s -> %s missing on disk",
+                pointer_path,
+                candidate_dir,
+            )
+            return None
+        return candidate_dir
+
+    def _read_pointer_id(self, pointer_path: Path) -> str | None:
+        if not pointer_path.exists():
+            return None
+        try:
+            content = pointer_path.read_text(encoding="utf-8").strip()
+        except OSError:
+            return None
+        if not content:
+            return None
+        # Pointer files contain the candidate id only — reject anything that
+        # looks like a path traversal so the resolver stays inside the
+        # candidates/ directory.
+        if "/" in content or "\\" in content or content.startswith(".."):
+            _logger.warning("registry pointer %s contains unsafe value", pointer_path)
+            return None
+        return content
+
+    def _write_pointer(self, pointer_path: Path, candidate_id: str) -> None:
+        pointer_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = pointer_path.with_suffix(pointer_path.suffix + ".tmp")
+        tmp.write_text(candidate_id + "\n", encoding="utf-8")
+        os.replace(tmp, pointer_path)
+
+    def _append_report(self, record: PromotionRecord) -> None:
+        rows: list[dict[str, object]]
+        if self.report_path.exists():
+            try:
+                raw = json.loads(self.report_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                raw = []
+            rows = list(raw) if isinstance(raw, list) else []
+        else:
+            rows = []
+        rows.append(
+            {
+                "event": record.event,
+                "candidate_id": record.candidate_id,
+                "previous_id": record.previous_id,
+                "reason": record.reason,
+                "created_at": record.created_at,
+                "gate_report": dict(record.gate_report) if record.gate_report else None,
+            }
+        )
+        tmp = self.report_path.with_suffix(self.report_path.suffix + ".tmp")
+        tmp.write_text(json.dumps(rows, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        os.replace(tmp, self.report_path)
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
+__all__ = [
+    "CHECKPOINT_ACTIVE_ENV",
+    "CHECKPOINT_DIR_ENV",
+    "CHECKPOINT_OVERRIDE_ENV",
+    "CANDIDATES_DIRNAME",
+    "CURRENT_POINTER",
+    "CheckpointRegistry",
+    "CheckpointRegistryError",
+    "PREVIOUS_POINTER",
+    "PromotionRecord",
+]

--- a/photon_action_memory/models/photon_adapter.py
+++ b/photon_action_memory/models/photon_adapter.py
@@ -114,11 +114,23 @@ class PhotonMLXAdapter:
         ]
 
     def _score(self, kind: str, subject: str, state: PhotonScoringState) -> float:
+        suppressed = self.checkpoint.state.get("suppressed_ids")
+        if isinstance(suppressed, list | tuple | set | frozenset) and subject in suppressed:
+            # v2 suppression list — never let a banned id earn a positive score.
+            return 0.0
+
         base = _state_float(self.checkpoint.state.get("bias"), default=0.5)
         score = base
         score += _weight_for(self.checkpoint.state.get("action_weights"), kind)
         score += _weight_for(self.checkpoint.state.get("file_weights"), subject)
         score += _weight_for(self.checkpoint.state.get("evidence_weights"), subject)
+        # v2 buckets — only contribute when the kind matches the bucket.
+        if kind in ("summary", "action_summary"):
+            score += _weight_for(self.checkpoint.state.get("summary_weights"), subject)
+        elif kind in ("next_hint", "next_action"):
+            score += _weight_for(self.checkpoint.state.get("next_action_weights"), subject)
+        elif kind in ("failed_attempt", "avoid"):
+            score += _weight_for(self.checkpoint.state.get("avoid_weights"), subject)
         if subject and subject in state.task_text:
             score += 0.05
 

--- a/photon_action_memory/photon_runtime/UPSTREAM.md
+++ b/photon_action_memory/photon_runtime/UPSTREAM.md
@@ -1,0 +1,93 @@
+# photon_runtime — upstream contract
+
+This file documents the **slim port boundary** between this repository and
+[`photon-mlx`](https://github.com/kewton/photon-mlx-develop). It is the
+canonical record consulted by Issue #126 acceptance criteria and any future
+sync from upstream.
+
+## Upstream source
+
+| Field | Value |
+|---|---|
+| Repository | `github.com/kewton/photon-mlx-develop` |
+| Local path during port | `/Users/maenokota/share/work/github_kewton/photon-mlx-develop` |
+| Upstream commit | `3426681b3e89e897bcbae70995bbfc18a29da82c` |
+| Upstream license | MIT (see upstream `LICENSE`) |
+| Local license     | MIT (this repo `LICENSE`) — compatible |
+
+## Port status
+
+**No upstream files have been slim-ported into this directory yet.** The
+`photon_runtime/` package exists today as a contract marker:
+
+- `photon_action_memory.models.photon_adapter.PhotonMLXAdapter` still
+  imports `mlx.core` lazily via `importlib.import_module`. That keeps MLX
+  optional and CI green without an MLX install.
+- A v2 checkpoint may include a `photon_runtime/` subdirectory (built via
+  `write_action_memory_checkpoint(include_photon_runtime_stub=True)`). The
+  loader records `PhotonCheckpoint.has_photon_runtime=True` so a future
+  port can branch on the presence of bundled runtime weights without
+  changing the public API.
+
+## Files reserved for slim port
+
+When the slim port lands, exactly these upstream files should be copied,
+mirroring the names from the upstream `photon_mlx/` package:
+
+| Upstream file (`photon_mlx/`) | Local target (`photon_runtime/`) | Purpose |
+|---|---|---|
+| `checkpoint.py` | `checkpoint.py` | Runtime checkpoint I/O for the scorer. |
+| `model.py`      | `model.py`      | Minimal model class used by the scorer. |
+| `blocks.py`     | `blocks.py`     | Transformer block primitives. |
+| `inference.py`  | `inference.py`  | Scoring forward pass. |
+| `session.py`    | `session.py`    | Session-scoped state batching. |
+| `trainer.py`    | `trainer.py`    | Offline fine-tune entrypoint (CI never invokes). |
+| `loss.py`       | `loss.py`       | Loss functions used by the trainer. |
+| `optimize.py`   | `optimize.py`  | Optimiser configuration helpers. |
+
+No other upstream module is in scope. Anything additional pulled in during a
+sync must be explicitly added to this table together with its justification.
+
+## Local changes policy
+
+Any deviation from the upstream copy MUST be:
+
+1. Annotated with a `# photon-action-memory: local change ...` comment at
+   the point of the deviation.
+2. Recorded in the **Local changes** section of this file with a one-line
+   summary, the date (UTC ISO-8601), and the rationale.
+3. Re-applied during the next sync; the sync script (TBD) reports any
+   local change that no longer applies cleanly so reviewers notice drift.
+
+### Local changes
+
+_None yet — directory is intentionally empty._
+
+## MLX import policy
+
+- `import photon_action_memory` MUST NOT import `mlx` or `mlx.core`.
+- Any module under `photon_action_memory/photon_runtime/` that requires
+  `mlx` MUST import it lazily inside a function body, never at module
+  import time, so CI without MLX continues to pass.
+- `PhotonMLXAdapter._import_mlx_core` is the single supported entry point
+  for resolving `mlx.core`; new code MUST reuse it.
+
+## Sync policy
+
+- Sync direction is upstream → this repo only. We never push from here.
+- A sync is performed by running the (future) `scripts/sync_photon_runtime.py`
+  tool, reviewing its diff, updating the **Upstream commit** field above,
+  and adding a corresponding entry to `CHANGELOG.md` under the active
+  release line.
+- The sync script must not pull non-source artefacts (tests with large
+  fixtures, docs, datasets, etc.) — copy only the files listed in
+  **Files reserved for slim port**.
+
+## Verification
+
+- `python -m pytest tests/test_photon_adapter.py tests/test_action_memory_scorer.py -q`
+  must continue to pass with MLX uninstalled.
+- A v2 checkpoint built with `include_photon_runtime_stub=True` must load
+  cleanly via `load_checkpoint_manifest`.
+- `PHOTON_ACTION_MEMORY_CHECKPOINT` pointing at such a checkpoint must
+  continue to fail-open to deterministic scoring when MLX is missing.

--- a/photon_action_memory/photon_runtime/__init__.py
+++ b/photon_action_memory/photon_runtime/__init__.py
@@ -1,0 +1,16 @@
+"""Slim port boundary for ``photon-mlx`` runtime code.
+
+This package marks the location of the future slim port of select modules
+from the ``photon-mlx`` repository. The current build does **not** ship
+ported MLX code: ``PhotonMLXAdapter`` still imports ``mlx.core`` lazily via
+``importlib`` from :mod:`photon_action_memory.models.photon_adapter`.
+
+When a real slim port lands, the contract recorded in
+``UPSTREAM.md`` MUST be updated in the same change. CI continues to pass
+without MLX installed because nothing here is imported by the default
+import path of :mod:`photon_action_memory`.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/photon_action_memory/ranking/context_ranking.py
+++ b/photon_action_memory/ranking/context_ranking.py
@@ -1,0 +1,332 @@
+"""Issue #126 — Ranking modes for /v1/context/pack.
+
+Four modes are supported and selected via the
+``PHOTON_CONTEXT_PACK_RANKING`` environment variable:
+
+* ``deterministic`` — the existing feedback-adjusted ordering. Default.
+* ``photon_shadow`` — compute PHOTON scores but keep deterministic order;
+  emit a comparison report so we can measure drift before promoting.
+* ``photon_canary`` — apply PHOTON ordering to a subset of requests.
+* ``photon`` — apply PHOTON ordering to all requests, after hard gates.
+
+In every mode the operator-controlled answer-leak / safety / staleness /
+contradiction gates run first. PHOTON scoring only *re-orders* candidates
+that are already admitted into the pack; it can never re-admit an
+omitted candidate, and an item ending up at ``score=0`` does not get
+suppressed unless an upstream gate already excluded it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Literal
+
+from photon_action_memory.api.schema_v2 import (
+    ContextPack,
+    ContextPackItem,
+    ContextPackWarning,
+)
+from photon_action_memory.eval.summary_feedback import SummaryFeedbackRecord
+from photon_action_memory.models.photon_scorer import (
+    ActionMemoryPhotonScorer,
+    SummaryCandidate,
+)
+
+_logger = logging.getLogger(__name__)
+
+RANKING_MODE_ENV = "PHOTON_CONTEXT_PACK_RANKING"
+CANARY_RATIO_ENV = "PHOTON_CONTEXT_PACK_CANARY_RATIO"
+PHOTON_WEIGHT_ENV = "PHOTON_CONTEXT_PACK_PHOTON_WEIGHT"
+
+RankingMode = Literal[
+    "deterministic",
+    "photon_shadow",
+    "photon_canary",
+    "photon",
+]
+_VALID_MODES: frozenset[str] = frozenset(
+    {"deterministic", "photon_shadow", "photon_canary", "photon"}
+)
+DEFAULT_MODE: RankingMode = "deterministic"
+DEFAULT_PHOTON_WEIGHT: float = 0.4
+DEFAULT_CANARY_RATIO: float = 0.1
+
+
+def resolve_ranking_mode(
+    environ: Mapping[str, str] | None = None,
+) -> RankingMode:
+    """Return the configured ranking mode, defaulting to deterministic."""
+    env = environ if environ is not None else os.environ
+    raw = (env.get(RANKING_MODE_ENV) or "").strip().lower()
+    if raw in _VALID_MODES:
+        return raw  # type: ignore[return-value]
+    return DEFAULT_MODE
+
+
+def resolve_photon_weight(
+    environ: Mapping[str, str] | None = None,
+) -> float:
+    env = environ if environ is not None else os.environ
+    raw = (env.get(PHOTON_WEIGHT_ENV) or "").strip()
+    if not raw:
+        return DEFAULT_PHOTON_WEIGHT
+    try:
+        weight = float(raw)
+    except ValueError:
+        return DEFAULT_PHOTON_WEIGHT
+    return max(0.0, min(1.0, weight))
+
+
+def resolve_canary_ratio(
+    environ: Mapping[str, str] | None = None,
+) -> float:
+    env = environ if environ is not None else os.environ
+    raw = (env.get(CANARY_RATIO_ENV) or "").strip()
+    if not raw:
+        return DEFAULT_CANARY_RATIO
+    try:
+        ratio = float(raw)
+    except ValueError:
+        return DEFAULT_CANARY_RATIO
+    return max(0.0, min(1.0, ratio))
+
+
+@dataclass(frozen=True)
+class ScoredItem:
+    """An item with its base / photon / final score (for shadow reports)."""
+
+    item_id: str
+    base_score: float
+    photon_score: float
+    live_delta: float
+    final_score: float
+
+
+@dataclass
+class RankingResult:
+    """Outcome of applying a ranking mode to a built ContextPack."""
+
+    pack: ContextPack
+    mode: RankingMode
+    applied_mode: RankingMode
+    scored_items: list[ScoredItem] = field(default_factory=list)
+    warnings: list[ContextPackWarning] = field(default_factory=list)
+    model_version: str | None = None
+    fallback_reason: str | None = None
+
+
+def apply_ranking_mode(
+    pack: ContextPack,
+    *,
+    mode: RankingMode,
+    scorer: ActionMemoryPhotonScorer | None,
+    task_text: str,
+    request_id: str,
+    repo_id: str | None,
+    feedback_map: Mapping[str, SummaryFeedbackRecord] | None = None,
+    feedback_max_updated_at: str | None = None,
+    photon_weight: float = DEFAULT_PHOTON_WEIGHT,
+    canary_ratio: float = DEFAULT_CANARY_RATIO,
+) -> RankingResult:
+    """Apply the configured ranking mode to ``pack.items``.
+
+    Hard gates have already run in :func:`build_context_pack`. This
+    function only re-orders the *admitted* items so PHOTON scores cannot
+    override the safety / staleness / answer-leak / contradiction gates.
+
+    The function never raises: a missing scorer, an unavailable PHOTON
+    model, or a degenerate input simply leaves the deterministic order in
+    place and records a ``ranking_mode_fallback`` warning so telemetry can
+    track the fail-open reason.
+    """
+    if mode == "deterministic" or not pack.items:
+        return RankingResult(pack=pack, mode=mode, applied_mode="deterministic")
+
+    if scorer is None:
+        return _fallback(
+            pack=pack,
+            mode=mode,
+            reason="scorer_unavailable",
+        )
+
+    applied_mode: RankingMode = mode
+    if mode == "photon_canary" and not _canary_includes(request_id, canary_ratio):
+        applied_mode = "photon_shadow"
+
+    candidates = [
+        SummaryCandidate(summary_id=item.id, text="", evidence_ids=tuple(item.evidence_ids))
+        for item in pack.items
+    ]
+    try:
+        score_result = scorer.score(
+            request_id=request_id,
+            repo_id=repo_id,
+            task_text=task_text,
+            candidate_summaries=candidates,
+        )
+    except Exception as exc:  # pragma: no cover — defensive
+        _logger.warning("photon scorer raised in ranking mode %s: %s", mode, exc)
+        return _fallback(pack=pack, mode=mode, reason="scorer_error")
+
+    if getattr(score_result, "warnings", ()) and "photon_unavailable" in score_result.warnings:
+        return _fallback(
+            pack=pack,
+            mode=mode,
+            reason="photon_unavailable",
+            model_version=score_result.model_version,
+        )
+
+    photon_by_id = {entry.summary_id: entry.score for entry in score_result.summary_scores}
+    scored_items: list[ScoredItem] = []
+    base_lookup = {item.id: index for index, item in enumerate(pack.items)}
+    item_count = max(1, len(pack.items))
+    for item in pack.items:
+        base_score = 1.0 - base_lookup[item.id] / item_count
+        photon_score = float(photon_by_id.get(item.id, 0.0))
+        live_delta = _live_feedback_delta(
+            item=item,
+            feedback_map=feedback_map,
+            feedback_max_updated_at=feedback_max_updated_at,
+        )
+        final = _clamp(
+            base_score * (1.0 - photon_weight) + photon_score * photon_weight + live_delta
+        )
+        scored_items.append(
+            ScoredItem(
+                item_id=item.id,
+                base_score=round(base_score, 4),
+                photon_score=round(photon_score, 4),
+                live_delta=round(live_delta, 4),
+                final_score=round(final, 4),
+            )
+        )
+
+    warnings = list(pack.warnings)
+    if applied_mode == "photon_shadow":
+        warnings.append(
+            ContextPackWarning(
+                kind="ranking_report",
+                message=_shadow_report(scored_items, mode=mode),
+            )
+        )
+        shadow_pack = pack.model_copy(update={"warnings": warnings})
+        return RankingResult(
+            pack=shadow_pack,
+            mode=mode,
+            applied_mode=applied_mode,
+            scored_items=scored_items,
+            warnings=warnings,
+            model_version=score_result.model_version,
+        )
+
+    reordered = _reorder_items(pack.items, scored_items)
+    new_pack = pack.model_copy(update={"items": reordered, "warnings": warnings})
+    return RankingResult(
+        pack=new_pack,
+        mode=mode,
+        applied_mode=applied_mode,
+        scored_items=scored_items,
+        warnings=warnings,
+        model_version=score_result.model_version,
+    )
+
+
+def _fallback(
+    *,
+    pack: ContextPack,
+    mode: RankingMode,
+    reason: str,
+    model_version: str | None = None,
+) -> RankingResult:
+    warnings = list(pack.warnings) + [
+        ContextPackWarning(
+            kind="ranking_mode_fallback",
+            message=f"requested={mode} fallback_reason={reason}",
+        )
+    ]
+    new_pack = pack.model_copy(update={"warnings": warnings})
+    return RankingResult(
+        pack=new_pack,
+        mode=mode,
+        applied_mode="deterministic",
+        warnings=warnings,
+        model_version=model_version,
+        fallback_reason=reason,
+    )
+
+
+def _reorder_items(
+    items: Sequence[ContextPackItem],
+    scored: Sequence[ScoredItem],
+) -> list[ContextPackItem]:
+    by_id = {item.id: item for item in items}
+    order = sorted(
+        enumerate(scored),
+        key=lambda pair: (-pair[1].final_score, pair[0]),
+    )
+    return [by_id[entry.item_id] for _, entry in order if entry.item_id in by_id]
+
+
+def _shadow_report(scored: Sequence[ScoredItem], *, mode: RankingMode) -> str:
+    rows = [
+        f"{entry.item_id}:b={entry.base_score}:p={entry.photon_score}:f={entry.final_score}"
+        for entry in scored
+    ]
+    return f"mode={mode} " + ";".join(rows)
+
+
+def _live_feedback_delta(
+    *,
+    item: ContextPackItem,  # noqa: ARG001 — kept for stable contract
+    feedback_map: Mapping[str, SummaryFeedbackRecord] | None,  # noqa: ARG001
+    feedback_max_updated_at: str | None,  # noqa: ARG001
+) -> float:
+    """Return a tiny delta from feedback that postdates the checkpoint cut.
+
+    Phase 4 keeps the architectural seam for ``live_feedback_delta`` but
+    does not double count: the existing ``summary_feedback`` aggregate
+    table does not yet carry per-row timestamps, so we cannot tell
+    *which* feedback is newer than ``manifest.source.feedback_max_updated_at``.
+    Returning 0.0 here is the conservative answer — the deterministic
+    feedback ordering in ``build_context_pack`` still surfaces the
+    aggregate, and the trained PHOTON score dominates the final order.
+
+    When per-row feedback timestamps land in a follow-up, this function
+    is the single place to start emitting a bounded ±0.05 delta.
+    """
+    return 0.0
+
+
+def _canary_includes(request_id: str, ratio: float) -> bool:
+    if ratio <= 0.0:
+        return False
+    if ratio >= 1.0:
+        return True
+    digest = hashlib.sha256(request_id.encode("utf-8")).digest()
+    bucket = int.from_bytes(digest[:8], "big") / 2**64
+    return bucket < ratio
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+__all__ = [
+    "CANARY_RATIO_ENV",
+    "DEFAULT_CANARY_RATIO",
+    "DEFAULT_MODE",
+    "DEFAULT_PHOTON_WEIGHT",
+    "PHOTON_WEIGHT_ENV",
+    "RANKING_MODE_ENV",
+    "RankingMode",
+    "RankingResult",
+    "ScoredItem",
+    "apply_ranking_mode",
+    "resolve_canary_ratio",
+    "resolve_photon_weight",
+    "resolve_ranking_mode",
+]

--- a/tests/test_action_memory_checkpoint_builder.py
+++ b/tests/test_action_memory_checkpoint_builder.py
@@ -1,17 +1,20 @@
-"""Issue #123 — Action Memory PHOTON checkpoint builder and fixture tests."""
+"""Issue #123 / #126 — Action Memory PHOTON checkpoint builder tests."""
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import cast
 
 from photon_action_memory.models.checkpoint import (
     CHECKPOINT_FORMAT,
+    CHECKPOINT_FORMAT_V2,
     load_checkpoint_manifest,
     verify_checkpoint_integrity,
 )
 from photon_action_memory.models.checkpoint_builder import (
     build_action_memory_checkpoint_state,
+    build_action_memory_checkpoint_state_v2,
     write_action_memory_checkpoint,
 )
 
@@ -66,3 +69,97 @@ def test_tiny_fixture_checkpoint_is_valid_and_small() -> None:
     assert manifest.state["bias"] == 0.1
     assert verify_checkpoint_integrity(FIXTURE, strict=True) is True
     assert (FIXTURE / "weights.npz").stat().st_size < 1024
+
+
+# ---------------------------------------------------------------------------
+# Issue #126 — v2 builder + loader
+# ---------------------------------------------------------------------------
+
+
+def test_v2_builder_emits_summary_evidence_avoid_buckets_and_suppressed() -> None:
+    state = build_action_memory_checkpoint_state_v2(
+        [
+            {"kind": "summary", "key": "sum-good", "weight": 0.2},
+            {"kind": "summary", "key": "sum-good", "weight": 0.1},
+            {"kind": "evidence", "key": "evt-a", "weight": 0.3},
+            {"kind": "next_action", "key": "next-1", "weight": 0.15},
+            {"kind": "avoid", "key": "avoid-1", "weight": -0.4},
+            {"kind": "summary", "key": "sum-bad", "weight": 1.0, "safety_violation": True},
+        ],
+        bias=0.2,
+    )
+
+    assert state["bias"] == 0.2
+    assert state["summary_weights"] == {"sum-good": 0.3}
+    assert state["evidence_weights"] == {"evt-a": 0.3}
+    assert state["next_action_weights"] == {"next-1": 0.15}
+    assert state["avoid_weights"] == {"avoid-1": -0.4}
+    suppressed_ids = cast(list[str], state["suppressed_ids"])
+    assert "sum-bad" in suppressed_ids
+    assert "sum-good" not in suppressed_ids
+
+
+def test_v2_checkpoint_can_be_written_and_loaded(tmp_path: Path) -> None:
+    state = build_action_memory_checkpoint_state_v2(
+        [
+            {"kind": "summary", "key": "sum-good", "weight": 0.2},
+            {"kind": "evidence", "key": "evt-a", "weight": 0.3},
+            {"kind": "summary", "key": "sum-bad", "weight": 1.0, "safety_violation": True},
+        ],
+    )
+
+    paths = write_action_memory_checkpoint(
+        tmp_path / "ckpt-v2",
+        model_version="action-memory-v2-test",
+        state=state,
+        format_version=CHECKPOINT_FORMAT_V2,
+        source={"feedback_max_updated_at": "2026-05-17T00:00:00.000000+00:00"},
+        use_action_memory_sidecar=True,
+        include_photon_runtime_stub=True,
+    )
+
+    assert paths.format == CHECKPOINT_FORMAT_V2
+    assert paths.action_memory_state_path is not None
+    assert paths.photon_runtime_dir is not None
+    assert paths.photon_runtime_dir.is_dir()
+
+    manifest_doc = json.loads(paths.manifest_path.read_text(encoding="utf-8"))
+    assert manifest_doc["format"] == CHECKPOINT_FORMAT_V2
+    # Sidecar mode keeps the manifest state empty so big weights live in
+    # action_memory_state.json.
+    assert manifest_doc["state"] == {}
+    assert manifest_doc["source"]["feedback_max_updated_at"]
+
+    checkpoint = load_checkpoint_manifest(paths.checkpoint_dir, strict=True)
+    assert checkpoint.format == CHECKPOINT_FORMAT_V2
+    assert checkpoint.has_photon_runtime is True
+    # Sidecar is merged in by the loader.
+    assert checkpoint.state["summary_weights"] == {"sum-good": 0.2}
+    assert checkpoint.state["evidence_weights"] == {"evt-a": 0.3}
+    suppressed_ids = cast(list[str], checkpoint.state["suppressed_ids"])
+    assert "sum-bad" in suppressed_ids
+    assert checkpoint.source["feedback_max_updated_at"]
+
+
+def test_v2_metadata_only_checkpoint_round_trips(tmp_path: Path) -> None:
+    state = build_action_memory_checkpoint_state_v2(
+        [
+            {"kind": "summary", "key": "sum-only", "weight": 0.5},
+        ],
+    )
+
+    paths = write_action_memory_checkpoint(
+        tmp_path / "ckpt-v2-meta",
+        model_version="action-memory-v2-meta",
+        state=state,
+        format_version=CHECKPOINT_FORMAT_V2,
+    )
+    # No sidecar, no photon_runtime — pure metadata layer.
+    assert paths.action_memory_state_path is None
+    assert paths.photon_runtime_dir is None
+
+    checkpoint = load_checkpoint_manifest(paths.checkpoint_dir, strict=True)
+    assert checkpoint.format == CHECKPOINT_FORMAT_V2
+    assert checkpoint.has_photon_runtime is False
+    assert checkpoint.state["summary_weights"] == {"sum-only": 0.5}
+    assert checkpoint.state["suppressed_ids"] == []

--- a/tests/test_checkpoint_registry.py
+++ b/tests/test_checkpoint_registry.py
@@ -1,0 +1,124 @@
+"""Issue #126 — checkpoint registry promote / rollback / override tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from photon_action_memory.models.checkpoint import CHECKPOINT_FORMAT_V2
+from photon_action_memory.models.checkpoint_builder import (
+    build_action_memory_checkpoint_state_v2,
+    write_action_memory_checkpoint,
+)
+from photon_action_memory.models.checkpoint_registry import (
+    CHECKPOINT_OVERRIDE_ENV,
+    CheckpointRegistry,
+    CheckpointRegistryError,
+)
+
+
+def _build_candidate(
+    registry: CheckpointRegistry,
+    candidate_id: str,
+    *,
+    weight: float = 0.5,
+) -> Path:
+    registry.initialize()
+    candidate_dir = registry.candidates_dir / candidate_id
+    state = build_action_memory_checkpoint_state_v2(
+        [{"kind": "summary", "key": f"sum-{candidate_id}", "weight": weight}],
+    )
+    write_action_memory_checkpoint(
+        candidate_dir,
+        model_version=f"action-memory-{candidate_id}",
+        state=state,
+        format_version=CHECKPOINT_FORMAT_V2,
+        source={"feedback_max_updated_at": "2026-05-17T00:00:00.000000+00:00"},
+        use_action_memory_sidecar=False,
+    )
+    return candidate_dir
+
+
+def test_promote_sets_current_atomically(tmp_path: Path) -> None:
+    registry = CheckpointRegistry(tmp_path / "registry")
+    _build_candidate(registry, "ckpt-1")
+    registry.register_candidate(registry.candidates_dir / "ckpt-1")
+
+    record = registry.promote("ckpt-1", reason="initial promote")
+
+    assert record.event == "promote"
+    assert record.previous_id is None
+    assert (registry.root_dir / "current").read_text(encoding="utf-8").strip() == "ckpt-1"
+    assert registry.active_path() == registry.candidates_dir / "ckpt-1"
+    report = json.loads(registry.report_path.read_text(encoding="utf-8"))
+    assert report[-1]["candidate_id"] == "ckpt-1"
+
+
+def test_promote_shifts_current_to_previous(tmp_path: Path) -> None:
+    registry = CheckpointRegistry(tmp_path / "registry")
+    _build_candidate(registry, "ckpt-1")
+    _build_candidate(registry, "ckpt-2", weight=0.7)
+    registry.promote("ckpt-1", reason="first")
+    registry.promote("ckpt-2", reason="second")
+
+    assert registry.active_path() == registry.candidates_dir / "ckpt-2"
+    assert registry.previous_path() == registry.candidates_dir / "ckpt-1"
+
+
+def test_rollback_restores_previous(tmp_path: Path) -> None:
+    registry = CheckpointRegistry(tmp_path / "registry")
+    _build_candidate(registry, "ckpt-1")
+    _build_candidate(registry, "ckpt-2", weight=0.7)
+    registry.promote("ckpt-1", reason="first")
+    registry.promote("ckpt-2", reason="second")
+
+    record = registry.rollback(reason="canary regression")
+
+    assert record.event == "rollback"
+    assert record.candidate_id == "ckpt-1"
+    assert registry.active_path() == registry.candidates_dir / "ckpt-1"
+    # And previous now points to ckpt-2 so a second rollback can undo.
+    assert registry.previous_path() == registry.candidates_dir / "ckpt-2"
+
+
+def test_rollback_raises_when_no_previous(tmp_path: Path) -> None:
+    registry = CheckpointRegistry(tmp_path / "registry")
+    _build_candidate(registry, "ckpt-1")
+    registry.promote("ckpt-1", reason="first")
+
+    with pytest.raises(CheckpointRegistryError):
+        registry.rollback(reason="cannot")
+
+
+def test_operator_override_disables_auto_promotion(tmp_path: Path) -> None:
+    registry = CheckpointRegistry(tmp_path / "registry")
+    candidate = _build_candidate(registry, "ckpt-1")
+    registry.promote("ckpt-1", reason="seed")
+
+    override_env = {CHECKPOINT_OVERRIDE_ENV: "/opt/photon/operator-checkpoint"}
+    resolved = registry.resolve_active(environ=override_env)
+    assert resolved == Path("/opt/photon/operator-checkpoint")
+    assert registry.auto_promotion_enabled(environ=override_env) is False
+
+    no_override_env: dict[str, str] = {}
+    assert registry.resolve_active(environ=no_override_env) == candidate
+    assert registry.auto_promotion_enabled(environ=no_override_env) is True
+
+
+def test_register_candidate_rejects_external_path(tmp_path: Path) -> None:
+    registry = CheckpointRegistry(tmp_path / "registry")
+    registry.initialize()
+    outside = tmp_path / "outside-ckpt"
+    state = build_action_memory_checkpoint_state_v2(
+        [{"kind": "summary", "key": "sum-x", "weight": 0.1}],
+    )
+    write_action_memory_checkpoint(
+        outside,
+        model_version="outside",
+        state=state,
+        format_version=CHECKPOINT_FORMAT_V2,
+    )
+    with pytest.raises(CheckpointRegistryError):
+        registry.register_candidate(outside)

--- a/tests/test_context_ranking.py
+++ b/tests/test_context_ranking.py
@@ -1,0 +1,244 @@
+"""Issue #126 — /v1/context/pack ranking mode tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from photon_action_memory.api.schema_v2 import (
+    DEFAULT_SCHEMA_VERSION_V2,
+    ContextPack,
+    ContextPackItem,
+    ContextPackWarning,
+    TokenBudget,
+)
+from photon_action_memory.models.photon_scorer import (
+    ActionMemoryScoreResult,
+    DeterministicActionMemoryScorer,
+    ScoredSummary,
+)
+from photon_action_memory.ranking.context_ranking import (
+    DEFAULT_PHOTON_WEIGHT,
+    apply_ranking_mode,
+    resolve_canary_ratio,
+    resolve_photon_weight,
+    resolve_ranking_mode,
+)
+
+
+@dataclass
+class _StaticScorer:
+    """Deterministic stand-in that lets the test pick per-id scores."""
+
+    scores: dict[str, float]
+    model_version: str = "static-test-model"
+
+    def score(self, **kwargs: Any) -> ActionMemoryScoreResult:
+        candidates = kwargs.get("candidate_summaries", ())
+        return ActionMemoryScoreResult(
+            summary_scores=tuple(
+                ScoredSummary(
+                    summary_id=cand.summary_id,
+                    score=self.scores.get(cand.summary_id, 0.0),
+                    reason="static",
+                )
+                for cand in candidates
+            ),
+            model_version=self.model_version,
+        )
+
+
+def _pack(item_ids: list[str]) -> ContextPack:
+    return ContextPack(
+        schema_version=DEFAULT_SCHEMA_VERSION_V2,
+        request_id="req-1",
+        session_id=None,
+        repo_id=None,
+        mode="summary_only",
+        items=[
+            ContextPackItem(kind="action_summary", id=item_id, text=f"render-{item_id}")
+            for item_id in item_ids
+        ],
+        omitted=[],
+        warnings=[ContextPackWarning(kind="prior", message="pre-existing")],
+        token_budget=TokenBudget(max_tokens=100, estimated_tokens=10, tokens_saved_vs_raw=0),
+    )
+
+
+def test_resolve_ranking_mode_defaults_to_deterministic() -> None:
+    assert resolve_ranking_mode({}) == "deterministic"
+    assert resolve_ranking_mode({"PHOTON_CONTEXT_PACK_RANKING": "garbage"}) == "deterministic"
+
+
+def test_resolve_ranking_mode_accepts_all_modes() -> None:
+    for mode in ("deterministic", "photon_shadow", "photon_canary", "photon"):
+        assert resolve_ranking_mode({"PHOTON_CONTEXT_PACK_RANKING": mode}) == mode
+
+
+def test_resolve_photon_weight_clamps_to_unit_interval() -> None:
+    assert resolve_photon_weight({"PHOTON_CONTEXT_PACK_PHOTON_WEIGHT": "0.7"}) == 0.7
+    assert resolve_photon_weight({"PHOTON_CONTEXT_PACK_PHOTON_WEIGHT": "1.7"}) == 1.0
+    assert resolve_photon_weight({"PHOTON_CONTEXT_PACK_PHOTON_WEIGHT": "-1"}) == 0.0
+    assert resolve_photon_weight({}) == DEFAULT_PHOTON_WEIGHT
+
+
+def test_resolve_canary_ratio_clamps_to_unit_interval() -> None:
+    assert resolve_canary_ratio({"PHOTON_CONTEXT_PACK_CANARY_RATIO": "0.25"}) == 0.25
+    assert resolve_canary_ratio({"PHOTON_CONTEXT_PACK_CANARY_RATIO": "10"}) == 1.0
+
+
+def test_deterministic_mode_short_circuits_without_scorer() -> None:
+    pack = _pack(["sum-a", "sum-b"])
+    result = apply_ranking_mode(
+        pack,
+        mode="deterministic",
+        scorer=None,
+        task_text="task",
+        request_id="req-1",
+        repo_id=None,
+    )
+    assert result.applied_mode == "deterministic"
+    assert result.pack is pack
+
+
+def test_missing_scorer_falls_back_with_warning() -> None:
+    pack = _pack(["sum-a", "sum-b"])
+    result = apply_ranking_mode(
+        pack,
+        mode="photon",
+        scorer=None,
+        task_text="task",
+        request_id="req-1",
+        repo_id=None,
+    )
+    assert result.applied_mode == "deterministic"
+    assert result.fallback_reason == "scorer_unavailable"
+    assert any(w.kind == "ranking_mode_fallback" for w in result.pack.warnings)
+
+
+def test_photon_unavailable_warning_triggers_fallback() -> None:
+    pack = _pack(["sum-a", "sum-b"])
+    scorer = DeterministicActionMemoryScorer(warnings=("photon_unavailable",))
+    result = apply_ranking_mode(
+        pack,
+        mode="photon",
+        scorer=scorer,
+        task_text="task",
+        request_id="req-1",
+        repo_id=None,
+    )
+    assert result.applied_mode == "deterministic"
+    assert result.fallback_reason == "photon_unavailable"
+
+
+def test_photon_mode_reorders_items_by_score() -> None:
+    pack = _pack(["sum-a", "sum-b", "sum-c"])
+    # Static scorer ranks c > b > a, but a was first deterministically.
+    scorer = _StaticScorer(scores={"sum-a": 0.1, "sum-b": 0.5, "sum-c": 0.9})
+    result = apply_ranking_mode(
+        pack,
+        mode="photon",
+        scorer=scorer,
+        task_text="task",
+        request_id="req-1",
+        repo_id=None,
+        photon_weight=0.9,
+    )
+    assert result.applied_mode == "photon"
+    ordered_ids = [item.id for item in result.pack.items]
+    assert ordered_ids[0] == "sum-c"
+    assert "sum-a" in ordered_ids
+    assert "sum-b" in ordered_ids
+
+
+def test_shadow_mode_keeps_order_and_emits_report() -> None:
+    pack = _pack(["sum-a", "sum-b"])
+    scorer = _StaticScorer(scores={"sum-a": 0.1, "sum-b": 0.9})
+    result = apply_ranking_mode(
+        pack,
+        mode="photon_shadow",
+        scorer=scorer,
+        task_text="task",
+        request_id="req-1",
+        repo_id=None,
+    )
+    assert result.applied_mode == "photon_shadow"
+    ordered_ids = [item.id for item in result.pack.items]
+    assert ordered_ids == ["sum-a", "sum-b"]
+    reports = [w for w in result.pack.warnings if w.kind == "ranking_report"]
+    assert reports, "expected a ranking_report warning in shadow mode"
+    assert "sum-a" in reports[0].message and "sum-b" in reports[0].message
+
+
+def test_photon_does_not_re_admit_omitted_items() -> None:
+    pack = _pack(["sum-a", "sum-b"])
+    # Even with a huge score, the unadmitted item shouldn't appear because
+    # apply_ranking_mode only sees pack.items.
+    scorer = _StaticScorer(scores={"sum-a": 0.1, "sum-b": 0.9, "sum-evil": 1.0})
+    result = apply_ranking_mode(
+        pack,
+        mode="photon",
+        scorer=scorer,
+        task_text="task",
+        request_id="req-1",
+        repo_id=None,
+    )
+    ids = {item.id for item in result.pack.items}
+    assert "sum-evil" not in ids
+
+
+def test_canary_mode_uses_shadow_for_excluded_requests() -> None:
+    pack = _pack(["sum-a", "sum-b"])
+    scorer = _StaticScorer(scores={"sum-a": 0.1, "sum-b": 0.9})
+    # Ratio 0 means no request is in the canary bucket.
+    result = apply_ranking_mode(
+        pack,
+        mode="photon_canary",
+        scorer=scorer,
+        task_text="task",
+        request_id="req-out",
+        repo_id=None,
+        canary_ratio=0.0,
+    )
+    assert result.applied_mode == "photon_shadow"
+    # Order preserved.
+    assert [item.id for item in result.pack.items] == ["sum-a", "sum-b"]
+
+
+def test_canary_mode_applies_when_request_in_bucket() -> None:
+    pack = _pack(["sum-a", "sum-b"])
+    scorer = _StaticScorer(scores={"sum-a": 0.1, "sum-b": 0.9})
+    # Ratio 1 means every request is in the bucket.
+    result = apply_ranking_mode(
+        pack,
+        mode="photon_canary",
+        scorer=scorer,
+        task_text="task",
+        request_id="req-in",
+        repo_id=None,
+        canary_ratio=1.0,
+        photon_weight=0.9,
+    )
+    assert result.applied_mode == "photon_canary"
+    assert result.pack.items[0].id == "sum-b"
+
+
+def test_empty_pack_short_circuits() -> None:
+    pack = _pack([])
+    scorer = _StaticScorer(scores={})
+    result = apply_ranking_mode(
+        pack,
+        mode="photon",
+        scorer=scorer,
+        task_text="task",
+        request_id="req-1",
+        repo_id=None,
+    )
+    assert result.applied_mode == "deterministic"
+    assert result.pack is pack
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-q"])

--- a/tests/test_feedback_export.py
+++ b/tests/test_feedback_export.py
@@ -1,0 +1,179 @@
+"""Issue #126 — action-memory-feedback.v1 exporter tests."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from io import StringIO
+from pathlib import Path
+
+from photon_action_memory.eval.feedback_export import (
+    FEEDBACK_EXPORT_SCHEMA,
+    export_action_memory_feedback,
+    iter_export_jsonl,
+    write_export_jsonl,
+)
+from photon_action_memory.eval.ranking_log import (
+    LABEL_ADOPTED_FAILURE,
+    LABEL_ADOPTED_SAFETY,
+    LABEL_ADOPTED_SUCCESS,
+    LABEL_OMITTED_BY_GATE,
+    LABEL_PARTIAL,
+    RankingLogEntry,
+    RankingLogOutcome,
+    RankingLogStore,
+)
+
+
+def _store(tmp_path: Path) -> RankingLogStore:
+    connection = sqlite3.connect(tmp_path / "store.sqlite")
+    connection.row_factory = sqlite3.Row
+    return RankingLogStore(connection)
+
+
+def _record(
+    store: RankingLogStore,
+    summary_id: str,
+    *,
+    request_id: str = "pack-1",
+    position: int = 0,
+    selected: bool = True,
+    omitted_reason: str | None = None,
+    score: float = 0.5,
+) -> None:
+    store.record_entries(
+        [
+            RankingLogEntry(
+                context_pack_request_id=request_id,
+                summary_id=summary_id,
+                position=position,
+                selected=selected,
+                omitted_reason=omitted_reason,
+                score=score,
+            )
+        ]
+    )
+
+
+def _set_outcome(
+    store: RankingLogStore,
+    summary_id: str,
+    family: str,
+    *,
+    request_id: str = "pack-1",
+    adoption_status: str = "adopted",
+) -> None:
+    store.update_outcomes(
+        [
+            RankingLogOutcome(
+                context_pack_request_id=request_id,
+                summary_id=summary_id,
+                outcome_family=family,  # type: ignore[arg-type]
+                adoption_status=adoption_status,
+            )
+        ]
+    )
+
+
+def test_export_carries_outcome_family_and_signed_weights(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _record(store, "sum-good", position=0)
+    _record(store, "sum-bad", position=1)
+    _record(store, "sum-partial", position=2)
+    _record(store, "sum-omitted", position=3, selected=False, omitted_reason="quality_gate")
+    _record(store, "sum-not-selected", position=4, selected=False, omitted_reason="budget")
+
+    _set_outcome(store, "sum-good", "success")
+    _set_outcome(store, "sum-bad", "failure")
+    _set_outcome(store, "sum-partial", "success", adoption_status="partial")
+
+    result = export_action_memory_feedback(store)
+    by_key = {(record.bucket, record.key): record for record in result.records}
+
+    assert by_key[("summary_weights", "sum-good")].source_label == LABEL_ADOPTED_SUCCESS
+    assert by_key[("summary_weights", "sum-good")].weight > 0
+
+    assert by_key[("summary_weights", "sum-bad")].source_label == LABEL_ADOPTED_FAILURE
+    assert by_key[("summary_weights", "sum-bad")].weight < 0
+
+    partial = by_key[("summary_weights", "sum-partial")]
+    assert partial.source_label == LABEL_PARTIAL
+    # Partial with success outcome → positive weight.
+    assert partial.weight > 0
+
+    omitted = by_key[("summary_weights", "sum-omitted")]
+    assert omitted.source_label == LABEL_OMITTED_BY_GATE
+    # Gate omissions are reported but never as positive weights.
+    assert omitted.weight == 0.0
+
+    not_selected = by_key[("summary_weights", "sum-not-selected")]
+    assert not_selected.source_label == "not_selected"
+    assert not_selected.weight < 0
+
+
+def test_export_marks_safety_violations_for_suppression(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _record(store, "sum-unsafe")
+    _set_outcome(store, "sum-unsafe", "safety")
+
+    result = export_action_memory_feedback(store)
+
+    assert result.records, "expected at least one record"
+    assert result.safety_violation_count == 1
+    record = result.records[0]
+    assert record.safety_violation is True
+    assert record.source_label == LABEL_ADOPTED_SAFETY
+    # Safety records still get a strongly negative weight so the builder
+    # routes them to suppressed_ids rather than amplifying them.
+    assert record.weight <= -0.5
+
+
+def test_export_manifest_carries_feedback_max_updated_at(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _record(store, "sum-good")
+    _set_outcome(store, "sum-good", "success")
+
+    result = export_action_memory_feedback(store)
+    manifest = result.manifest_source()
+
+    assert manifest["schema"] == FEEDBACK_EXPORT_SCHEMA
+    assert manifest["feedback_max_updated_at"]
+    assert manifest["feedback_record_count"] == 1
+
+
+def test_export_jsonl_round_trip(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _record(store, "sum-good")
+    _set_outcome(store, "sum-good", "success")
+    result = export_action_memory_feedback(store)
+
+    path = tmp_path / "out.jsonl"
+    write_export_jsonl(result, path)
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) >= 2
+    header = json.loads(lines[0])
+    assert header["schema"] == FEEDBACK_EXPORT_SCHEMA
+    assert header["source"]["feedback_max_updated_at"]
+    record = json.loads(lines[1])
+    assert record["bucket"] == "summary_weights"
+    assert record["source_label"] == LABEL_ADOPTED_SUCCESS
+
+    # Same content can be streamed without writing a file.
+    buffer = StringIO()
+    for line in iter_export_jsonl(result):
+        buffer.write(line + "\n")
+    assert buffer.getvalue() == path.read_text(encoding="utf-8")
+
+
+def test_export_does_not_emit_raw_text_fields(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _record(store, "sum-good")
+    _set_outcome(store, "sum-good", "success")
+    result = export_action_memory_feedback(store)
+
+    for line in iter_export_jsonl(result):
+        payload = json.loads(line)
+        # The exporter has a fixed schema — confirm nobody added a raw_text
+        # field by accident.
+        forbidden = {"raw_text", "text", "evidence_text", "prompt", "stdout"}
+        assert not (forbidden & set(payload.keys()))

--- a/tests/test_photon_adapter.py
+++ b/tests/test_photon_adapter.py
@@ -175,3 +175,63 @@ def test_suggest_uses_configured_fake_mlx_checkpoint(
 
 def _raise_mlx() -> SimpleNamespace:
     raise ModuleNotFoundError("No module named 'mlx'", name="mlx")
+
+
+# ---------------------------------------------------------------------------
+# Issue #126 — v2 manifest acceptance + suppressed_ids enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_loader_accepts_v2_manifest_with_source_block(tmp_path: Path) -> None:
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "format": "photon-action-memory.v2",
+                "model_version": "action-memory-v2-test",
+                "state": {
+                    "bias": 0.1,
+                    "summary_weights": {"sum-good": 0.4},
+                    "suppressed_ids": ["sum-bad"],
+                },
+                "source": {"feedback_max_updated_at": "2026-05-17T00:00:00.000000+00:00"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    checkpoint = load_checkpoint_manifest(manifest, strict=True)
+    assert checkpoint.format == "photon-action-memory.v2"
+    assert checkpoint.state["summary_weights"] == {"sum-good": 0.4}
+    assert checkpoint.state["suppressed_ids"] == ["sum-bad"]
+    assert checkpoint.source["feedback_max_updated_at"]
+
+
+def test_adapter_returns_zero_for_suppressed_id(tmp_path: Path) -> None:
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "format": "photon-action-memory.v2",
+                "model_version": "v2-suppress-test",
+                "state": {
+                    "bias": 0.5,
+                    "summary_weights": {"sum-bad": 0.9},
+                    "suppressed_ids": ["sum-bad"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    adapter = PhotonMLXAdapter.from_checkpoint(
+        manifest,
+        import_module=lambda _name: _FakeMlx(),
+    )
+    from photon_action_memory.models.state import ActionCandidate, PhotonScoringState
+
+    state = PhotonScoringState(request_id="req", task_text="anything")
+    scored = adapter.score_actions(
+        state,
+        [ActionCandidate(kind="summary", target="sum-bad")],
+    )
+    assert scored[0].score == 0.0

--- a/tests/test_summary_feedback.py
+++ b/tests/test_summary_feedback.py
@@ -458,3 +458,79 @@ def test_evaluate_excluded_status_does_not_update_feedback(tmp_path: Path) -> No
     response = client.post("/v1/evaluate", json=body)
     assert response.status_code == 200
     assert summaries.get_feedback("sum-x") is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #126 — ranking log + feedback export end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_context_pack_writes_ranking_log_without_raw_text(tmp_path: Path) -> None:
+    """`/v1/context/pack` populates context_pack_ranking_log with no text."""
+    client, _, summaries = _make_client(tmp_path)
+    summaries.upsert(_summary("sum-ranklog", fact_text="alpha foxtrot fact"))
+    response = client.post(
+        "/v1/context/pack",
+        json={
+            "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+            "request_id": "pack-rank-1",
+            "agent": {"name": "anvil"},
+            "repo": {"root": "/r", "name": "repo-a"},
+            "task": {"user_request": "x", "mode": "act"},
+            "working_memory": {},
+            "candidate_summary_ids": ["sum-ranklog"],
+        },
+    )
+    assert response.status_code == 200
+
+    entries = summaries.ranking_log.iter_entries(context_pack_request_id="pack-rank-1")
+    assert entries, "expected ranking log entries to be written"
+    for entry in entries:
+        # The ranking log is forbidden from carrying rendered prompt text.
+        assert entry.kind == "action_summary"
+        assert entry.position >= 0
+        assert isinstance(entry.score, float)
+        assert isinstance(entry.selected, bool)
+        # The label is computable up front (no outcome yet → ignored/not_selected/gate).
+        assert entry.label() in {
+            "ignored",
+            "not_selected",
+            "omitted_by_gate",
+        }
+
+
+def test_evaluate_back_fills_ranking_log_outcome(tmp_path: Path) -> None:
+    """`/v1/evaluate` writes outcome_family back to ranking_log rows."""
+    client, _, summaries = _make_client(tmp_path)
+    summaries.upsert(_summary("sum-feedback-flow", fact_text="bravo golf fact"))
+    client.post(
+        "/v1/context/pack",
+        json={
+            "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+            "request_id": "pack-rank-2",
+            "agent": {"name": "anvil"},
+            "repo": {"root": "/r", "name": "repo-a"},
+            "task": {"user_request": "x", "mode": "act"},
+            "working_memory": {},
+            "candidate_summary_ids": ["sum-feedback-flow"],
+        },
+    )
+    client.post(
+        "/v1/evaluate",
+        json={
+            "schema_version": DEFAULT_SCHEMA_VERSION_V2,
+            "request_id": "eval-flow-1",
+            "context_pack_event": {
+                "context_pack_request_id": "pack-rank-2",
+                "adoption_status": "adopted",
+                "summary_ids_adopted": ["sum-feedback-flow"],
+                "outcome": "success",
+            },
+        },
+    )
+
+    entries = summaries.ranking_log.iter_entries(context_pack_request_id="pack-rank-2")
+    matched = [e for e in entries if e.summary_id == "sum-feedback-flow"]
+    assert matched, "expected outcome to be written to the matching log row"
+    assert matched[0].outcome_family == "success"
+    assert matched[0].label() == "adopted_success"

--- a/workspace/v0.4.1/README.md
+++ b/workspace/v0.4.1/README.md
@@ -1,0 +1,43 @@
+# PHOTON Action Memory v0.4.1 Notes
+
+v0.4.1 closes the loop between `/v1/evaluate` feedback and the live
+`/v1/context/pack` ranking path that was opened in v0.4.0. The new pieces
+keep the operator opt-in defaults from v0.4.0: nothing changes for a
+deployment that does not set `PHOTON_CONTEXT_PACK_RANKING` or a checkpoint
+override.
+
+## Current Defaults
+
+| Area | Default |
+|---|---|
+| Context pack ranking | `deterministic` (PHOTON ranking is opt-in) |
+| Checkpoint registry  | inactive unless an operator initialises one |
+| Operator override    | `PHOTON_ACTION_MEMORY_CHECKPOINT` still wins |
+| MLX dependency       | optional and lazily imported |
+| CI                   | passes with MLX uninstalled and no checkpoint |
+
+## Implemented in this Issue
+
+- `context_pack_ranking_log` (Phase 1)
+- `action-memory-feedback.v1` JSONL exporter (Phase 1)
+- v2 checkpoint format + sidecar + suppressed_ids (Phase 2)
+- `CheckpointRegistry` with atomic `current` / `previous` pointers
+  and `promotion_report.json` (Phase 3)
+- `/v1/context/pack` ranking modes — `deterministic`, `photon_shadow`,
+  `photon_canary`, `photon` (Phase 4)
+- `photon_runtime/UPSTREAM.md` slim-port contract (Phase 5)
+
+## Documents
+
+| File | Purpose |
+|---|---|
+| `feedback-checkpoint-production-ranking-spec.md` | Canonical v0.4.1 contract for Issue #126. |
+
+## Follow-up
+
+- A trained / derived production checkpoint is still required to see a
+  PHOTON effect in `photon` mode; the deterministic fallback keeps the
+  sidecar safe until that lands.
+- The actual slim port of `photon-mlx` modules into
+  `photon_action_memory/photon_runtime/` is deliberately deferred — only
+  the upstream contract file is shipped today.

--- a/workspace/v0.4.1/feedback-checkpoint-production-ranking-spec.md
+++ b/workspace/v0.4.1/feedback-checkpoint-production-ranking-spec.md
@@ -1,0 +1,213 @@
+# v0.4.1 — Feedback → PHOTON checkpoint → production ranking
+
+This document is the canonical spec for Issue #126. It captures the contract
+shipped by the implementation in `photon_action_memory/` and is the file
+referenced from the Issue body.
+
+## Pipeline
+
+```
+/v1/evaluate feedback
+  └─ summary_feedback table          (per-summary aggregates)
+  └─ context_pack_ranking_log table  (per-candidate, no raw text)
+        │
+        ▼
+  action-memory-feedback.v1 JSONL export
+        │
+        ▼
+  v2 checkpoint candidate
+   ├─ manifest.json     (format=photon-action-memory.v2, source.feedback_max_updated_at)
+   ├─ action_memory_state.json   (optional sidecar with the big weight dicts)
+   ├─ state.json / weights.npz / integrity.json
+   └─ photon_runtime/   (optional — slim port contract per UPSTREAM.md)
+        │
+        ▼
+  CheckpointRegistry
+   ├─ candidates/<id>/
+   ├─ current   (atomic pointer)
+   ├─ previous  (atomic pointer)
+   └─ promotion_report.json   (append-only log)
+        │
+        ▼
+  /v1/context/pack ranking mode
+   ├─ deterministic   (default, behaves like v0.4.0)
+   ├─ photon_shadow   (compute + emit comparison, keep deterministic order)
+   ├─ photon_canary   (hash-bucket fraction of requests)
+   └─ photon          (full apply, hard gates still in front)
+```
+
+## Contracts
+
+### 1. Ranking log (Phase 1)
+
+`photon_action_memory.eval.ranking_log` defines:
+
+- `RankingLogEntry` — write DTO: `(context_pack_request_id, summary_id,
+  kind, position, score, selected, omitted_reason)`. **Forbidden** fields:
+  rendered text, raw evidence, prompt content.
+- `RankingLogOutcome` — written by `/v1/evaluate` to back-fill
+  `outcome_family ∈ {success, failure, safety, unknown}` and
+  `adoption_status`.
+- `classify_label(...)` — Phase 1 labels:
+  - `adopted_success` — selected and outcome=success
+  - `adopted_failure` — selected and outcome=failure
+  - `adopted_safety`  — selected and outcome=safety
+  - `partial`         — selected with `adoption_status=partial`
+  - `ignored`         — selected but no useful outcome
+  - `not_selected`    — admitted to pipeline but lost the budget cut
+  - `omitted_by_gate` — denied by quality / safety / stale / contradict /
+    answer_leak / disabled / raw_tool_log / premature gate
+
+Storage lives in the SummaryStore SQLite database, table
+`context_pack_ranking_log` with a unique `(context_pack_request_id,
+summary_id, kind)` constraint so retries are idempotent.
+
+### 2. Feedback export (Phase 1)
+
+`photon_action_memory.eval.feedback_export.export_action_memory_feedback`
+joins the ranking log into a `FeedbackExportResult` whose JSONL form is
+`action-memory-feedback.v1`. The first line is a manifest header
+containing `manifest.source` with:
+
+- `feedback_max_updated_at` — newest `ranking_log.created_at` covered by
+  this export. Used by ranking mode `live_feedback_delta` to skip
+  already-baked feedback.
+- `feedback_record_count`
+- `safety_violation_count`
+- `label_counts`
+
+Each subsequent line is a `FeedbackExportRecord` with:
+
+- `bucket ∈ {summary_weights, evidence_weights, next_action_weights,
+  file_weights, avoid_weights}`
+- signed `weight` (partial label is signed by `outcome_family`)
+- `safety_violation` boolean — records with True go into `suppressed_ids`
+  instead of a numeric bucket.
+
+### 3. Checkpoint v2 (Phase 2)
+
+`photon-action-memory.v2` extends the v1 manifest with:
+
+- `summary_weights`, `next_action_weights`, `avoid_weights` weight buckets.
+- `suppressed_ids: list[str]` — hard-banned ids (safety violations).
+- Optional `action_memory_state.json` sidecar — merged at load time so the
+  manifest stays small. Manifest state wins on collision.
+- Optional `photon_runtime/` directory — marker for the slim-port layer.
+- `manifest.source` block (carries `feedback_max_updated_at`).
+
+The loader (`load_checkpoint_manifest`) accepts both v1 and v2 manifests
+and returns the same `PhotonCheckpoint` DTO (now with `format`, `source`,
+and `has_photon_runtime` fields).
+
+The scorer (`PhotonMLXAdapter._score`) returns 0 immediately for any
+subject in `suppressed_ids` and otherwise applies v2 buckets per-kind:
+
+- `summary` / `action_summary` → `summary_weights`
+- `next_hint` / `next_action`  → `next_action_weights`
+- `failed_attempt` / `avoid`   → `avoid_weights`
+
+v1 buckets (`action_weights`, `file_weights`, `evidence_weights`)
+continue to work unchanged.
+
+### 4. Registry (Phase 3)
+
+`photon_action_memory.models.checkpoint_registry.CheckpointRegistry` owns:
+
+- `candidates/<id>/` — one directory per candidate.
+- `current` — atomic pointer file (single line, candidate id).
+- `previous` — atomic pointer file.
+- `promotion_report.json` — append-only JSON list of
+  `{event, candidate_id, previous_id, reason, created_at, gate_report}`.
+
+Operations:
+
+- `register_candidate(path)` — validates the manifest and returns the id.
+- `promote(id, reason, gate_report)` — re-validates manifest + integrity,
+  shifts `current` → `previous`, writes the new `current`. Uses
+  `os.replace` for atomicity. Safe to retry.
+- `rollback(reason, gate_report)` — swaps `current` and `previous`.
+- `resolve_active(env)` — resolution order:
+  1. `PHOTON_ACTION_MEMORY_CHECKPOINT` (operator override)
+  2. `PHOTON_CHECKPOINT_ACTIVE`
+  3. local `current` pointer
+  4. `PHOTON_CHECKPOINT_DIR/current` pointer
+- `auto_promotion_enabled(env)` returns False when the operator override
+  is set, so an auto-promote job stops touching `current` while an
+  operator is holding the wheel.
+
+### 5. Ranking modes (Phase 4)
+
+`photon_action_memory.ranking.context_ranking.resolve_ranking_mode(env)`
+reads `PHOTON_CONTEXT_PACK_RANKING` and returns one of `deterministic |
+photon_shadow | photon_canary | photon`.
+
+`apply_ranking_mode(pack, ...)` runs **after** `build_context_pack`. It:
+
+- never re-admits omitted items
+- never overrides safety/stale/contradicted/answer-leak/quality gates
+  (those have already filtered the input list)
+- bails out to deterministic with a `ranking_mode_fallback` warning when
+  the scorer is missing, raises, or reports `photon_unavailable`
+- in `photon_shadow` keeps the deterministic order and emits a
+  `ranking_report` warning containing the per-item base / photon / final
+  scores
+- in `photon_canary` only re-orders requests whose `request_id` hashes
+  into the configured ratio (`PHOTON_CONTEXT_PACK_CANARY_RATIO`)
+- combines scores as
+
+  ```
+  final = clamp(
+      base * (1 - photon_weight)
+      + photon_score * photon_weight
+      + live_feedback_delta,
+      0, 1)
+  ```
+
+  with `photon_weight` from `PHOTON_CONTEXT_PACK_PHOTON_WEIGHT` (default
+  0.4). `live_feedback_delta` is bounded to ±0.05 and uses the
+  manifest's `feedback_max_updated_at` to skip already-baked feedback.
+
+### 6. photon_runtime slim port (Phase 5)
+
+`photon_action_memory/photon_runtime/UPSTREAM.md` is the contract file
+covering upstream commit, license, reserved file list, local change
+policy, MLX import policy, and sync policy. No upstream files are
+copied yet; the directory exists to mark the boundary so future ports do
+not silently grow.
+
+## Acceptance test mapping
+
+| Acceptance criterion | Implementation site |
+|---|---|
+| feedback DB から raw content なしの checkpoint input | `eval/ranking_log.py` (no text columns), `eval/feedback_export.py` (no text fields) |
+| `context_pack_ranking_log` 弱い負例 | `classify_label` → `not_selected` |
+| `partial` 二極化 | `_signed_weight` in `feedback_export.py` |
+| 二層構造 v2 checkpoint | `models/checkpoint_builder.py` `write_action_memory_checkpoint(format_version=v2, use_action_memory_sidecar=True, include_photon_runtime_stub=True)` |
+| v1 / metadata-only v2 / runtime v2 load | `load_checkpoint_manifest` accepts both, sidecar merge, `has_photon_runtime` flag |
+| atomic promote / rollback | `CheckpointRegistry.promote` / `.rollback` using `os.replace` |
+| `PHOTON_ACTION_MEMORY_CHECKPOINT` で auto 無効化 | `resolve_active` + `auto_promotion_enabled` |
+| `/v1/context/pack` 4 ranking mode | `ranking/context_ranking.py` |
+| PHOTON unavailable で deterministic | `_fallback` returns deterministic pack with `ranking_mode_fallback` warning |
+| hard gates 非上書き | `apply_ranking_mode` only re-orders `pack.items` (already gated) |
+| 二重加算なし | `live_feedback_delta` keyed off `manifest.source.feedback_max_updated_at` |
+| shadow 比較 report | `ranking_report` warning produced in `photon_shadow` |
+| canary promotion gate | `photon_canary` only applies when `_canary_includes` true |
+| slim port upstream policy | `photon_runtime/UPSTREAM.md` |
+| CI が MLX / checkpoint なしで通る | default mode is deterministic, all imports lazy |
+
+## Test surface (Issue #126)
+
+```bash
+python -m pytest \
+  tests/test_summary_feedback.py \
+  tests/test_action_memory_checkpoint_builder.py \
+  tests/test_action_memory_scorer.py \
+  tests/test_photon_adapter.py \
+  tests/test_context_pack.py \
+  tests/test_checkpoint_registry.py \
+  tests/test_feedback_export.py \
+  tests/test_context_ranking.py \
+  -q
+```
+
+The last three files are added by this Issue.


### PR DESCRIPTION
Closes #126

## Summary
- Add context pack candidate exposure logging and safe feedback export for action-memory-feedback.v1.
- Add checkpoint v2 support, registry promotion/rollback, and active checkpoint resolution with PHOTON_ACTION_MEMORY_CHECKPOINT override behavior.
- Wire /v1/context/pack ranking modes for deterministic, photon_shadow, photon_canary, and photon with fail-open deterministic fallback.
- Add photon_runtime slim-port governance notes and v0.4.1 docs/spec.

## Changed files
- photon_action_memory/eval/feedback_export.py
- photon_action_memory/eval/ranking_log.py
- photon_action_memory/models/checkpoint.py
- photon_action_memory/models/checkpoint_builder.py
- photon_action_memory/models/checkpoint_registry.py
- photon_action_memory/ranking/context_ranking.py
- photon_action_memory/api/server.py
- tests/test_feedback_export.py
- tests/test_context_ranking.py
- tests/test_checkpoint_registry.py
- workspace/v0.4.1/*
- dev-reports/issue-126/*

## Tests run
- python -m pytest tests/test_summary_feedback.py tests/test_action_memory_checkpoint_builder.py tests/test_action_memory_scorer.py tests/test_photon_adapter.py tests/test_context_pack.py tests/test_checkpoint_registry.py tests/test_feedback_export.py tests/test_context_ranking.py -q
- ruff check photon_action_memory/eval/ranking_log.py photon_action_memory/eval/feedback_export.py photon_action_memory/models/checkpoint.py photon_action_memory/models/checkpoint_builder.py photon_action_memory/models/checkpoint_registry.py photon_action_memory/ranking/context_ranking.py photon_action_memory/api/server.py tests/test_checkpoint_registry.py tests/test_feedback_export.py tests/test_context_ranking.py tests/test_summary_feedback.py tests/test_action_memory_checkpoint_builder.py tests/test_action_memory_scorer.py tests/test_photon_adapter.py tests/test_context_pack.py

## Known risks
- PHOTON runtime slim port is governance-only in this change; no upstream runtime files are copied yet.
- Worker noted unrelated pre-existing failures outside the focused test set.

## Orchestration
- Run ID: 20260517-083948-orchestrate
