### PR TITLE
fix(memory): avoid mlx import when model is missing

### DIFF
--- a/photon_action_memory/memory/llm_draft_summary.py
+++ b/photon_action_memory/memory/llm_draft_summary.py
@@ -479,22 +479,19 @@ def _load_mlx_generator(config: LLMDraftConfig) -> GeneratorCallable:
     :class:`MlxUnavailable` or :class:`ModelUnavailable` (never network-fetch)
     so CI without ``mlx_lm`` keeps passing.
     """
-    try:
-        import importlib  # local — avoid top-level import
+    if not _model_present_locally(config.model):
+        raise ModelUnavailable(f"model not found locally: {config.model}")
 
+    try:
         mlx_lm = importlib.import_module("mlx_lm")
     except ModuleNotFoundError as exc:
         if exc.name in {"mlx", "mlx_lm", "mlx.core"}:
             raise MlxUnavailable("optional dependency 'mlx_lm' is not installed") from exc
         raise
-
     load = getattr(mlx_lm, "load", None)
     generate = getattr(mlx_lm, "generate", None)
     if load is None or generate is None:
         raise MlxUnavailable("mlx_lm is missing 'load'/'generate' entry points")
-
-    if not _model_present_locally(config.model):
-        raise ModelUnavailable(f"model not found locally: {config.model}")
 
     model, tokenizer = load(config.model)
 


### PR DESCRIPTION
Linked Issue: none; QA follow-up found during pull and verification.

Summary:
- Check the configured local model path before importing optional mlx_lm.
- Preserve fallback behavior when the model is missing.
- Avoid aborting the Python process in environments where optional MLX native import is broken.

Changed files:
- photon_action_memory/memory/llm_draft_summary.py

Tests run:
- ruff format --check .
- ruff check .
- mypy photon_action_memory tests
- PHOTON_ACTION_MEMORY_DB=/tmp/photon-action-memory-qa-commit-events.sqlite PHOTON_ACTION_MEMORY_SUMMARY_DB=/tmp/photon-action-memory-qa-commit-summaries.sqlite python -m pytest -q
- python -m build
- API smoke for health / summarize / context_pack / evaluate during QA
- photon_shadow ranking smoke during QA
- checkpoint CLI smoke during QA

Known risks:
- This does not repair a broken local MLX native installation. PHOTON_RUN_MLX_SMOKE=1 still requires a working mlx.core import.

Orchestration run ID: N/A